### PR TITLE
chore: adding @nrwl/devkit peer dep for nx-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,11 @@
         "react-is": "18.2.0"
       },
       "devDependencies": {
-        "@abgov/nx-release": "^3.1.1",
+        "@abgov/nx-release": "^3.1.2",
         "@angular-devkit/core": "16.2.12",
         "@angular-devkit/schematics": "16.2.12",
         "@nrwl/cli": "15.9.2",
+        "@nrwl/devkit": "14.7.17",
         "@nx-dotnet/core": "^1.16.3",
         "@nx/angular": "16.10.0",
         "@nx/eslint-plugin": "16.10.0",
@@ -4179,7 +4180,6 @@
       "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-14.7.17.tgz",
       "integrity": "sha512-flTV8BuC7oacWGHseoKsyOAYmWsMSP6iYGRjrCaV0MyRbDkNy0P07elXXFUW01er+l7x/awZYQR9/n/eNyqfXA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@phenomnomnominal/tsquery": "4.1.1",
         "ejs": "^3.1.7",
@@ -4195,7 +4195,6 @@
       "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
       "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esquery": "^1.0.1"
       },
@@ -24958,7 +24957,6 @@
       "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-14.7.17.tgz",
       "integrity": "sha512-flTV8BuC7oacWGHseoKsyOAYmWsMSP6iYGRjrCaV0MyRbDkNy0P07elXXFUW01er+l7x/awZYQR9/n/eNyqfXA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@phenomnomnominal/tsquery": "4.1.1",
         "ejs": "^3.1.7",
@@ -24971,7 +24969,6 @@
           "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
           "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "esquery": "^1.0.1"
           }

--- a/package.json
+++ b/package.json
@@ -35,10 +35,11 @@
     "react-is": "18.2.0"
   },
   "devDependencies": {
-    "@abgov/nx-release": "^3.1.1",
+    "@abgov/nx-release": "^3.1.2",
     "@angular-devkit/core": "16.2.12",
     "@angular-devkit/schematics": "16.2.12",
     "@nrwl/cli": "15.9.2",
+    "@nrwl/devkit": "14.7.17",
     "@nx-dotnet/core": "^1.16.3",
     "@nx/angular": "16.10.0",
     "@nx/eslint-plugin": "16.10.0",


### PR DESCRIPTION
This repo uses an older version of @abgov/nx-release that still requires @nrwl/devkit as a peer dep.