### PR TITLE
fix(nx-adsp): update express generator to also use dynamic import of …

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -104,8 +104,8 @@ function removeFiles(host: Tree, options: NormalizedSchema) {
 
 export default async function (host: Tree, options: AngularAppGeneratorSchema) {
   const normalizedOptions = normalizeOptions(host, options);
+  
   const { applicationGenerator: initAngular } = await import('@nrwl/angular/generators');
-
   await initAngular(host, { name: options.name });
 
   addDependenciesToPackageJson(

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -1,3 +1,4 @@
+import { UnitTestRunner } from '@nrwl/angular/src/utils/test-runners';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -7,7 +8,7 @@ import {
   names,
   Tree,
 } from '@nrwl/devkit';
-import { wrapAngularDevkitSchematic } from '@nrwl/devkit/ngcli-adapter';
+import { Linter } from '@nrwl/linter';
 import * as path from 'path';
 import { getAdspConfiguration, hasDependency } from '../../utils/adsp-utils';
 import { Schema, NormalizedSchema } from './schema';
@@ -44,11 +45,21 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 }
 
 export default async function (host: Tree, options: Schema) {
-  
   const normalizedOptions = normalizeOptions(host, options);
-  
-  const initExpress = wrapAngularDevkitSchematic('@nrwl/express', 'application');
-  await initExpress(host, options);
+
+  const { applicationGenerator: initExpress } = await import('@nrwl/express');
+  await initExpress(
+    host, 
+    { 
+      ...options, 
+      skipFormat: true, 
+      skipPackageJson: false, 
+      linter: Linter.EsLint, 
+      unitTestRunner: UnitTestRunner.Jest, 
+      pascalCaseFiles: false, 
+      js: false, 
+    }
+  );
   
   addDependenciesToPackageJson(
     host, 

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -1,3 +1,4 @@
+import { E2eTestRunner, UnitTestRunner } from '@nrwl/angular/src/utils/test-runners';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -112,10 +113,10 @@ export default async function (host: Tree, options: Schema) {
     name: options.name, 
     style: 'styled-components', 
     skipFormat: true, 
-    unitTestRunner: 'jest', 
-    babelJest: false, 
-    e2eTestRunner: 'cypress', 
     linter:  Linter.EsLint, 
+    unitTestRunner: UnitTestRunner.Jest, 
+    e2eTestRunner: E2eTestRunner.Cypress, 
+    babelJest: false, 
     strict: false,
   });
   


### PR DESCRIPTION
…underlying nx generator instead of running it as an ng cli builder.

Some extra cleanup in related code of other generators.