### PR TITLE
chore: overriding dep @nrwl/devkit to @nx/devkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@angular-devkit/core": "16.2.12",
         "@angular-devkit/schematics": "16.2.12",
         "@nrwl/cli": "15.9.2",
-        "@nrwl/devkit": "14.7.17",
         "@nx-dotnet/core": "^1.16.3",
         "@nx/angular": "16.10.0",
         "@nx/eslint-plugin": "16.10.0",
@@ -4176,44 +4175,11 @@
       }
     },
     "node_modules/@nrwl/devkit": {
-      "version": "14.7.17",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-14.7.17.tgz",
-      "integrity": "sha512-flTV8BuC7oacWGHseoKsyOAYmWsMSP6iYGRjrCaV0MyRbDkNy0P07elXXFUW01er+l7x/awZYQR9/n/eNyqfXA==",
-      "dev": true,
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.10.0.tgz",
+      "integrity": "sha512-fRloARtsDQoQgQ7HKEy0RJiusg/HSygnmg4gX/0n/Z+SUS+4KoZzvHjXc6T5ZdEiSjvLypJ+HBM8dQzIcVACPQ==",
       "dependencies": {
-        "@phenomnomnominal/tsquery": "4.1.1",
-        "ejs": "^3.1.7",
-        "ignore": "^5.0.4",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "nx": ">= 13.10 <= 15"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/@phenomnomnominal/tsquery": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-      "dev": true,
-      "dependencies": {
-        "esquery": "^1.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "^3 || ^4"
-      }
-    },
-    "node_modules/@nrwl/devkit/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
+        "@nx/devkit": "16.10.0"
       }
     },
     "node_modules/@nrwl/eslint-plugin-nx": {
@@ -4358,49 +4324,6 @@
         }
       }
     },
-    "node_modules/@nx-dotnet/core/node_modules/@nrwl/devkit": {
-      "version": "15.8.5",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.8.5.tgz",
-      "integrity": "sha512-NgpD1I1BfFb6wRxB5i5PGP4hMyRhPsArCyENWWvY4gCn8tylAc7yjpQyiDiy2QnymL2PjWM8QeAeCOy1eF2xgw==",
-      "dev": true,
-      "dependencies": {
-        "@phenomnomnominal/tsquery": "4.1.1",
-        "ejs": "^3.1.7",
-        "ignore": "^5.0.4",
-        "semver": "7.3.4",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "nx": ">= 14.1 <= 16"
-      }
-    },
-    "node_modules/@nx-dotnet/core/node_modules/@phenomnomnominal/tsquery": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-      "dev": true,
-      "dependencies": {
-        "esquery": "^1.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "^3 || ^4"
-      }
-    },
-    "node_modules/@nx-dotnet/core/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@nx-dotnet/dotnet": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@nx-dotnet/dotnet/-/dotnet-1.23.0.tgz",
@@ -4417,49 +4340,6 @@
         "@nx-dotnet/utils": "1.23.0"
       }
     },
-    "node_modules/@nx-dotnet/dotnet/node_modules/@nrwl/devkit": {
-      "version": "15.8.5",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.8.5.tgz",
-      "integrity": "sha512-NgpD1I1BfFb6wRxB5i5PGP4hMyRhPsArCyENWWvY4gCn8tylAc7yjpQyiDiy2QnymL2PjWM8QeAeCOy1eF2xgw==",
-      "dev": true,
-      "dependencies": {
-        "@phenomnomnominal/tsquery": "4.1.1",
-        "ejs": "^3.1.7",
-        "ignore": "^5.0.4",
-        "semver": "7.3.4",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "nx": ">= 14.1 <= 16"
-      }
-    },
-    "node_modules/@nx-dotnet/dotnet/node_modules/@phenomnomnominal/tsquery": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-      "dev": true,
-      "dependencies": {
-        "esquery": "^1.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "^3 || ^4"
-      }
-    },
-    "node_modules/@nx-dotnet/dotnet/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@nx-dotnet/utils": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@nx-dotnet/utils/-/utils-1.23.0.tgz",
@@ -4470,49 +4350,6 @@
         "fast-glob": "3.2.12",
         "rimraf": "3.0.2",
         "xmldoc": "1.1.2"
-      }
-    },
-    "node_modules/@nx-dotnet/utils/node_modules/@nrwl/devkit": {
-      "version": "15.8.5",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.8.5.tgz",
-      "integrity": "sha512-NgpD1I1BfFb6wRxB5i5PGP4hMyRhPsArCyENWWvY4gCn8tylAc7yjpQyiDiy2QnymL2PjWM8QeAeCOy1eF2xgw==",
-      "dev": true,
-      "dependencies": {
-        "@phenomnomnominal/tsquery": "4.1.1",
-        "ejs": "^3.1.7",
-        "ignore": "^5.0.4",
-        "semver": "7.3.4",
-        "tmp": "~0.2.1",
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "nx": ">= 14.1 <= 16"
-      }
-    },
-    "node_modules/@nx-dotnet/utils/node_modules/@phenomnomnominal/tsquery": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-      "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-      "dev": true,
-      "dependencies": {
-        "esquery": "^1.0.1"
-      },
-      "peerDependencies": {
-        "typescript": "^3 || ^4"
-      }
-    },
-    "node_modules/@nx-dotnet/utils/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/@nx/angular": {
@@ -4623,14 +4460,6 @@
       },
       "peerDependencies": {
         "nx": ">= 15 <= 17"
-      }
-    },
-    "node_modules/@nx/devkit/node_modules/@nrwl/devkit": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.10.0.tgz",
-      "integrity": "sha512-fRloARtsDQoQgQ7HKEy0RJiusg/HSygnmg4gX/0n/Z+SUS+4KoZzvHjXc6T5ZdEiSjvLypJ+HBM8dQzIcVACPQ==",
-      "dependencies": {
-        "@nx/devkit": "16.10.0"
       }
     },
     "node_modules/@nx/eslint-plugin": {
@@ -24953,33 +24782,11 @@
       }
     },
     "@nrwl/devkit": {
-      "version": "14.7.17",
-      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-14.7.17.tgz",
-      "integrity": "sha512-flTV8BuC7oacWGHseoKsyOAYmWsMSP6iYGRjrCaV0MyRbDkNy0P07elXXFUW01er+l7x/awZYQR9/n/eNyqfXA==",
-      "dev": true,
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.10.0.tgz",
+      "integrity": "sha512-fRloARtsDQoQgQ7HKEy0RJiusg/HSygnmg4gX/0n/Z+SUS+4KoZzvHjXc6T5ZdEiSjvLypJ+HBM8dQzIcVACPQ==",
       "requires": {
-        "@phenomnomnominal/tsquery": "4.1.1",
-        "ejs": "^3.1.7",
-        "ignore": "^5.0.4",
-        "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@phenomnomnominal/tsquery": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-          "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-          "dev": true,
-          "requires": {
-            "esquery": "^1.0.1"
-          }
-        },
-        "typescript": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-          "dev": true,
-          "peer": true
-        }
+        "@nx/devkit": "16.10.0"
       }
     },
     "@nrwl/eslint-plugin-nx": {
@@ -25096,7 +24903,7 @@
       "integrity": "sha512-DDAOWCMh74JsZC68lHVWlOTpSJ7C+1Gj4t81YgpqD44w/KZCnSgah49QPPVIsGXimHlQLomdgA1gNpaO6+w5ww==",
       "dev": true,
       "requires": {
-        "@nrwl/devkit": "15.8.5",
+        "@nrwl/devkit": "16.10.0",
         "@nx-dotnet/dotnet": "1.23.0",
         "@nx-dotnet/utils": "1.23.0",
         "fast-glob": "^3.2.11",
@@ -25104,38 +24911,6 @@
         "rimraf": "3.0.2",
         "semver": "^7.3.4",
         "xmldoc": "1.1.2"
-      },
-      "dependencies": {
-        "@nrwl/devkit": {
-          "version": "15.8.5",
-          "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.8.5.tgz",
-          "integrity": "sha512-NgpD1I1BfFb6wRxB5i5PGP4hMyRhPsArCyENWWvY4gCn8tylAc7yjpQyiDiy2QnymL2PjWM8QeAeCOy1eF2xgw==",
-          "dev": true,
-          "requires": {
-            "@phenomnomnominal/tsquery": "4.1.1",
-            "ejs": "^3.1.7",
-            "ignore": "^5.0.4",
-            "semver": "^7.3.4",
-            "tmp": "~0.2.1",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@phenomnomnominal/tsquery": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-          "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-          "dev": true,
-          "requires": {
-            "esquery": "^1.0.1"
-          }
-        },
-        "typescript": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "@nx-dotnet/dotnet": {
@@ -25144,43 +24919,11 @@
       "integrity": "sha512-GEpJrkACgLkaCxnC8wFTuqIFDQmsOas2OVmcUh8+DE+msVeL9h82KeSkKkMICT7fjN4fNE6VaAa9LG9tBgRF8Q==",
       "dev": true,
       "requires": {
-        "@nrwl/devkit": "15.8.5",
+        "@nrwl/devkit": "16.10.0",
         "fast-glob": "^3.2.11",
         "rimraf": "3.0.2",
         "semver": "^7.3.4",
         "xmldoc": "1.1.2"
-      },
-      "dependencies": {
-        "@nrwl/devkit": {
-          "version": "15.8.5",
-          "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.8.5.tgz",
-          "integrity": "sha512-NgpD1I1BfFb6wRxB5i5PGP4hMyRhPsArCyENWWvY4gCn8tylAc7yjpQyiDiy2QnymL2PjWM8QeAeCOy1eF2xgw==",
-          "dev": true,
-          "requires": {
-            "@phenomnomnominal/tsquery": "4.1.1",
-            "ejs": "^3.1.7",
-            "ignore": "^5.0.4",
-            "semver": "^7.3.4",
-            "tmp": "~0.2.1",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@phenomnomnominal/tsquery": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-          "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-          "dev": true,
-          "requires": {
-            "esquery": "^1.0.1"
-          }
-        },
-        "typescript": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "@nx-dotnet/utils": {
@@ -25189,42 +24932,10 @@
       "integrity": "sha512-CC3Ao2bBDNxDbkg0YIKH00N5zrEGWGcObA/CHn1vIBCGU0X94SeKs//0giV3PA/+d3AVCQH9eEP0N0+3LmZ+sw==",
       "dev": true,
       "requires": {
-        "@nrwl/devkit": "15.8.5",
+        "@nrwl/devkit": "16.10.0",
         "fast-glob": "^3.2.11",
         "rimraf": "3.0.2",
         "xmldoc": "1.1.2"
-      },
-      "dependencies": {
-        "@nrwl/devkit": {
-          "version": "15.8.5",
-          "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-15.8.5.tgz",
-          "integrity": "sha512-NgpD1I1BfFb6wRxB5i5PGP4hMyRhPsArCyENWWvY4gCn8tylAc7yjpQyiDiy2QnymL2PjWM8QeAeCOy1eF2xgw==",
-          "dev": true,
-          "requires": {
-            "@phenomnomnominal/tsquery": "4.1.1",
-            "ejs": "^3.1.7",
-            "ignore": "^5.0.4",
-            "semver": "^7.3.4",
-            "tmp": "~0.2.1",
-            "tslib": "^2.3.0"
-          }
-        },
-        "@phenomnomnominal/tsquery": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
-          "integrity": "sha512-jjMmK1tnZbm1Jq5a7fBliM4gQwjxMU7TFoRNwIyzwlO+eHPRCFv/Nv+H/Gi1jc3WR7QURG8D5d0Tn12YGrUqBQ==",
-          "dev": true,
-          "requires": {
-            "esquery": "^1.0.1"
-          }
-        },
-        "typescript": {
-          "version": "4.9.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-          "dev": true,
-          "peer": true
-        }
       }
     },
     "@nx/angular": {
@@ -25303,16 +25014,6 @@
         "semver": "^7.3.4",
         "tmp": "~0.2.1",
         "tslib": "^2.3.0"
-      },
-      "dependencies": {
-        "@nrwl/devkit": {
-          "version": "16.10.0",
-          "resolved": "https://registry.npmjs.org/@nrwl/devkit/-/devkit-16.10.0.tgz",
-          "integrity": "sha512-fRloARtsDQoQgQ7HKEy0RJiusg/HSygnmg4gX/0n/Z+SUS+4KoZzvHjXc6T5ZdEiSjvLypJ+HBM8dQzIcVACPQ==",
-          "requires": {
-            "@nx/devkit": "16.10.0"
-          }
-        }
       }
     },
     "@nx/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@angular-devkit/core": "16.2.12",
     "@angular-devkit/schematics": "16.2.12",
     "@nrwl/cli": "15.9.2",
-    "@nrwl/devkit": "14.7.17",
     "@nx-dotnet/core": "^1.16.3",
     "@nx/angular": "16.10.0",
     "@nx/eslint-plugin": "16.10.0",
@@ -87,6 +86,7 @@
     "yaml": "~2.2.2"
   },
   "overrides": {
+    "@nrwl/devkit": "$@nx/devkit",
     "@nx/devkit": "16.10.0",
     "nx": "16.10.0",
     "semver": "^7.3.4",


### PR DESCRIPTION
This repo uses an older version of @abgov/nx-release that still requires @nrwl/devkit as a peer dep.