### PR TITLE
docs: enforce branch + PR workflow in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,17 @@ unless explicitly directed.
   repo (docs, dependency updates, refactors, generator logic covered by unit/e2e
   tests) should target `main` directly.
 
+### Branch workflow (required)
+
+All changes — no matter how small — must follow this workflow:
+
+1. Create a feature branch from `main` (or `beta` if the change is beta-only):
+   `git checkout -b fix/short-description`
+2. Commit changes to that branch.
+3. Open a pull request targeting `main` or `beta` and wait for CI to pass.
+4. **Never push commits directly to `main` or `beta`**, even when repository
+   permissions allow it. Always integrate via PR.
+
 ### Version convention
 
 **@abgov major version = Nx major version − 10**


### PR DESCRIPTION
## Summary

- Adds a **Branch workflow (required)** section to `AGENTS.md` under Branching and Release
- Makes explicit that all changes must go through a feature branch and PR, never pushed directly to `main` or `beta`
- Reinforces the existing Don't entry with a concrete step-by-step workflow

## Test plan

- [ ] No code changes — docs only, no tests required
- [ ] Verify the new section reads clearly in the rendered AGENTS.md on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)