### PR TITLE
chore: bump CI actions from v4 to v5 to resolve Node.js 20 warnings

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,10 +23,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -25,17 +25,17 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: "npm"
       - run: npm ci
       - name: Get last successful commit
         id: last_successful_commit
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@v5
       - name: Lint
         run: npm run affected:lint -- --base=${{ steps.last_successful_commit.outputs.base }}
       - name: Test


### PR DESCRIPTION
v4 actions run on Node.js 20, which GitHub is deprecating (forced to Node.js 24 from June 16th 2026). Bumps `actions/checkout`, `actions/setup-node`, and `nrwl/nx-set-shas` to v5 in both `pull-request.yml` and `release-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)