### PR TITLE
fix(semantic-release-nuget): enumerate .nupkg files explicitly instead of relying on shell glob

### DIFF
--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCb } from 'child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { publish } from './publish';
 
 jest.mock('child_process', () => ({
@@ -10,12 +10,14 @@ jest.mock('util', () => ({
 }));
 jest.mock('fs', () => ({
   mkdtempSync: jest.fn().mockReturnValue('/tmp/sr-nuget-test'),
-  writeFileSync: jest.fn(),
+  readdirSync: jest.fn().mockReturnValue(['MyLib.1.2.3.nupkg']),
   rmSync: jest.fn(),
+  writeFileSync: jest.fn(),
 }));
 
 const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
 const mockedMkdtempSync = mkdtempSync as jest.MockedFunction<typeof mkdtempSync>;
+const mockedReaddirSync = readdirSync as jest.MockedFunction<typeof readdirSync>;
 const mockedWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
 const mockedRmSync = rmSync as jest.MockedFunction<typeof rmSync>;
 
@@ -32,18 +34,56 @@ describe('publish', () => {
     mockedExecFile.mockReset();
     (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
     (mockedMkdtempSync as jest.Mock).mockReturnValue('/tmp/sr-nuget-test');
+    (mockedReaddirSync as jest.Mock).mockReturnValue(['MyLib.1.2.3.nupkg']);
     (mockedWriteFileSync as jest.Mock).mockReset();
     (mockedRmSync as jest.Mock).mockReset();
   });
 
-  it('invokes dotnet nuget push with *.nupkg glob', async () => {
+  it('invokes dotnet nuget push with an explicit filename per package', async () => {
     await publish({}, makeContext());
 
     const [file, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(file).toBe('dotnet');
     expect(args).toContain('nuget');
     expect(args).toContain('push');
-    expect(args).toContain('*.nupkg');
+    expect(args).toContain('MyLib.1.2.3.nupkg');
+    expect(args).not.toContain('*.nupkg');
+  });
+
+  it('pushes each .nupkg file in a separate execFile call', async () => {
+    (mockedReaddirSync as jest.Mock).mockReturnValue(['Foo.1.0.0.nupkg', 'Bar.2.0.0.nupkg']);
+    await publish({}, makeContext());
+
+    expect(mockedExecFile).toHaveBeenCalledTimes(2);
+    const firstArgs = (mockedExecFile as unknown as jest.Mock).mock.calls[0][1];
+    const secondArgs = (mockedExecFile as unknown as jest.Mock).mock.calls[1][1];
+    expect(firstArgs).toContain('Foo.1.0.0.nupkg');
+    expect(secondArgs).toContain('Bar.2.0.0.nupkg');
+  });
+
+  it('scans basePath for .nupkg files', async () => {
+    await publish({ nupkgRoot: 'artifacts' }, makeContext({ cwd: '/project' }));
+
+    expect(mockedReaddirSync).toHaveBeenCalledWith('/project/artifacts');
+  });
+
+  it('filters non-.nupkg files from the directory listing', async () => {
+    (mockedReaddirSync as jest.Mock).mockReturnValue([
+      'MyLib.1.2.3.nupkg',
+      'README.md',
+      'MyLib.1.2.3.snupkg',
+    ]);
+    await publish({}, makeContext());
+
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('MyLib.1.2.3.nupkg');
+    expect(args).not.toContain('README.md');
+  });
+
+  it('throws when no .nupkg files are found', async () => {
+    (mockedReaddirSync as jest.Mock).mockReturnValue([]);
+    await expect(publish({}, makeContext())).rejects.toThrow('No .nupkg files found');
   });
 
   it('passes api-key via config file, not as a CLI arg', async () => {

--- a/packages/semantic-release-nuget/src/plugin/publish.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.ts
@@ -1,7 +1,7 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PublishContext } from 'semantic-release';
 import { execFile as execFileCb } from 'child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
@@ -25,6 +25,11 @@ export const publish: PluginFunction<PublishContext> = async (
   const { cwd, env } = context;
 
   const basePath = nupkgRoot ? path.resolve(cwd, nupkgRoot) : cwd;
+  const nupkgFiles = readdirSync(basePath).filter((f) => f.endsWith('.nupkg'));
+
+  if (nupkgFiles.length === 0) {
+    throw new Error(`No .nupkg files found in ${basePath}`);
+  }
 
   let tempDir: string | null = null;
 
@@ -50,18 +55,19 @@ export const publish: PluginFunction<PublishContext> = async (
       configArgs = ['--config-file', configPath];
     }
 
-    const args: string[] = [
-      'nuget',
-      'push',
-      '*.nupkg',
-      ...(source ? ['--source', source] : []),
-      ...(symbolSource ? ['--symbol-source', symbolSource] : []),
-      ...configArgs,
-      ...(skipDuplicate ? ['--skip-duplicate'] : []),
-      ...(timeout ? ['--timeout', String(timeout)] : []),
-    ];
-
-    await execFile('dotnet', args, { env, cwd: basePath });
+    for (const nupkg of nupkgFiles) {
+      const args: string[] = [
+        'nuget',
+        'push',
+        nupkg,
+        ...(source ? ['--source', source] : []),
+        ...(symbolSource ? ['--symbol-source', symbolSource] : []),
+        ...configArgs,
+        ...(skipDuplicate ? ['--skip-duplicate'] : []),
+        ...(timeout ? ['--timeout', String(timeout)] : []),
+      ];
+      await execFile('dotnet', args, { env, cwd: basePath });
+    }
   } finally {
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- `dotnet nuget push '*.nupkg'` requires the shell to expand the glob; since PR #213 switched to `execFile` (no shell), the literal string `'*.nupkg'` would be passed to dotnet and silently fail to match anything on Windows (and behave unpredictably elsewhere)
- Replaces the glob with a `readdirSync` scan of `basePath`, filtering for files ending in `.nupkg`
- Each matched file is pushed in its own `execFile` call so push errors are tied to a specific package
- Throws a descriptive error when no `.nupkg` files are found, preventing silent no-op releases
- Builds on #214

## Test plan

- [ ] All 26 tests passing (`npx nx test semantic-release-nuget`)
- [ ] New tests cover: per-file push calls, directory scan, non-`.nupkg` filtering, error on empty directory
- [ ] Verify behaviour with multiple packages in the same output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)