### PR TITLE
fix(e2e): allow deprecation warning on stderr for jenkins pipeline test

### DIFF
--- a/e2e/nx-oc-e2e/tests/nx-oc.spec.ts
+++ b/e2e/nx-oc-e2e/tests/nx-oc.spec.ts
@@ -15,7 +15,7 @@ describe('nx-oc e2e', () => {
         `generate @abgov/nx-oc:pipeline ${plugin}-build ${plugin}-infra --t jenkins --e ${plugin}-dev --r ghcr.io/test-org`
       );
 
-      expect(result.stderr).toBeFalsy();
+      expect(result.stderr).not.toMatch(/error/i);
       expect(() =>
         checkFilesExist(
           `.openshift/environment.infra.yml`,


### PR DESCRIPTION
## Summary

- The jenkins pipeline generator now emits a deprecation warning to stderr (`Jenkins pipeline support is deprecated...`)
- The e2e test was asserting `expect(result.stderr).toBeFalsy()`, which fails on any stderr output
- Changed to `expect(result.stderr).not.toMatch(/error/i)` to allow warnings while still catching real errors

## Test plan

- [ ] `nx-oc-e2e` should pass with all 3 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)