### PR TITLE
fix: schema titles, additionalProperties, lib generator error handling, jest snapshot format

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -2,14 +2,4 @@ const nxPreset = require('@nx/jest/preset').default;
 
 module.exports = {
   ...nxPreset,
-  /* TODO: Update to latest Jest snapshotFormat
-   * By default Nx has kept the older style of Jest Snapshot formats
-   * to prevent breaking of any existing tests with snapshots.
-   * It's recommend you update to the latest format.
-   * You can do this by removing snapshotFormat property
-   * and running tests with --update-snapshot flag.
-   * Example: "nx affected --targets=e2e --update-snapshot"
-   * More info: https://jestjs.io/docs/upgrading-to-jest29#snapshot-format
-   */
-  snapshotFormat: { escapeString: true, printBasicPrototype: true },
 };

--- a/packages/nx-adsp/src/generators/angular-app/schema.json
+++ b/packages/nx-adsp/src/generators/angular-app/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "AngularApp",
-  "title": "",
+  "title": "Angular ADSP Application",
   "type": "object",
   "properties": {
     "name": {
@@ -77,5 +77,6 @@
   "required": [
     "name",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/dotnet-service/schema.json
+++ b/packages/nx-adsp/src/generators/dotnet-service/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspDotnetService",
-  "title": "",
+  "title": ".NET ADSP Service",
   "type": "object",
   "properties": {
     "name": {
@@ -40,5 +40,6 @@
   "required": [
     "name",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/express-service/schema.json
+++ b/packages/nx-adsp/src/generators/express-service/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspExpressService",
-  "title": "",
+  "title": "Express ADSP Service",
   "type": "object",
   "properties": {
     "name": {
@@ -40,5 +40,6 @@
   "required": [
     "name",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/mern/schema.json
+++ b/packages/nx-adsp/src/generators/mern/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspMern",
-  "title": "",
+  "title": "MERN Stack ADSP Solution",
   "type": "object",
   "properties": {
     "name": {
@@ -40,5 +40,6 @@
   "required": [
     "name",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-app/schema.json
+++ b/packages/nx-adsp/src/generators/react-app/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspReactApp",
-  "title": "",
+  "title": "React ADSP Application",
   "type": "object",
   "properties": {
     "name": {
@@ -77,5 +77,6 @@
   "required": [
     "name",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-dotnet/schema.json
+++ b/packages/nx-adsp/src/generators/react-dotnet/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspReactDotnet",
-  "title": "",
+  "title": "React + .NET ADSP Solution",
   "type": "object",
   "properties": {
     "name": {
@@ -40,5 +40,6 @@
   "required": [
     "name",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-form/schema.json
+++ b/packages/nx-adsp/src/generators/react-form/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspReactForm",
-  "title": "",
+  "title": "React Form from ADSP Form Definitions",
   "type": "object",
   "properties": {
     "project": {
@@ -40,5 +40,6 @@
   "required": [
     "project",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-task-list/schema.json
+++ b/packages/nx-adsp/src/generators/react-task-list/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspReactTaskList",
-  "title": "",
+  "title": "React Task List Component from ADSP",
   "type": "object",
   "properties": {
     "project": {
@@ -40,5 +40,6 @@
   "required": [
     "project",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-oc/src/generators/apply-infra/schema.json
+++ b/packages/nx-oc/src/generators/apply-infra/schema.json
@@ -1,8 +1,9 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxOcApplyInfra",
-  "title": "",
+  "title": "Apply OpenShift Infrastructure",
   "type": "object",
   "properties": {},
-  "required": []
+  "required": [],
+  "additionalProperties": false
 }

--- a/packages/nx-oc/src/generators/deployment/schema.json
+++ b/packages/nx-oc/src/generators/deployment/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxOcDeployment",
-  "title": "",
+  "title": "ADSP Application Deployment",
   "type": "object",
   "properties": {
     "project": {
@@ -59,5 +59,6 @@
     "project",
     "appType",
     "env"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-oc/src/generators/pipeline/schema.json
+++ b/packages/nx-oc/src/generators/pipeline/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxOcPipeline",
-  "title": "",
+  "title": "OpenShift CI/CD Pipeline",
   "type": "object",
   "properties": {
     "pipeline": {
@@ -47,5 +47,6 @@
     "infra",
     "type",
     "envs"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/packages/nx-release/src/generators/lib/lib.spec.ts
+++ b/packages/nx-release/src/generators/lib/lib.spec.ts
@@ -39,6 +39,30 @@ describe('nx-release generator', () => {
     expect(appTree.exists('libs/test/.releaserc.json')).toBeTruthy();
   });
 
+  it('should throw when project is not a library', async () => {
+    addProjectConfiguration(appTree, 'my-app', {
+      root: 'apps/my-app',
+      projectType: 'application',
+      targets: { build: { executor: '@nx/webpack:webpack', options: {} } },
+    });
+
+    await expect(generator(appTree, { project: 'my-app' })).rejects.toThrow(
+      'This generator can only be run against buildable libraries.'
+    );
+  });
+
+  it('should throw when project has no build target', async () => {
+    addProjectConfiguration(appTree, 'no-build', {
+      root: 'libs/no-build',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await expect(generator(appTree, { project: 'no-build' })).rejects.toThrow(
+      'This generator can only be run against buildable libraries.'
+    );
+  });
+
   it('should skip root .releaserc.json if present', async () => {
     await generator(appTree, options);
     const config = readProjectConfiguration(appTree, 'test');

--- a/packages/nx-release/src/generators/lib/lib.ts
+++ b/packages/nx-release/src/generators/lib/lib.ts
@@ -40,38 +40,38 @@ export default async function (host: Tree, options: Schema) {
   const config = readProjectConfiguration(host, options.project);
   const { build } = config.targets;
   if (config.projectType !== 'library' || !build) {
-    console.log('This generator can only be run against buildable libraries.');
-  } else {
-    addDependenciesToPackageJson(
-      host,
-      {},
-      {
-        'semantic-release': '^23.0.0',
-      }
-    );
-
-    config.targets.release = {
-      executor: 'nx:run-commands',
-      options: {
-        command: `npx semantic-release -e ./${config.root}/.releaserc.json`,
-      },
-    };
-
-    updateProjectConfiguration(host, options.project, config);
-
-    const { libsDir } = getWorkspaceLayout(host);
-    const normalizedOptions = {
-      ...options,
-      projectRoot: config.root,
-      projectDist:
-        build.options.outputPath || `dist/${libsDir}/${options.project}`,
-    };
-
-    addFiles(host, normalizedOptions);
-    await formatFiles(host);
-
-    return () => {
-      installPackagesTask(host);
-    };
+    throw new Error('This generator can only be run against buildable libraries.');
   }
+
+  addDependenciesToPackageJson(
+    host,
+    {},
+    {
+      'semantic-release': '^24.0.0',
+    }
+  );
+
+  config.targets.release = {
+    executor: 'nx:run-commands',
+    options: {
+      command: `npx semantic-release -e ./${config.root}/.releaserc.json`,
+    },
+  };
+
+  updateProjectConfiguration(host, options.project, config);
+
+  const { libsDir } = getWorkspaceLayout(host);
+  const normalizedOptions = {
+    ...options,
+    projectRoot: config.root,
+    projectDist:
+      build.options.outputPath || `dist/${libsDir}/${options.project}`,
+  };
+
+  addFiles(host, normalizedOptions);
+  await formatFiles(host);
+
+  return () => {
+    installPackagesTask(host);
+  };
 }

--- a/packages/nx-release/src/generators/lib/schema.json
+++ b/packages/nx-release/src/generators/lib/schema.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json-schema.org/schema",
   "id": "NxRelease",
-  "title": "",
+  "title": "Semantic Release Configuration",
   "type": "object",
   "properties": {
     "project": {
       "type": "string",
-      "description": "",
+      "description": "Name of the publishable library to add semantic release to.",
       "$default": {
         "$source": "argv",
         "index": 0
@@ -16,5 +16,6 @@
   },
   "required": [
     "project"
-  ]
+  ],
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Summary

- **Schema titles**: Add descriptive titles to all 12 generator/executor schemas (were all empty strings)
- **additionalProperties: false**: Add to all generator schemas so unknown CLI options are rejected with a clear error rather than silently ignored
- **nx-release lib generator**: Change silent \`console.log\` to \`throw Error\` when the target project is not a buildable library; fixes ^23.0.0 semantic-release version to ^24.0.0
- **Jest snapshot format**: Remove the legacy \`snapshotFormat\` override from \`jest.preset.js\` (no snapshot files exist in this repo; the TODO has been open since the workspace was created)
- **Tests**: Add two new test cases covering the lib generator error paths

## Test plan

- [x] \`nx test nx-release\` — 10 tests pass (including 2 new error cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)