### PR TITLE
fix(nx-release): improve commit filter robustness and code quality

### DIFF
--- a/packages/nx-release/src/release-plugin/git-utils.spec.ts
+++ b/packages/nx-release/src/release-plugin/git-utils.spec.ts
@@ -1,26 +1,35 @@
 import { ChildProcess, spawn } from 'child_process';
 import { ReadableStreamBuffer } from 'stream-buffers';
 import { mocked } from 'jest-mock'
-import { getPathCommitHashes } from './git-utils';
+import { clearCache, getPathCommitHashes } from './git-utils';
 
 jest.mock('child_process');
 const mockedSpawn = mocked(spawn);
 
 describe('git-utils', () => {
-  
+
   beforeEach(() => {
-    mockedSpawn.mockReset()
+    mockedSpawn.mockReset();
+    clearCache();
   });
 
   describe('getPathCommitHashes', () => {
   
     it('can get commits', async () => {
-  
-      const stream = new ReadableStreamBuffer();
-      stream.put('test1\ntest2\n');
-      stream.stop();
-      
-      mockedSpawn.mockReturnValue({ stdout: stream } as unknown as ChildProcess)
+
+      const stdout = new ReadableStreamBuffer();
+      stdout.put('test1\ntest2\n');
+      stdout.stop();
+
+      const stderr = new ReadableStreamBuffer();
+      stderr.stop();
+
+      mockedSpawn.mockReturnValue({
+        stdout,
+        stderr,
+        on: jest.fn((event, cb) => { if (event === 'close') cb(0); }),
+      } as unknown as ChildProcess);
+
       const commits = await getPathCommitHashes(
         '/repo',
         'test', 

--- a/packages/nx-release/src/release-plugin/git-utils.ts
+++ b/packages/nx-release/src/release-plugin/git-utils.ts
@@ -1,7 +1,11 @@
 import { spawn } from 'child_process';
 import { createInterface } from 'readline';
 
-const projectCommits: Record<string, string[]> = {};
+let projectCommits: Record<string, string[]> = {};
+
+export function clearCache(): void {
+  projectCommits = {};
+}
 
 export async function getPathCommitHashes(
   cwd: string,
@@ -25,9 +29,17 @@ export async function getPathCommitHashes(
       { cwd }
     );
 
+    let stderr = '';
+    child.stderr.on('data', (d) => (stderr += d.toString()));
+
     const commits: string[] = [];
     for await (const line of createInterface({ input: child.stdout, crlfDelay: Infinity })) {
       if (line) commits.push(line);
+    }
+
+    const exitCode = await new Promise<number>((resolve) => child.on('close', resolve));
+    if (exitCode !== 0) {
+      throw new Error(`git log failed with exit code ${exitCode}: ${stderr.trim()}`);
     }
 
     projectCommits[project] = commits;

--- a/packages/nx-release/src/release-plugin/nx-util.ts
+++ b/packages/nx-release/src/release-plugin/nx-util.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { readFile } from 'fs';
 import { resolve } from 'path';
 import { promisify } from 'util';
@@ -19,24 +19,16 @@ interface DependencyGraph {
   dependencies: Record<string, Dependency[]>;
 }
 
-const paths: Record<string, string[]> = {}
+let paths: Record<string, string[]> = {};
+
+export function clearCache(): void {
+  paths = {};
+}
 
 export const getProjectChangePaths = async (cwd: string, project: string) => {
-  
   if (!paths[project]) {
-    
     const file = resolve(cwd, `tmp/${project}-deps.json`);
-    await promisify(exec)(
-      [
-        'npx',
-        'nx',
-        'dep-graph',
-        '--focus',
-        project,
-        '--file',
-        file
-      ].join(' ')
-    );
+    await promisify(execFile)('npx', ['nx', 'graph', '--focus', project, '--file', file]);
   
     const result = await promisify(readFile)(file, 'utf8');
     const { graph }: { graph: DependencyGraph } = JSON.parse(result);

--- a/packages/nx-release/src/release-plugin/nx-utils.spec.ts
+++ b/packages/nx-release/src/release-plugin/nx-utils.spec.ts
@@ -1,6 +1,6 @@
-import { getProjectChangePaths } from './nx-util';
+import { clearCache, getProjectChangePaths } from './nx-util';
 jest.mock('child_process', () => ({
-  exec: jest.fn((_c, cb) => cb(null)),
+  execFile: jest.fn((_cmd, _args, cb) => cb(null)),
 }));
 jest.mock('fs', () => ({
   readFile: jest.fn((_f, _e, cb) =>
@@ -30,6 +30,10 @@ jest.mock('fs', () => ({
 }));
 
 describe('getProjectChangePaths', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
   it('can get paths', async () => {
     const paths = await getProjectChangePaths('', 'test');
 


### PR DESCRIPTION
## Summary

- **Silent git failure** (`git-utils.ts`): throws a descriptive error on non-zero exit code rather than returning an empty commit list, which would silently suppress releases
- **Shell injection** (`nx-util.ts`): replaces `exec` with string concatenation with `execFile` and an args array, consistent with the approach already used in the nuget plugin
- **Deprecated command** (`nx-util.ts`): replaces `nx dep-graph` with `nx graph` (dep-graph is an alias since Nx 15; this removes deprecation warnings from release logs)
- **Test isolation** (`git-utils.spec.ts`, `nx-utils.spec.ts`): exports `clearCache()` from both modules and calls it in `beforeEach`; previously the second test in `nx-utils.spec.ts` was silently hitting the module-level cache and not exercising the path resolution at all

## Test plan

- [ ] All existing tests pass (`nx test nx-release`)
- [ ] No behavioural change in normal operation — only the error path in `getPathCommitHashes` is new

🤖 Generated with [Claude Code](https://claude.com/claude-code)