### PR TITLE
fix(semantic-release-nuget): close three security issues in dotnet invocations

### DIFF
--- a/packages/semantic-release-nuget/src/plugin/prepare.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/prepare.spec.ts
@@ -1,15 +1,15 @@
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { prepare } from './prepare';
 
 jest.mock('child_process', () => ({
-  exec: jest.fn(),
+  execFile: jest.fn(),
 }));
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),
 }));
 
-const mockedExec = execCb as jest.MockedFunction<typeof execCb>;
+const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
 
 function makeContext(version = '1.2.3') {
   return {
@@ -21,67 +21,68 @@ function makeContext(version = '1.2.3') {
 
 describe('prepare', () => {
   beforeEach(() => {
-    mockedExec.mockReset();
-    (mockedExec as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+    mockedExecFile.mockReset();
+    (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
   });
 
-  it('builds dotnet pack command with required args', async () => {
+  it('invokes dotnet pack with required args', async () => {
     const config = { project: 'MyProject.csproj' };
     await prepare(config, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('dotnet pack');
-    expect(cmd).toContain('MyProject.csproj');
-    expect(cmd).toContain('/p:Version=1.2.3');
-    expect(cmd).toContain('/p:Configuration=Release');
+    const [file, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(file).toBe('dotnet');
+    expect(args).toContain('pack');
+    expect(args).toContain('MyProject.csproj');
+    expect(args).toContain('/p:Version=1.2.3');
+    expect(args).toContain('/p:Configuration=Release');
   });
 
   it('uses custom configuration when provided', async () => {
     await prepare({ project: 'MyProject.csproj', configuration: 'Debug' }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('/p:Configuration=Debug');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('/p:Configuration=Debug');
   });
 
   it('includes --no-build when noBuild is true', async () => {
     await prepare({ project: 'MyProject.csproj', noBuild: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--no-build');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--no-build');
   });
 
   it('omits --no-build when noBuild is false', async () => {
     await prepare({ project: 'MyProject.csproj', noBuild: false }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).not.toContain('--no-build');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).not.toContain('--no-build');
   });
 
   it('includes --include-symbols when set', async () => {
     await prepare({ project: 'MyProject.csproj', includeSymbols: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--include-symbols');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--include-symbols');
   });
 
   it('includes --include-source when set', async () => {
     await prepare({ project: 'MyProject.csproj', includeSource: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--include-source');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--include-source');
   });
 
   it('includes --serviceable when set', async () => {
     await prepare({ project: 'MyProject.csproj', serviceable: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--serviceable');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--serviceable');
   });
 
   it('passes cwd from context', async () => {
     await prepare({ project: 'MyProject.csproj' }, makeContext());
 
-    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    const [, , options] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(options.cwd).toBe('/project');
   });
 });

--- a/packages/semantic-release-nuget/src/plugin/prepare.ts
+++ b/packages/semantic-release-nuget/src/plugin/prepare.ts
@@ -1,41 +1,32 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PrepareContext } from 'semantic-release';
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { promisify } from 'util';
 import { NugetPluginConfig } from './config';
-const exec = promisify(execCb);
+
+const execFile = promisify(execFileCb);
 
 export const prepare: PluginFunction<PrepareContext> = async (
   config: NugetPluginConfig,
   context
 ) => {
-  const { project, configuration, noBuild, includeSymbols, includeSource, serviceable } =
-    config;
-
+  const { project, configuration, noBuild, includeSymbols, includeSource, serviceable } = config;
   const {
     cwd,
     env,
-    // stdout,
-    // stderr,
     nextRelease: { version },
   } = context;
 
-  const args = [
-    'dotnet',
+  const args: string[] = [
     'pack',
     project,
-    noBuild ? '--no-build' : null,
-    includeSymbols ? '--include-symbols' : null,
-    includeSource ? '--include-source' : null,
-    serviceable ? '--serviceable' : null,
+    ...(noBuild ? ['--no-build'] : []),
+    ...(includeSymbols ? ['--include-symbols'] : []),
+    ...(includeSource ? ['--include-source'] : []),
+    ...(serviceable ? ['--serviceable'] : []),
     `/p:Configuration=${configuration || 'Release'}`,
     `/p:Version=${version}`,
-  ].filter((v) => !!v);
+  ];
 
-  const dotnetResult = await exec(args.join(' '), { env, cwd });
-
-  // dotnetResult.stdout.pipe(stdout, { end: false });
-  // dotnetResult.stderr.pipe(stderr, { end: false });
-
-  await dotnetResult;
+  await execFile('dotnet', args, { env, cwd });
 };

--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCb } from 'child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { publish } from './publish';
 
 jest.mock('child_process', () => ({
@@ -10,12 +10,14 @@ jest.mock('util', () => ({
 }));
 jest.mock('fs', () => ({
   mkdtempSync: jest.fn().mockReturnValue('/tmp/sr-nuget-test'),
-  writeFileSync: jest.fn(),
+  readdirSync: jest.fn().mockReturnValue(['MyLib.1.2.3.nupkg']),
   rmSync: jest.fn(),
+  writeFileSync: jest.fn(),
 }));
 
 const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
 const mockedMkdtempSync = mkdtempSync as jest.MockedFunction<typeof mkdtempSync>;
+const mockedReaddirSync = readdirSync as jest.MockedFunction<typeof readdirSync>;
 const mockedWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
 const mockedRmSync = rmSync as jest.MockedFunction<typeof rmSync>;
 
@@ -32,18 +34,56 @@ describe('publish', () => {
     mockedExecFile.mockReset();
     (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
     (mockedMkdtempSync as jest.Mock).mockReturnValue('/tmp/sr-nuget-test');
+    (mockedReaddirSync as jest.Mock).mockReturnValue(['MyLib.1.2.3.nupkg']);
     (mockedWriteFileSync as jest.Mock).mockReset();
     (mockedRmSync as jest.Mock).mockReset();
   });
 
-  it('invokes dotnet nuget push with *.nupkg glob', async () => {
+  it('invokes dotnet nuget push with an explicit filename per package', async () => {
     await publish({}, makeContext());
 
     const [file, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(file).toBe('dotnet');
     expect(args).toContain('nuget');
     expect(args).toContain('push');
-    expect(args).toContain('*.nupkg');
+    expect(args).toContain('MyLib.1.2.3.nupkg');
+    expect(args).not.toContain('*.nupkg');
+  });
+
+  it('pushes each .nupkg file in a separate execFile call', async () => {
+    (mockedReaddirSync as jest.Mock).mockReturnValue(['Foo.1.0.0.nupkg', 'Bar.2.0.0.nupkg']);
+    await publish({}, makeContext());
+
+    expect(mockedExecFile).toHaveBeenCalledTimes(2);
+    const firstArgs = (mockedExecFile as unknown as jest.Mock).mock.calls[0][1];
+    const secondArgs = (mockedExecFile as unknown as jest.Mock).mock.calls[1][1];
+    expect(firstArgs).toContain('Foo.1.0.0.nupkg');
+    expect(secondArgs).toContain('Bar.2.0.0.nupkg');
+  });
+
+  it('scans basePath for .nupkg files', async () => {
+    await publish({ nupkgRoot: 'artifacts' }, makeContext({ cwd: '/project' }));
+
+    expect(mockedReaddirSync).toHaveBeenCalledWith('/project/artifacts');
+  });
+
+  it('filters non-.nupkg files from the directory listing', async () => {
+    (mockedReaddirSync as jest.Mock).mockReturnValue([
+      'MyLib.1.2.3.nupkg',
+      'README.md',
+      'MyLib.1.2.3.snupkg',
+    ]);
+    await publish({}, makeContext());
+
+    expect(mockedExecFile).toHaveBeenCalledTimes(1);
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('MyLib.1.2.3.nupkg');
+    expect(args).not.toContain('README.md');
+  });
+
+  it('throws when no .nupkg files are found', async () => {
+    (mockedReaddirSync as jest.Mock).mockReturnValue([]);
+    await expect(publish({}, makeContext())).rejects.toThrow('No .nupkg files found');
   });
 
   it('passes api-key via config file, not as a CLI arg', async () => {

--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCb } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { publish } from './publish';
 
 jest.mock('child_process', () => ({
@@ -7,8 +8,16 @@ jest.mock('child_process', () => ({
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),
 }));
+jest.mock('fs', () => ({
+  mkdtempSync: jest.fn().mockReturnValue('/tmp/sr-nuget-test'),
+  writeFileSync: jest.fn(),
+  rmSync: jest.fn(),
+}));
 
 const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
+const mockedMkdtempSync = mkdtempSync as jest.MockedFunction<typeof mkdtempSync>;
+const mockedWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
+const mockedRmSync = rmSync as jest.MockedFunction<typeof rmSync>;
 
 function makeContext(overrides: Record<string, unknown> = {}) {
   return {
@@ -22,6 +31,9 @@ describe('publish', () => {
   beforeEach(() => {
     mockedExecFile.mockReset();
     (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+    (mockedMkdtempSync as jest.Mock).mockReturnValue('/tmp/sr-nuget-test');
+    (mockedWriteFileSync as jest.Mock).mockReset();
+    (mockedRmSync as jest.Mock).mockReset();
   });
 
   it('invokes dotnet nuget push with *.nupkg glob', async () => {
@@ -34,21 +46,72 @@ describe('publish', () => {
     expect(args).toContain('*.nupkg');
   });
 
-  it('passes api-key as a discrete arg when NUGET_API_KEY is set', async () => {
+  it('passes api-key via config file, not as a CLI arg', async () => {
     await publish({}, makeContext({ env: { NUGET_API_KEY: 'my-key' } }));
-
-    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
-    const keyIdx = args.indexOf('--api-key');
-    expect(keyIdx).toBeGreaterThan(-1);
-    expect(args[keyIdx + 1]).toBe('my-key');
-  });
-
-  it('omits api-key args when NUGET_API_KEY is not set', async () => {
-    await publish({}, makeContext({ env: {} }));
 
     const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(args).not.toContain('--api-key');
     expect(args).not.toContain('--symbol-api-key');
+    expect(args).toContain('--config-file');
+  });
+
+  it('writes api-key to temp nuget.config', async () => {
+    await publish(
+      { source: 'https://nuget.example.com/v3/index.json' },
+      makeContext({ env: { NUGET_API_KEY: 'secret' } }),
+    );
+
+    expect(mockedWriteFileSync).toHaveBeenCalledTimes(1);
+    const [, content] = (mockedWriteFileSync as jest.Mock).mock.calls[0];
+    expect(content).toContain('https://nuget.example.com/v3/index.json');
+    expect(content).toContain('secret');
+  });
+
+  it('falls back to nuget.org source when no source is configured', async () => {
+    await publish({}, makeContext({ env: { NUGET_API_KEY: 'secret' } }));
+
+    const [, content] = (mockedWriteFileSync as jest.Mock).mock.calls[0];
+    expect(content).toContain('https://api.nuget.org/v3/index.json');
+  });
+
+  it('includes symbol source key in config when symbolSource is set', async () => {
+    await publish(
+      { symbolSource: 'https://symbols.example.com' },
+      makeContext({ env: { NUGET_API_KEY: 'key' } }),
+    );
+
+    const [, content] = (mockedWriteFileSync as jest.Mock).mock.calls[0];
+    expect(content).toContain('https://symbols.example.com');
+  });
+
+  it('removes temp directory after push', async () => {
+    await publish({}, makeContext({ env: { NUGET_API_KEY: 'key' } }));
+
+    expect(mockedRmSync).toHaveBeenCalledWith('/tmp/sr-nuget-test', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('removes temp directory even when push fails', async () => {
+    (mockedExecFile as unknown as jest.Mock).mockRejectedValue(new Error('push failed'));
+
+    await expect(
+      publish({}, makeContext({ env: { NUGET_API_KEY: 'key' } })),
+    ).rejects.toThrow('push failed');
+    expect(mockedRmSync).toHaveBeenCalledWith('/tmp/sr-nuget-test', {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it('skips config file when NUGET_API_KEY is not set', async () => {
+    await publish({}, makeContext({ env: {} }));
+
+    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).not.toContain('--config-file');
+    expect(args).not.toContain('--api-key');
   });
 
   it('passes --source as a discrete arg', async () => {

--- a/packages/semantic-release-nuget/src/plugin/publish.spec.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.spec.ts
@@ -1,14 +1,14 @@
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import { publish } from './publish';
 
 jest.mock('child_process', () => ({
-  exec: jest.fn(),
+  execFile: jest.fn(),
 }));
 jest.mock('util', () => ({
   promisify: jest.fn((fn) => fn),
 }));
 
-const mockedExec = execCb as jest.MockedFunction<typeof execCb>;
+const mockedExecFile = execFileCb as jest.MockedFunction<typeof execFileCb>;
 
 function makeContext(overrides: Record<string, unknown> = {}) {
   return {
@@ -20,72 +20,82 @@ function makeContext(overrides: Record<string, unknown> = {}) {
 
 describe('publish', () => {
   beforeEach(() => {
-    mockedExec.mockReset();
-    (mockedExec as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
+    mockedExecFile.mockReset();
+    (mockedExecFile as unknown as jest.Mock).mockResolvedValue({ stdout: '', stderr: '' });
   });
 
-  it('builds dotnet nuget push command with *.nupkg glob', async () => {
+  it('invokes dotnet nuget push with *.nupkg glob', async () => {
     await publish({}, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('dotnet nuget push');
-    expect(cmd).toContain('*.nupkg');
+    const [file, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(file).toBe('dotnet');
+    expect(args).toContain('nuget');
+    expect(args).toContain('push');
+    expect(args).toContain('*.nupkg');
   });
 
-  it('includes api-key from env when NUGET_API_KEY is set', async () => {
+  it('passes api-key as a discrete arg when NUGET_API_KEY is set', async () => {
     await publish({}, makeContext({ env: { NUGET_API_KEY: 'my-key' } }));
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--api-key my-key');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const keyIdx = args.indexOf('--api-key');
+    expect(keyIdx).toBeGreaterThan(-1);
+    expect(args[keyIdx + 1]).toBe('my-key');
   });
 
   it('omits api-key args when NUGET_API_KEY is not set', async () => {
     await publish({}, makeContext({ env: {} }));
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).not.toContain('--api-key');
-    expect(cmd).not.toContain('--symbol-api-key');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).not.toContain('--api-key');
+    expect(args).not.toContain('--symbol-api-key');
   });
 
-  it('includes --source when provided', async () => {
+  it('passes --source as a discrete arg', async () => {
     await publish({ source: 'https://nuget.example.com/v3/index.json' }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--source https://nuget.example.com/v3/index.json');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const srcIdx = args.indexOf('--source');
+    expect(srcIdx).toBeGreaterThan(-1);
+    expect(args[srcIdx + 1]).toBe('https://nuget.example.com/v3/index.json');
   });
 
-  it('includes --symbol-source when provided', async () => {
+  it('passes --symbol-source as a discrete arg', async () => {
     await publish({ symbolSource: 'https://symbols.example.com' }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--symbol-source https://symbols.example.com');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const symIdx = args.indexOf('--symbol-source');
+    expect(symIdx).toBeGreaterThan(-1);
+    expect(args[symIdx + 1]).toBe('https://symbols.example.com');
   });
 
   it('includes --skip-duplicate when set', async () => {
     await publish({ skipDuplicate: true }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--skip-duplicate');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    expect(args).toContain('--skip-duplicate');
   });
 
-  it('includes --timeout when provided', async () => {
+  it('passes --timeout as a discrete arg', async () => {
     await publish({ timeout: 300 }, makeContext());
 
-    const [cmd] = (mockedExec as unknown as jest.Mock).mock.calls[0];
-    expect(cmd).toContain('--timeout 300');
+    const [, args] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
+    const tIdx = args.indexOf('--timeout');
+    expect(tIdx).toBeGreaterThan(-1);
+    expect(args[tIdx + 1]).toBe('300');
   });
 
   it('resolves nupkgRoot relative to cwd', async () => {
     await publish({ nupkgRoot: 'artifacts' }, makeContext({ cwd: '/project' }));
 
-    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    const [, , options] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(options.cwd).toBe('/project/artifacts');
   });
 
   it('uses cwd directly when nupkgRoot is not set', async () => {
     await publish({}, makeContext({ cwd: '/project' }));
 
-    const [, options] = (mockedExec as unknown as jest.Mock).mock.calls[0];
+    const [, , options] = (mockedExecFile as unknown as jest.Mock).mock.calls[0];
     expect(options.cwd).toBe('/project');
   });
 });

--- a/packages/semantic-release-nuget/src/plugin/publish.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.ts
@@ -1,7 +1,7 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PublishContext } from 'semantic-release';
 import { execFile as execFileCb } from 'child_process';
-import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
@@ -25,6 +25,11 @@ export const publish: PluginFunction<PublishContext> = async (
   const { cwd, env } = context;
 
   const basePath = nupkgRoot ? path.resolve(cwd, nupkgRoot) : cwd;
+  const nupkgFiles = readdirSync(basePath).filter((f) => f.endsWith('.nupkg'));
+
+  if (nupkgFiles.length === 0) {
+    throw new Error(`No .nupkg files found in ${basePath}`);
+  }
 
   let tempDir: string | null = null;
 
@@ -50,18 +55,19 @@ export const publish: PluginFunction<PublishContext> = async (
       configArgs = ['--config-file', configPath];
     }
 
-    const args: string[] = [
-      'nuget',
-      'push',
-      '*.nupkg',
-      ...(source ? ['--source', source] : []),
-      ...(symbolSource ? ['--symbol-source', symbolSource] : []),
-      ...configArgs,
-      ...(skipDuplicate ? ['--skip-duplicate'] : []),
-      ...(timeout ? ['--timeout', String(timeout)] : []),
-    ];
-
-    await execFile('dotnet', args, { env, cwd: basePath });
+    for (const nupkg of nupkgFiles) {
+      const args: string[] = [
+        'nuget',
+        'push',
+        nupkg,
+        ...(source ? ['--source', source] : []),
+        ...(symbolSource ? ['--symbol-source', symbolSource] : []),
+        ...configArgs,
+        ...(skipDuplicate ? ['--skip-duplicate'] : []),
+        ...(timeout ? ['--timeout', String(timeout)] : []),
+      ];
+      await execFile('dotnet', args, { env, cwd: basePath });
+    }
   } finally {
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });

--- a/packages/semantic-release-nuget/src/plugin/publish.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.ts
@@ -1,11 +1,21 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PublishContext } from 'semantic-release';
 import { execFile as execFileCb } from 'child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 import { NugetPluginConfig } from './config';
 
 const execFile = promisify(execFileCb);
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 export const publish: PluginFunction<PublishContext> = async (
   config: NugetPluginConfig,
@@ -16,19 +26,47 @@ export const publish: PluginFunction<PublishContext> = async (
 
   const basePath = nupkgRoot ? path.resolve(cwd, nupkgRoot) : cwd;
 
-  const args: string[] = [
-    'nuget',
-    'push',
-    '*.nupkg',
-    ...(source ? ['--source', source] : []),
-    ...(env.NUGET_API_KEY ? ['--api-key', env.NUGET_API_KEY] : []),
-    ...(symbolSource ? ['--symbol-source', symbolSource] : []),
-    ...(env.NUGET_API_KEY ? ['--symbol-api-key', env.NUGET_API_KEY] : []),
-    ...(skipDuplicate ? ['--skip-duplicate'] : []),
-    ...(timeout ? ['--timeout', String(timeout)] : []),
-  ];
+  let tempDir: string | null = null;
 
-  await execFile('dotnet', args, { env, cwd: basePath });
+  try {
+    let configArgs: string[] = [];
+
+    if (env.NUGET_API_KEY) {
+      tempDir = mkdtempSync(path.join(tmpdir(), 'sr-nuget-'));
+      const configPath = path.join(tempDir, 'nuget.config');
+      const targetSource = source || 'https://api.nuget.org/v3/index.json';
+      const apiKeyLines = [
+        `    <add key="${escapeXml(targetSource)}" value="${escapeXml(env.NUGET_API_KEY)}" />`,
+        ...(symbolSource
+          ? [
+              `    <add key="${escapeXml(symbolSource)}" value="${escapeXml(env.NUGET_API_KEY)}" />`,
+            ]
+          : []),
+      ].join('\n');
+      writeFileSync(
+        configPath,
+        `<?xml version="1.0" encoding="utf-8"?>\n<configuration>\n  <apikeys>\n${apiKeyLines}\n  </apikeys>\n</configuration>`,
+      );
+      configArgs = ['--config-file', configPath];
+    }
+
+    const args: string[] = [
+      'nuget',
+      'push',
+      '*.nupkg',
+      ...(source ? ['--source', source] : []),
+      ...(symbolSource ? ['--symbol-source', symbolSource] : []),
+      ...configArgs,
+      ...(skipDuplicate ? ['--skip-duplicate'] : []),
+      ...(timeout ? ['--timeout', String(timeout)] : []),
+    ];
+
+    await execFile('dotnet', args, { env, cwd: basePath });
+  } finally {
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
 
   return false;
 };

--- a/packages/semantic-release-nuget/src/plugin/publish.ts
+++ b/packages/semantic-release-nuget/src/plugin/publish.ts
@@ -1,45 +1,34 @@
 import { PluginFunction } from '@semantic-release/semantic-release';
 import { PublishContext } from 'semantic-release';
-import { exec as execCb } from 'child_process';
+import { execFile as execFileCb } from 'child_process';
 import * as path from 'path';
 import { promisify } from 'util';
 import { NugetPluginConfig } from './config';
 
-const exec = promisify(execCb);
+const execFile = promisify(execFileCb);
 
 export const publish: PluginFunction<PublishContext> = async (
   config: NugetPluginConfig,
   context
 ) => {
   const { nupkgRoot, source, symbolSource, skipDuplicate, timeout } = config;
-  const {
-    cwd,
-    env,
-    // stdout,
-    // stderr
-  } = context;
+  const { cwd, env } = context;
 
   const basePath = nupkgRoot ? path.resolve(cwd, nupkgRoot) : cwd;
 
-  const args = [
-    'dotnet',
+  const args: string[] = [
     'nuget',
     'push',
     '*.nupkg',
-    source ? `--source ${source}` : null,
-    env.NUGET_API_KEY ? `--api-key ${env.NUGET_API_KEY}` : null,
-    symbolSource ? `--symbol-source ${symbolSource}` : null,
-    env.NUGET_API_KEY ? `--symbol-api-key ${env.NUGET_API_KEY}` : null,
-    skipDuplicate ? '--skip-duplicate' : null,
-    timeout ? `--timeout ${timeout}` : null,
-  ].filter((v) => !!v);
+    ...(source ? ['--source', source] : []),
+    ...(env.NUGET_API_KEY ? ['--api-key', env.NUGET_API_KEY] : []),
+    ...(symbolSource ? ['--symbol-source', symbolSource] : []),
+    ...(env.NUGET_API_KEY ? ['--symbol-api-key', env.NUGET_API_KEY] : []),
+    ...(skipDuplicate ? ['--skip-duplicate'] : []),
+    ...(timeout ? ['--timeout', String(timeout)] : []),
+  ];
 
-  const dotnetResult = await exec(args.join(' '), { env, cwd: basePath });
-
-  // dotnetResult.stdout.pipe(stdout, { end: false });
-  // dotnetResult.stderr.pipe(stderr, { end: false });
-
-  await dotnetResult;
+  await execFile('dotnet', args, { env, cwd: basePath });
 
   return false;
 };


### PR DESCRIPTION
## Summary

Three related security and correctness fixes to how `semantic-release-nuget` invokes `dotnet`:

- **Command injection** — `exec` passed a shell-interpolated command string; user-supplied values (`project` path, `source` URL, `configuration`) could contain shell metacharacters. Replaced with `execFile` + explicit `string[]` args array to bypass the shell entirely.
- **API key in process table** — `--api-key` on the CLI exposes `NUGET_API_KEY` in `/proc/PID/cmdline` and in any tooling that logs argv. Now writes a temporary `nuget.config` with an `<apikeys>` entry for the target source and passes `--config-file`; the temp directory is removed in a `finally` block.
- **Glob expansion on Windows** — `*.nupkg` is expanded by the shell on Unix but not by `cmd.exe` on Windows, and `execFile` (no shell) breaks it on all platforms. Now uses `readdirSync` to enumerate `.nupkg` files explicitly, pushing each in its own `execFile` call. Throws a clear error when no packages are found.

## Test plan

- [ ] `npx nx test semantic-release-nuget` — 26 tests passing
- [ ] New tests cover: per-file push, directory scan, non-`.nupkg` filtering, error on empty dir, config file written with key, cleanup on success and failure, key absent from CLI args

🤖 Generated with [Claude Code](https://claude.com/claude-code)