### PR TITLE
fix(nx-release): replace split2/get-stream with Node.js readline

### DIFF
--- a/packages/nx-release/package.json
+++ b/packages/nx-release/package.json
@@ -16,9 +16,7 @@
   },
   "dependencies": {
     "@semantic-release/commit-analyzer": "^11.1.0",
-    "@semantic-release/release-notes-generator": "^12.1.0",
-    "get-stream": "~6.0.0",
-    "split2": "~4.2.0"
+    "@semantic-release/release-notes-generator": "^12.1.0"
   },
   "generators": "./generators.json",
   "scripts": {}

--- a/packages/nx-release/src/index.ts
+++ b/packages/nx-release/src/index.ts
@@ -1,1 +1,1 @@
-export * from './release-plugin/index.js';
+export * from './release-plugin/index';

--- a/packages/nx-release/src/release-plugin/git-utils.ts
+++ b/packages/nx-release/src/release-plugin/git-utils.ts
@@ -1,6 +1,5 @@
 import { spawn } from 'child_process';
-import { array } from 'get-stream';
-import split from 'split2';
+import { createInterface } from 'readline';
 
 const projectCommits: Record<string, string[]> = {};
 
@@ -13,20 +12,23 @@ export async function getPathCommitHashes(
 ) {
   if (!projectCommits[project]) {
     // --full-history to avoid history simplification ignoring commits on some merged branches.
-    const commits = await array<string>(
-      spawn(
-        'git',
-        [
-          'log',
-          '--format=%H',
-          '--full-history',
-          `${from ? `${from}..` : ''}${to}`,
-          '--',
-          ...paths,
-        ],
-        { cwd }
-      ).stdout.pipe(split())
+    const child = spawn(
+      'git',
+      [
+        'log',
+        '--format=%H',
+        '--full-history',
+        `${from ? `${from}..` : ''}${to}`,
+        '--',
+        ...paths,
+      ],
+      { cwd }
     );
+
+    const commits: string[] = [];
+    for await (const line of createInterface({ input: child.stdout, crlfDelay: Infinity })) {
+      if (line) commits.push(line);
+    }
 
     projectCommits[project] = commits;
   }

--- a/packages/nx-release/src/release-plugin/index.ts
+++ b/packages/nx-release/src/release-plugin/index.ts
@@ -1,7 +1,7 @@
 import type { AnalyzeCommitsContext, GenerateNotesContext } from 'semantic-release';
 import { analyzeCommits as baseAnalyzeCommits } from '@semantic-release/commit-analyzer';
 import { generateNotes as baseGenerateNotes } from '@semantic-release/release-notes-generator';
-import { wrapPlugin } from './wrap-plugin.js';
+import { wrapPlugin } from './wrap-plugin';
 
 const analyzeCommits = wrapPlugin<AnalyzeCommitsContext>(baseAnalyzeCommits);
 const generateNotes = wrapPlugin<GenerateNotesContext>(baseGenerateNotes);

--- a/packages/nx-release/src/release-plugin/wrap-plugin.ts
+++ b/packages/nx-release/src/release-plugin/wrap-plugin.ts
@@ -4,8 +4,8 @@ import type {
   PluginFunction,
 } from '@semantic-release/semantic-release';
 import type { BaseContext } from 'semantic-release';
-import { getPathCommitHashes } from './git-utils.js';
-import { getProjectChangePaths } from './nx-util.js';
+import { getPathCommitHashes } from './git-utils';
+import { getProjectChangePaths } from './nx-util';
 
 export interface WrappedPluginConfig extends PluginConfig {
   project: string;

--- a/packages/nx-release/tsconfig.lib.json
+++ b/packages/nx-release/tsconfig.lib.json
@@ -1,10 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ES2020",
+    "module": "commonjs",
     "outDir": "../../dist/out-tsc",
-    "esModuleInterop": true,
     "declaration": true,
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary

`split2` v4 is ESM-only, which forced `nx-release` to build as ES2020 ESM — inconsistent with the other three plugins that all build to CommonJS.

The fix replaces the single `split2` call site with Node.js built-in `readline.createInterface`, which produces the same result (an array of git commit hashes from a spawned process stdout) with zero external dependencies.

**Changes:**
- `git-utils.ts` — replace `spawn().stdout.pipe(split())` + `get-stream/array` with a `readline` async iterator
- `tsconfig.lib.json` — revert `module: ES2020` → `module: commonjs`; remove `target: ES2020` and `esModuleInterop`
- `package.json` — remove `split2` and `get-stream` dependencies
- `src/index.ts`, `wrap-plugin.ts`, `release-plugin/index.ts` — remove `.js` extensions from internal imports (required by ESM, not by CJS)

**Not breaking** — consumers reference this package as a plugin string; the public API is unchanged.

## Test plan

- [x] `nx build nx-release` passes
- [x] `nx test nx-release` — all 8 tests pass (including `git-utils.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)