### PR TITLE
test: add unit tests for semantic-release-nuget and nx-oc utilities

### DIFF
--- a/packages/nx-oc/src/utils/git-utils.spec.ts
+++ b/packages/nx-oc/src/utils/git-utils.spec.ts
@@ -1,0 +1,34 @@
+import { execSync } from 'child_process';
+import { mocked } from 'jest-mock';
+import { getGitRemoteUrl } from './git-utils';
+
+jest.mock('child_process');
+const mockedExecSync = mocked(execSync);
+
+describe('getGitRemoteUrl', () => {
+  beforeEach(() => {
+    mockedExecSync.mockReset();
+  });
+
+  it('returns the remote origin url', () => {
+    mockedExecSync.mockReturnValue(
+      Buffer.from('https://github.com/GovAlta/nx-tools.git\n')
+    );
+
+    const url = getGitRemoteUrl();
+    expect(url).toBe('https://github.com/GovAlta/nx-tools.git\n');
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      'git config --get remote.origin.url',
+      { stdio: 'pipe' }
+    );
+  });
+
+  it('returns undefined when git command fails', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not a git repo');
+    });
+
+    const url = getGitRemoteUrl();
+    expect(url).toBeUndefined();
+  });
+});

--- a/packages/nx-oc/src/utils/oc-utils.spec.ts
+++ b/packages/nx-oc/src/utils/oc-utils.spec.ts
@@ -1,0 +1,60 @@
+import { execSync } from 'child_process';
+import { mocked } from 'jest-mock';
+import { runOcCommand } from './oc-utils';
+
+jest.mock('child_process');
+const mockedExecSync = mocked(execSync);
+
+describe('runOcCommand', () => {
+  beforeEach(() => {
+    mockedExecSync.mockReset();
+  });
+
+  it('returns success with stdout on successful command', () => {
+    const output = Buffer.from('project set to test-dev');
+    mockedExecSync.mockReturnValue(output);
+
+    const result = runOcCommand('project', ['test-dev']);
+    expect(result.success).toBe(true);
+    expect(result.stdout).toBe(output);
+  });
+
+  it('builds the correct command string without input', () => {
+    mockedExecSync.mockReturnValue(Buffer.from(''));
+
+    runOcCommand('process', ['-f .openshift/app.yml', '-p ENV=dev']);
+    expect(mockedExecSync).toHaveBeenCalledWith(
+      'oc process -f .openshift/app.yml -p ENV=dev',
+      expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+
+  it('uses cat pipe form when input buffer is provided', () => {
+    mockedExecSync.mockReturnValue(Buffer.from(''));
+    const input = Buffer.from('{"kind":"List"}');
+
+    runOcCommand('apply', [], input);
+    const [cmd] = mockedExecSync.mock.calls[0];
+    expect(cmd).toContain('cat |');
+    expect(cmd).toContain('oc apply -f -');
+  });
+
+  it('passes input buffer to execSync', () => {
+    mockedExecSync.mockReturnValue(Buffer.from(''));
+    const input = Buffer.from('yaml-content');
+
+    runOcCommand('apply', [], input);
+    const [, options] = mockedExecSync.mock.calls[0];
+    expect((options as { input: Buffer }).input).toBe(input);
+  });
+
+  it('returns failure when command throws', () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('oc: command not found');
+    });
+
+    const result = runOcCommand('start-build', ['my-pipeline']);
+    expect(result.success).toBe(false);
+    expect(result.stdout).toBeUndefined();
+  });
+});

--- a/packages/semantic-release-nuget/src/plugin/prepare.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/prepare.spec.ts
@@ -1,0 +1,87 @@
+import { exec as execCb } from 'child_process';
+import { promisify } from 'util';
+import { prepare } from './prepare';
+
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+}));
+jest.mock('util', () => ({
+  promisify: jest.fn((fn) => fn),
+}));
+
+const mockedExec = execCb as jest.MockedFunction<typeof execCb>;
+
+function makeContext(version = '1.2.3') {
+  return {
+    cwd: '/project',
+    env: { NUGET_API_KEY: 'test-key' },
+    nextRelease: { version },
+  } as never;
+}
+
+describe('prepare', () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+    (mockedExec as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+  });
+
+  it('builds dotnet pack command with required args', async () => {
+    const config = { project: 'MyProject.csproj' };
+    await prepare(config, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('dotnet pack');
+    expect(cmd).toContain('MyProject.csproj');
+    expect(cmd).toContain('/p:Version=1.2.3');
+    expect(cmd).toContain('/p:Configuration=Release');
+  });
+
+  it('uses custom configuration when provided', async () => {
+    await prepare({ project: 'MyProject.csproj', configuration: 'Debug' }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('/p:Configuration=Debug');
+  });
+
+  it('includes --no-build when noBuild is true', async () => {
+    await prepare({ project: 'MyProject.csproj', noBuild: true }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--no-build');
+  });
+
+  it('omits --no-build when noBuild is false', async () => {
+    await prepare({ project: 'MyProject.csproj', noBuild: false }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).not.toContain('--no-build');
+  });
+
+  it('includes --include-symbols when set', async () => {
+    await prepare({ project: 'MyProject.csproj', includeSymbols: true }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--include-symbols');
+  });
+
+  it('includes --include-source when set', async () => {
+    await prepare({ project: 'MyProject.csproj', includeSource: true }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--include-source');
+  });
+
+  it('includes --serviceable when set', async () => {
+    await prepare({ project: 'MyProject.csproj', serviceable: true }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--serviceable');
+  });
+
+  it('passes cwd from context', async () => {
+    await prepare({ project: 'MyProject.csproj' }, makeContext());
+
+    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(options.cwd).toBe('/project');
+  });
+});

--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,0 +1,91 @@
+import { exec as execCb } from 'child_process';
+import { publish } from './publish';
+
+jest.mock('child_process', () => ({
+  exec: jest.fn(),
+}));
+jest.mock('util', () => ({
+  promisify: jest.fn((fn) => fn),
+}));
+
+const mockedExec = execCb as jest.MockedFunction<typeof execCb>;
+
+function makeContext(overrides: Record<string, unknown> = {}) {
+  return {
+    cwd: '/project',
+    env: { NUGET_API_KEY: 'test-key' },
+    ...overrides,
+  } as never;
+}
+
+describe('publish', () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+    (mockedExec as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+  });
+
+  it('builds dotnet nuget push command with *.nupkg glob', async () => {
+    await publish({}, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('dotnet nuget push');
+    expect(cmd).toContain('*.nupkg');
+  });
+
+  it('includes api-key from env when NUGET_API_KEY is set', async () => {
+    await publish({}, makeContext({ env: { NUGET_API_KEY: 'my-key' } }));
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--api-key my-key');
+  });
+
+  it('omits api-key args when NUGET_API_KEY is not set', async () => {
+    await publish({}, makeContext({ env: {} }));
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).not.toContain('--api-key');
+    expect(cmd).not.toContain('--symbol-api-key');
+  });
+
+  it('includes --source when provided', async () => {
+    await publish({ source: 'https://nuget.example.com/v3/index.json' }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--source https://nuget.example.com/v3/index.json');
+  });
+
+  it('includes --symbol-source when provided', async () => {
+    await publish({ symbolSource: 'https://symbols.example.com' }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--symbol-source https://symbols.example.com');
+  });
+
+  it('includes --skip-duplicate when set', async () => {
+    await publish({ skipDuplicate: true }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--skip-duplicate');
+  });
+
+  it('includes --timeout when provided', async () => {
+    await publish({ timeout: 300 }, makeContext());
+
+    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(cmd).toContain('--timeout 300');
+  });
+
+  it('resolves nupkgRoot relative to cwd', async () => {
+    await publish({ nupkgRoot: 'artifacts' }, makeContext({ cwd: '/project' }));
+
+    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(options.cwd).toBe('/project/artifacts');
+  });
+
+  it('uses cwd directly when nupkgRoot is not set', async () => {
+    await publish({}, makeContext({ cwd: '/project' }));
+
+    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    expect(options.cwd).toBe('/project');
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for two previously untested areas:

**semantic-release-nuget** (17 new tests across 2 suites):
- \`prepare.spec.ts\`: verifies \`dotnet pack\` command construction — required args, optional flags (noBuild, includeSymbols, includeSource, serviceable, custom configuration), cwd passthrough
- \`publish.spec.ts\`: verifies \`dotnet nuget push\` command construction — *.nupkg glob, API key inclusion/exclusion, source/symbolSource/skipDuplicate/timeout flags, nupkgRoot resolution

**nx-oc utilities** (7 new tests across 2 suites):
- \`git-utils.spec.ts\`: \`getGitRemoteUrl\` success and failure (throws → returns undefined)
- \`oc-utils.spec.ts\`: \`runOcCommand\` success/failure, command string construction with and without input buffer, cat-pipe form for apply

## Test plan

- [x] \`nx test semantic-release-nuget\` — 17 tests pass
- [x] \`nx test nx-oc\` — 23 tests pass (includes 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)