### PR TITLE
fix(nx-oc): fix mapOcProject bug, use execFileSync, fix return type

### DIFF
--- a/packages/nx-oc/src/executors/apply/apply.ts
+++ b/packages/nx-oc/src/executors/apply/apply.ts
@@ -8,7 +8,7 @@ function mapOcProject(
   i: number
 ): PipelineEnvironment {
   if (typeof project === 'string') {
-    return { project: 'string', tag: envs[i].toLowerCase() };
+    return { project, tag: envs[i].toLowerCase() };
   } else {
     return project;
   }
@@ -33,9 +33,9 @@ export default async function runExecutor(
   const failed = ocProjects
     .map(({ project, tag }) => {
       const processResult = runOcCommand('process', [
-        `-f .openshift/${projectName}/${projectName}.yml`,
-        `-p PROJECT=${project}`,
-        `-p DEPLOY_TAG=${tag}`,
+        '-f', `.openshift/${projectName}/${projectName}.yml`,
+        '-p', `PROJECT=${project}`,
+        '-p', `DEPLOY_TAG=${tag}`,
       ]);
 
       if (!processResult.success) {

--- a/packages/nx-oc/src/utils/git-utils.ts
+++ b/packages/nx-oc/src/utils/git-utils.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process'
 
-export function getGitRemoteUrl(): string {
+export function getGitRemoteUrl(): string | undefined {
   try {
     const stdout = execSync(
       "git config --get remote.origin.url", 

--- a/packages/nx-oc/src/utils/oc-utils.spec.ts
+++ b/packages/nx-oc/src/utils/oc-utils.spec.ts
@@ -1,55 +1,58 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { mocked } from 'jest-mock';
 import { runOcCommand } from './oc-utils';
 
 jest.mock('child_process');
-const mockedExecSync = mocked(execSync);
+const mockedExecFileSync = mocked(execFileSync);
 
 describe('runOcCommand', () => {
   beforeEach(() => {
-    mockedExecSync.mockReset();
+    mockedExecFileSync.mockReset();
   });
 
   it('returns success with stdout on successful command', () => {
     const output = Buffer.from('project set to test-dev');
-    mockedExecSync.mockReturnValue(output);
+    mockedExecFileSync.mockReturnValue(output);
 
     const result = runOcCommand('project', ['test-dev']);
     expect(result.success).toBe(true);
     expect(result.stdout).toBe(output);
   });
 
-  it('builds the correct command string without input', () => {
-    mockedExecSync.mockReturnValue(Buffer.from(''));
+  it('builds the correct args array without input', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
 
-    runOcCommand('process', ['-f .openshift/app.yml', '-p ENV=dev']);
-    expect(mockedExecSync).toHaveBeenCalledWith(
-      'oc process -f .openshift/app.yml -p ENV=dev',
+    runOcCommand('process', ['-f', '.openshift/app.yml', '-p', 'ENV=dev']);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'oc',
+      ['process', '-f', '.openshift/app.yml', '-p', 'ENV=dev'],
       expect.objectContaining({ stdio: 'pipe' })
     );
   });
 
-  it('uses cat pipe form when input buffer is provided', () => {
-    mockedExecSync.mockReturnValue(Buffer.from(''));
+  it('prepends -f - when input buffer is provided', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
     const input = Buffer.from('{"kind":"List"}');
 
     runOcCommand('apply', [], input);
-    const [cmd] = mockedExecSync.mock.calls[0];
-    expect(cmd).toContain('cat |');
-    expect(cmd).toContain('oc apply -f -');
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'oc',
+      ['apply', '-f', '-'],
+      expect.objectContaining({ stdio: 'pipe' })
+    );
   });
 
-  it('passes input buffer to execSync', () => {
-    mockedExecSync.mockReturnValue(Buffer.from(''));
+  it('passes input buffer to execFileSync', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
     const input = Buffer.from('yaml-content');
 
     runOcCommand('apply', [], input);
-    const [, options] = mockedExecSync.mock.calls[0];
+    const [, , options] = mockedExecFileSync.mock.calls[0];
     expect((options as { input: Buffer }).input).toBe(input);
   });
 
   it('returns failure when command throws', () => {
-    mockedExecSync.mockImplementation(() => {
+    mockedExecFileSync.mockImplementation(() => {
       throw new Error('oc: command not found');
     });
 

--- a/packages/nx-oc/src/utils/oc-utils.ts
+++ b/packages/nx-oc/src/utils/oc-utils.ts
@@ -1,20 +1,20 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 export function runOcCommand(
   command: 'project' | 'start-build' | 'process' | 'apply',
   params: string[],
   input?: Buffer
 ): { success: boolean, stdout?: Buffer} {
-  const execute = !input ?
-    `oc ${command} ${params.join(' ')}` :
-    `cat | oc ${command} ${['-f -', ...params].join(' ')}`;
+  const args = input
+    ? [command, '-f', '-', ...params]
+    : [command, ...params];
 
   try {
-    console.log(`Executing command: ${execute}`);
-    const stdout = execSync(execute, { stdio: 'pipe', input });
+    console.log(`Executing command: oc ${args.join(' ')}`);
+    const stdout = execFileSync('oc', args, { stdio: 'pipe', input });
     return { success: true, stdout };
   } catch (e) {
-    console.log(`Failed to execute command: ${execute}`, e);
+    console.log(`Failed to execute command: oc ${args.join(' ')}`, e);
     return { success: false };
   }
 }


### PR DESCRIPTION
## Summary

- **Bug fix** (`apply.ts`): `mapOcProject` was returning `{ project: 'string', ... }` — a literal string — instead of `{ project, ... }`. In the single-project case this caused `oc process` to receive `PROJECT=string` rather than the actual project name. The existing test didn't catch it because `runOcCommand` was mocked.
- **Shell injection** (`oc-utils.ts`): replaced `execSync` with a concatenated command string with `execFileSync` and a proper args array. Also eliminates the unnecessary `cat |` pipe — `execFileSync` accepts an `input` buffer directly via stdio options.
- **Type safety** (`git-utils.ts`): `getGitRemoteUrl` declared return type as `string` but returned `undefined` on error. Fixed to `string | undefined`.

## Test plan

- [ ] All existing tests pass (`nx test nx-oc`)
- [ ] `apply.ts` callers updated to pass pre-split args arrays to `runOcCommand` (e.g. `['-f', 'path']` instead of `['-f path']`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)