### PR TITLE
fix(semantic-release-nuget): replace exec with execFile to prevent command injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,17 @@ unless explicitly directed.
   repo (docs, dependency updates, refactors, generator logic covered by unit/e2e
   tests) should target `main` directly.
 
+### Branch workflow (required)
+
+All changes — no matter how small — must follow this workflow:
+
+1. Create a feature branch from `main` (or `beta` if the change is beta-only):
+   `git checkout -b fix/short-description`
+2. Commit changes to that branch.
+3. Open a pull request targeting `main` or `beta` and wait for CI to pass.
+4. **Never push commits directly to `main` or `beta`**, even when repository
+   permissions allow it. Always integrate via PR.
+
 ### Version convention
 
 **@abgov major version = Nx major version − 10**

--- a/packages/semantic-release-nuget/src/plugin/prepare.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/prepare.spec.ts
@@ -1,15 +1,15 @@
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { prepare } from './prepare';
 
 jest.mock('child_process', () => ({
-  exec: jest.fn(),
+  execFile: jest.fn(),
 }));
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),
 }));
 
-const mockedExec = execCb as jest.MockedFunction<typeof execCb>;
+const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
 
 function makeContext(version = '1.2.3') {
   return {
@@ -21,67 +21,68 @@ function makeContext(version = '1.2.3') {
 
 describe('prepare', () => {
   beforeEach(() => {
-    mockedExec.mockReset();
-    (mockedExec as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+    mockedExecFile.mockReset();
+    (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
   });
 
-  it('builds dotnet pack command with required args', async () => {
+  it('invokes dotnet pack with required args', async () => {
     const config = { project: 'MyProject.csproj' };
     await prepare(config, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('dotnet pack');
-    expect(cmd).toContain('MyProject.csproj');
-    expect(cmd).toContain('/p:Version=1.2.3');
-    expect(cmd).toContain('/p:Configuration=Release');
+    const [file, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(file).toBe('dotnet');
+    expect(args).toContain('pack');
+    expect(args).toContain('MyProject.csproj');
+    expect(args).toContain('/p:Version=1.2.3');
+    expect(args).toContain('/p:Configuration=Release');
   });
 
   it('uses custom configuration when provided', async () => {
     await prepare({ project: 'MyProject.csproj', configuration: 'Debug' }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('/p:Configuration=Debug');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('/p:Configuration=Debug');
   });
 
   it('includes --no-build when noBuild is true', async () => {
     await prepare({ project: 'MyProject.csproj', noBuild: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--no-build');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--no-build');
   });
 
   it('omits --no-build when noBuild is false', async () => {
     await prepare({ project: 'MyProject.csproj', noBuild: false }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).not.toContain('--no-build');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).not.toContain('--no-build');
   });
 
   it('includes --include-symbols when set', async () => {
     await prepare({ project: 'MyProject.csproj', includeSymbols: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--include-symbols');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--include-symbols');
   });
 
   it('includes --include-source when set', async () => {
     await prepare({ project: 'MyProject.csproj', includeSource: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--include-source');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--include-source');
   });
 
   it('includes --serviceable when set', async () => {
     await prepare({ project: 'MyProject.csproj', serviceable: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--serviceable');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--serviceable');
   });
 
   it('passes cwd from context', async () => {
     await prepare({ project: 'MyProject.csproj' }, makeContext());
 
-    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    const [, , options] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(options.cwd).toBe('/project');
   });
 });

--- a/packages/semantic-release-nuget/src/plugin/prepare.ts
+++ b/packages/semantic-release-nuget/src/plugin/prepare.ts
@@ -1,41 +1,32 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PrepareContext } from 'semantic-release';
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { NugetPluginConfig } from './config';
-const exec = promisify(execCb);
+
+const execFile = promisify(execFileCb);
 
 export const prepare: PluginFunction<PrepareContext> = async (
   config: NugetPluginConfig,
   context
 ) => {
-  const { project, configuration, noBuild, includeSymbols, includeSource, serviceable } =
-    config;
-
+  const { project, configuration, noBuild, includeSymbols, includeSource, serviceable } = config;
   const {
     cwd,
     env,
-    // stdout,
-    // stderr,
     nextRelease: { version },
   } = context;
 
-  const args = [
-    'dotnet',
+  const args: string[] = [
     'pack',
     project,
-    noBuild ? '--no-build' : null,
-    includeSymbols ? '--include-symbols' : null,
-    includeSource ? '--include-source' : null,
-    serviceable ? '--serviceable' : null,
+    ...(noBuild ? ['--no-build'] : []),
+    ...(includeSymbols ? ['--include-symbols'] : []),
+    ...(includeSource ? ['--include-source'] : []),
+    ...(serviceable ? ['--serviceable'] : []),
     `/p:Configuration=${configuration || 'Release'}`,
     `/p:Version=${version}`,
-  ].filter((v) => !!v);
+  ];
 
-  const dotnetResult = await exec(args.join(' '), { env, cwd });
-
-  // dotnetResult.stdout.pipe(stdout, { end: false });
-  // dotnetResult.stderr.pipe(stderr, { end: false });
-
-  await dotnetResult;
+  await execFile('dotnet', args, { env, cwd });
 };

--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,14 +1,14 @@
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { publish } from './publish';
 
 jest.mock('child_process', () => ({
-  exec: jest.fn(),
+  execFile: jest.fn(),
 }));
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),
 }));
 
-const mockedExec = execCb as jest.MockedFunction<typeof execCb>;
+const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
 
 function makeContext(overrides: Record<string, unknown> = {}) {
   return {
@@ -20,72 +20,82 @@ function makeContext(overrides: Record<string, unknown> = {}) {
 
 describe('publish', () => {
   beforeEach(() => {
-    mockedExec.mockReset();
-    (mockedExec as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+    mockedExecFile.mockReset();
+    (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
   });
 
-  it('builds dotnet nuget push command with *.nupkg glob', async () => {
+  it('invokes dotnet nuget push with *.nupkg glob', async () => {
     await publish({}, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('dotnet nuget push');
-    expect(cmd).toContain('*.nupkg');
+    const [file, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(file).toBe('dotnet');
+    expect(args).toContain('nuget');
+    expect(args).toContain('push');
+    expect(args).toContain('*.nupkg');
   });
 
-  it('includes api-key from env when NUGET_API_KEY is set', async () => {
+  it('passes api-key as a discrete arg when NUGET_API_KEY is set', async () => {
     await publish({}, makeContext({ env: { NUGET_API_KEY: 'my-key' } }));
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--api-key my-key');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const keyIdx = args.indexOf('--api-key');
+    expect(keyIdx).toBeGreaterThan(-1);
+    expect(args[keyIdx + 1]).toBe('my-key');
   });
 
   it('omits api-key args when NUGET_API_KEY is not set', async () => {
     await publish({}, makeContext({ env: {} }));
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).not.toContain('--api-key');
-    expect(cmd).not.toContain('--symbol-api-key');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).not.toContain('--api-key');
+    expect(args).not.toContain('--symbol-api-key');
   });
 
-  it('includes --source when provided', async () => {
+  it('passes --source as a discrete arg', async () => {
     await publish({ source: 'https://nuget.example.com/v3/index.json' }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--source https://nuget.example.com/v3/index.json');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const srcIdx = args.indexOf('--source');
+    expect(srcIdx).toBeGreaterThan(-1);
+    expect(args[srcIdx + 1]).toBe('https://nuget.example.com/v3/index.json');
   });
 
-  it('includes --symbol-source when provided', async () => {
+  it('passes --symbol-source as a discrete arg', async () => {
     await publish({ symbolSource: 'https://symbols.example.com' }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--symbol-source https://symbols.example.com');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const symIdx = args.indexOf('--symbol-source');
+    expect(symIdx).toBeGreaterThan(-1);
+    expect(args[symIdx + 1]).toBe('https://symbols.example.com');
   });
 
   it('includes --skip-duplicate when set', async () => {
     await publish({ skipDuplicate: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--skip-duplicate');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--skip-duplicate');
   });
 
-  it('includes --timeout when provided', async () => {
+  it('passes --timeout as a discrete arg', async () => {
     await publish({ timeout: 300 }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--timeout 300');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const tIdx = args.indexOf('--timeout');
+    expect(tIdx).toBeGreaterThan(-1);
+    expect(args[tIdx + 1]).toBe('300');
   });
 
   it('resolves nupkgRoot relative to cwd', async () => {
     await publish({ nupkgRoot: 'artifacts' }, makeContext({ cwd: '/project' }));
 
-    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    const [, , options] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(options.cwd).toBe('/project/artifacts');
   });
 
   it('uses cwd directly when nupkgRoot is not set', async () => {
     await publish({}, makeContext({ cwd: '/project' }));
 
-    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    const [, , options] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(options.cwd).toBe('/project');
   });
 });

--- a/packages/semantic-release-nuget/src/plugin/publish.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.ts
@@ -1,45 +1,34 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PublishContext } from 'semantic-release';
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import * as path from 'path';
 import { promisify } from 'util';
 import { NugetPluginConfig } from './config';
 
-const exec = promisify(execCb);
+const execFile = promisify(execFileCb);
 
 export const publish: PluginFunction<PublishContext> = async (
   config: NugetPluginConfig,
   context
 ) => {
   const { nupkgRoot, source, symbolSource, skipDuplicate, timeout } = config;
-  const {
-    cwd,
-    env,
-    // stdout,
-    // stderr
-  } = context;
+  const { cwd, env } = context;
 
   const basePath = nupkgRoot ? path.resolve(cwd, nupkgRoot) : cwd;
 
-  const args = [
-    'dotnet',
+  const args: string[] = [
     'nuget',
     'push',
     '*.nupkg',
-    source ? `--source ${source}` : null,
-    env.NUGET_API_KEY ? `--api-key ${env.NUGET_API_KEY}` : null,
-    symbolSource ? `--symbol-source ${symbolSource}` : null,
-    env.NUGET_API_KEY ? `--symbol-api-key ${env.NUGET_API_KEY}` : null,
-    skipDuplicate ? '--skip-duplicate' : null,
-    timeout ? `--timeout ${timeout}` : null,
-  ].filter((v) => !!v);
+    ...(source ? ['--source', source] : []),
+    ...(env.NUGET_API_KEY ? ['--api-key', env.NUGET_API_KEY] : []),
+    ...(symbolSource ? ['--symbol-source', symbolSource] : []),
+    ...(env.NUGET_API_KEY ? ['--symbol-api-key', env.NUGET_API_KEY] : []),
+    ...(skipDuplicate ? ['--skip-duplicate'] : []),
+    ...(timeout ? ['--timeout', String(timeout)] : []),
+  ];
 
-  const dotnetResult = await exec(args.join(' '), { env, cwd: basePath });
-
-  // dotnetResult.stdout.pipe(stdout, { end: false });
-  // dotnetResult.stderr.pipe(stderr, { end: false });
-
-  await dotnetResult;
+  await execFile('dotnet', args, { env, cwd: basePath });
 
   return false;
 };


### PR DESCRIPTION
## Summary

- `child_process.exec` passes the command through the shell, meaning user-supplied values (`project` path, `source` URL, `configuration`) can contain shell metacharacters that alter the command or execute arbitrary code
- Switches both `prepare` and `publish` to `execFile` with an explicit `string[]` args array, bypassing the shell entirely
- Updates tests to assert on `[file, args, options]` instead of a command string

## Test plan

- [ ] All 17 existing tests updated and passing
- [ ] Verify locally: `npx nx test semantic-release-nuget`
- [ ] Confirm no regression in `dotnet pack` / `dotnet nuget push` invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)