### PR TITLE
fix(e2e): correct pipeline file path assertions and jest config warnings

### DIFF
--- a/e2e/nx-adsp-e2e/jest.config.js
+++ b/e2e/nx-adsp-e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     '^.+\\.[tj]s$': [
       'ts-jest',
       {
-        tsConfig: '<rootDir>/tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
       },
     ],
   },
@@ -14,5 +14,4 @@ module.exports = {
   coverageDirectory: '../../coverage/e2e/nx-adsp-e2e',
   // ensureNxProject (beforeEach) does a full npm install — needs more than the default 5s
   testTimeout: 300000,
-  forceExit: true,
 };

--- a/e2e/nx-oc-e2e/jest.config.js
+++ b/e2e/nx-oc-e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     '^.+\\.[tj]s$': [
       'ts-jest',
       {
-        tsConfig: '<rootDir>/tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
       },
     ],
   },
@@ -14,5 +14,4 @@ module.exports = {
   coverageDirectory: '../../coverage/e2e/nx-oc-e2e',
   // ensureNxProject (beforeEach) does a full npm install — needs more than the default 5s
   testTimeout: 300000,
-  forceExit: true,
 };

--- a/e2e/nx-oc-e2e/tests/nx-oc.spec.ts
+++ b/e2e/nx-oc-e2e/tests/nx-oc.spec.ts
@@ -17,7 +17,10 @@ describe('nx-oc e2e', () => {
 
       expect(result.stderr).toBeFalsy();
       expect(() =>
-        checkFilesExist(`.openshift/${plugin}-build/${plugin}-build.yml`)
+        checkFilesExist(
+          `.openshift/environment.infra.yml`,
+          `.openshift/environments.yml`
+        )
       ).not.toThrow();
     }, 60000);
 
@@ -30,8 +33,9 @@ describe('nx-oc e2e', () => {
       expect(result.stderr).toBeFalsy();
       expect(() =>
         checkFilesExist(
-          `.openshift/${plugin}-build/${plugin}-build.yml`,
-          `.github/workflows/${plugin}-build.yml`
+          `.openshift/environment.infra.yml`,
+          `.openshift/environments.yml`,
+          `.github/workflows/pipeline.yml`
         )
       ).not.toThrow();
     }, 60000);

--- a/e2e/nx-release-e2e/jest.config.js
+++ b/e2e/nx-release-e2e/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     '^.+\\.[tj]s$': [
       'ts-jest',
       {
-        tsConfig: '<rootDir>/tsconfig.spec.json',
+        tsconfig: '<rootDir>/tsconfig.spec.json',
       },
     ],
   },
@@ -14,5 +14,4 @@ module.exports = {
   coverageDirectory: '../../coverage/e2e/nx-release-e2e',
   // ensureNxProject + copyNodeModules (beforeEach) do a full npm install — needs more than the default 5s
   testTimeout: 300000,
-  forceExit: true,
 };


### PR DESCRIPTION
## Summary

Fixes the CI failure introduced by the e2e improvements in the previous release.

**Root cause 1 — wrong file paths in nx-oc-e2e:**
The pipeline tests were checking for `.openshift/${plugin}-build/${plugin}-build.yml`, which is the per-app manifest output of the `deployment` generator. The `pipeline` generator outputs infrastructure setup files:
- `.openshift/environment.infra.yml`
- `.openshift/environments.yml`
- `.github/workflows/pipeline.yml` (actions type only)

**Root cause 2 — `forceExit: true` in jest configs:**
The `@nx/jest` executor's config validator does not recognise `forceExit` as a valid option in the jest config file. This produced an "Unknown option" warning that caused the executor to treat the run as failed. Removed from all three e2e jest configs.

**Root cause 3 — deprecated `tsConfig` key:**
`ts-jest` deprecated `tsConfig` in favour of `tsconfig` (lowercase). Fixed in all three e2e jest configs.

## Test plan

- [ ] CI E2E step passes on next merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)