### PR TITLE
fix(semantic-release-nuget): keep NUGET_API_KEY out of process arguments

### DIFF
--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCb } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { publish } from './publish';
 
 jest.mock('child_process', () => ({
@@ -7,8 +8,16 @@ jest.mock('child_process', () => ({
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),
 }));
+jest.mock('fs', () => ({
+  mkdtempSync: jest.fn().mockReturnValue('/tmp/sr-nuget-test'),
+  writeFileSync: jest.fn(),
+  rmSync: jest.fn(),
+}));
 
 const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
+const mockedMkdtempSync = mkdtempSync as jest.MockedFunction<typeof mkdtempSync>;
+const mockedWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
+const mockedRmSync = rmSync as jest.MockedFunction<typeof rmSync>;
 
 function makeContext(overrides: Record<string, unknown> = {}) {
   return {
@@ -22,6 +31,9 @@ describe('publish', () => {
   beforeEach(() => {
     mockedExecFile.mockReset();
     (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+    (mockedMkdtempSync as jest.Mock).mockReturnValue('/tmp/sr-nuget-test');
+    (mockedWriteFileSync as jest.Mock).mockReset();
+    (mockedRmSync as jest.Mock).mockReset();
   });
 
   it('invokes dotnet nuget push with *.nupkg glob', async () => {
@@ -34,21 +46,72 @@ describe('publish', () => {
     expect(args).toContain('*.nupkg');
   });
 
-  it('passes api-key as a discrete arg when NUGET_API_KEY is set', async () => {
+  it('passes api-key via config file, not as a CLI arg', async () => {
     await publish({}, makeContext({ env: { NUGET_API_KEY: 'my-key' } }));
-
-    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
-    const keyIdx = args.indexOf('--api-key');
-    expect(keyIdx).toBeGreaterThan(-1);
-    expect(args[keyIdx + 1]).toBe('my-key');
-  });
-
-  it('omits api-key args when NUGET_API_KEY is not set', async () => {
-    await publish({}, makeContext({ env: {} }));
 
     const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(args).not.toContain('--api-key');
     expect(args).not.toContain('--symbol-api-key');
+    expect(args).toContain('--config-file');
+  });
+
+  it('writes api-key to temp nuget.config', async () => {
+    await publish(
+      { source: 'https://nuget.example.com/v3/index.json' },
+      makeContext({ env: { NUGET_API_KEY: 'secret' } }),
+    );
+
+    expect(mockedWriteFileSync).toHaveBeenCalledTimes(1);
+    const [, content] = (mockedWriteFileSync as jest.Mock).mock.calls[0];
+    expect(content).toContain('https://nuget.example.com/v3/index.json');
+    expect(content).toContain('secret');
+  });
+
+  it('falls back to nuget.org source when no source is configured', async () => {
+    await publish({}, makeContext({ env: { NUGET_API_KEY: 'secret' } }));
+
+    const [, content] = (mockedWriteFileSync as jest.Mock).mock.calls[0];
+    expect(content).toContain('https://api.nuget.org/v3/index.json');
+  });
+
+  it('includes symbol source key in config when symbolSource is set', async () => {
+    await publish(
+      { symbolSource: 'https://symbols.example.com' },
+      makeContext({ env: { NUGET_API_KEY: 'key' } }),
+    );
+
+    const [, content] = (mockedWriteFileSync as jest.Mock).mock.calls[0];
+    expect(content).toContain('https://symbols.example.com');
+  });
+
+  it('removes temp directory after push', async () => {
+    await publish({}, makeContext({ env: { NUGET_API_KEY: 'key' } }));
+
+    expect(mockedRmSync).toHaveBeenCalledWith('/tmp/sr-nuget-test', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('removes temp directory even when push fails', async () => {
+    (mockedExecFile as unknown as jest.Mock).mockRejectedValue(new Error('push failed'));
+
+    await expect(
+      publish({}, makeContext({ env: { NUGET_API_KEY: 'key' } })),
+    ).rejects.toThrow('push failed');
+    expect(mockedRmSync).toHaveBeenCalledWith('/tmp/sr-nuget-test', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('skips config file when NUGET_API_KEY is not set', async () => {
+    await publish({}, makeContext({ env: {} }));
+
+    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).not.toContain('--config-file');
+    expect(args).not.toContain('--api-key');
   });
 
   it('passes --source as a discrete arg', async () => {

--- a/packages/semantic-release-nuget/src/plugin/publish.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.ts
@@ -1,11 +1,21 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PublishContext } from 'semantic-release';
 import { execFile as execFileCb } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 import { NugetPluginConfig } from './config';
 
 const execFile = promisify(execFileCb);
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 export const publish: PluginFunction<PublishContext> = async (
   config: NugetPluginConfig,
@@ -16,19 +26,47 @@ export const publish: PluginFunction<PublishContext> = async (
 
   const basePath = nupkgRoot ? path.resolve(cwd, nupkgRoot) : cwd;
 
-  const args: string[] = [
-    'nuget',
-    'push',
-    '*.nupkg',
-    ...(source ? ['--source', source] : []),
-    ...(env.NUGET_API_KEY ? ['--api-key', env.NUGET_API_KEY] : []),
-    ...(symbolSource ? ['--symbol-source', symbolSource] : []),
-    ...(env.NUGET_API_KEY ? ['--symbol-api-key', env.NUGET_API_KEY] : []),
-    ...(skipDuplicate ? ['--skip-duplicate'] : []),
-    ...(timeout ? ['--timeout', String(timeout)] : []),
-  ];
+  let tempDir: string | null = null;
 
-  await execFile('dotnet', args, { env, cwd: basePath });
+  try {
+    let configArgs: string[] = [];
+
+    if (env.NUGET_API_KEY) {
+      tempDir = mkdtempSync(path.join(tmpdir(), 'sr-nuget-'));
+      const configPath = path.join(tempDir, 'nuget.config');
+      const targetSource = source || 'https://api.nuget.org/v3/index.json';
+      const apiKeyLines = [
+        `    <add key="${escapeXml(targetSource)}" value="${escapeXml(env.NUGET_API_KEY)}" />`,
+        ...(symbolSource
+          ? [
+              `    <add key="${escapeXml(symbolSource)}" value="${escapeXml(env.NUGET_API_KEY)}" />`,
+            ]
+          : []),
+      ].join('\n');
+      writeFileSync(
+        configPath,
+        `<?xml version="1.0" encoding="utf-8"?>\n<configuration>\n  <apikeys>\n${apiKeyLines}\n  </apikeys>\n</configuration>`,
+      );
+      configArgs = ['--config-file', configPath];
+    }
+
+    const args: string[] = [
+      'nuget',
+      'push',
+      '*.nupkg',
+      ...(source ? ['--source', source] : []),
+      ...(symbolSource ? ['--symbol-source', symbolSource] : []),
+      ...configArgs,
+      ...(skipDuplicate ? ['--skip-duplicate'] : []),
+      ...(timeout ? ['--timeout', String(timeout)] : []),
+    ];
+
+    await execFile('dotnet', args, { env, cwd: basePath });
+  } finally {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
 
   return false;
 };


### PR DESCRIPTION
## Summary

- Passing `--api-key` on the CLI exposes `NUGET_API_KEY` in the process table (`/proc/PID/cmdline`) and in any tooling that logs argv
- Instead, writes a temporary `nuget.config` to a `mkdtemp` directory containing an `<apikeys>` entry for the push source (and symbol source if configured), then passes `--config-file` to `dotnet nuget push`
- The temp directory is removed in a `finally` block so it is cleaned up even when the push fails
- Builds on #213 (requires `execFile` landing first)

## Test plan

- [ ] All 22 tests passing (`npx nx test semantic-release-nuget`)
- [ ] New tests cover: config file creation, API key absent from args, fallback to nuget.org source, symbol source entry, cleanup on success and on failure
- [ ] Verify `NUGET_API_KEY` does not appear in `ps aux` output during a real push

🤖 Generated with [Claude Code](https://claude.com/claude-code)