### PR TITLE
fix(nx-release): correct channel state before addChannel for shared-commit releases

### DIFF
--- a/packages/nx-release/README.md
+++ b/packages/nx-release/README.md
@@ -10,17 +10,35 @@ There are multiple challenges with using semantic release in a monorepo:
 2. Each project should be evaluated based on only commits related to it.
 3. Interdependencies between projects need to be handled.
 4. Interdependencies between publishable/releasable projects require coordination of releases.
-5. Channel (next-major, next, latest) information is stored in a git note on a semantic-release ref and does not distinguished between tags (and consequently projects).
+5. Channel (next-major, next, latest) information is stored in a git note on a commit and is not distinguished between tags (and consequently projects) when multiple projects share a commit.
 
 For (1), (2), and (3) in part this project uses the approach from [semantic-release-monorepo](https://github.com/pmowrer/semantic-release-monorepo) along with Nx capabilities: 
 - Each project uses a distinct `tagFormat`; 
 - A custom plugin wraps default plugins for `analyzeCommits` and `generateNotes` and filters for only relevant commits;
-- Nx `dep-graph` is used to determine dependency paths that should also be included.
+- Nx `graph` is used to determine dependency paths that should also be included.
 
 (4) is not currently handled, but a solution leveraging Nx capabilities is the general direction. For example, Nx supports ordered execution of tasks based on 'affected'.
 
+### Channel promotion for shared-commit releases (5)
 
+When multiple projects release on the same commit (e.g. on a `next` branch with no intervening commits between project releases), promoting them all to `latest` requires special handling.
 
-**KNOWN ISSUE** (5) from above is not handled, and non-prerelease channel upgrades will result in only the first project being upgraded when release tags from multiple projects are on the same commit. 
+**Root cause:** Semantic-release stores each tag's channel state as a git note under a per-tag ref (`refs/notes/semantic-release-<tagName>`). However, git notes are stored on the commit object the tag points to, not on the tag object itself. When multiple tags share a commit, each tag has its own note ref but all notes live on the same commit.
 
-In Semantic Release the channel upgrade is done separately from the next version analysis and there are no extension hooks to modify the behaviour. Prerelease channels with a distinct version format (e.g. 1.0.0-beta.x) are excluded from that process and appear to work.
+Semantic-release reads these notes using a glob (`--notes=refs/notes/semantic-release*`), which causes git to emit all matching notes for that commit in a single log line. Only the first note retains its tag association in the `git log` output — the rest appear on subsequent lines with no tag decoration and are discarded. After the first project is promoted (its note updated to include `null` channel), the shared commit's combined note output maps all tags to the first note's updated channels, making every remaining project appear to already be on the `latest` channel.
+
+**Fix:** This package exports a `verifyConditions` lifecycle step that runs before semantic-release's `getReleaseToAdd` decision. It re-reads each tag's channel state by querying its specific note ref directly:
+
+```
+git notes --ref semantic-release-<tagName> show <tagName>
+```
+
+This bypasses the glob-based read entirely and corrects `context.branch.tags` in place before `getReleaseToAdd` consults it. Because `@abgov/nx-release` exports `verifyConditions` as a named function, semantic-release will invoke it automatically for any project already configured with `["@abgov/nx-release", { "project": "..." }]` — no config change is required.
+
+**Dependency on semantic-release internals:** This fix relies on two implementation details of semantic-release that are not part of its public API:
+
+1. **Execution order** — `verifyConditions` must run after `getBranches` (which populates `context.branch.tags`) but before `getReleaseToAdd` (which reads channel state from `context.branch.tags`). This is the order in `semantic-release/index.js` as of v24. If semantic-release moves `getReleaseToAdd` before `verifyConditions`, the fix will stop working.
+
+2. **Note ref naming convention** — The note ref for a tag is `refs/notes/semantic-release-<tagName>`. This is defined by `GIT_NOTE_REF` in `semantic-release/lib/definitions/constants.js`. If this naming convention changes, `verifyConditions` will fail to find the notes and silently fall back to the (incorrect) glob-read channels.
+
+If either of these internals changes in a future semantic-release version, this fix will need to be revisited. The correct long-term fix is an upstream change to `getTagsNotes` in semantic-release to query note refs individually rather than via glob, which would eliminate the cross-contamination between tags on shared commits.

--- a/packages/nx-release/src/release-plugin/index.ts
+++ b/packages/nx-release/src/release-plugin/index.ts
@@ -2,8 +2,9 @@ import type { AnalyzeCommitsContext, GenerateNotesContext } from 'semantic-relea
 import { analyzeCommits as baseAnalyzeCommits } from '@semantic-release/commit-analyzer';
 import { generateNotes as baseGenerateNotes } from '@semantic-release/release-notes-generator';
 import { wrapPlugin } from './wrap-plugin';
+import { verifyConditions } from './verify-conditions';
 
 const analyzeCommits = wrapPlugin<AnalyzeCommitsContext>(baseAnalyzeCommits);
 const generateNotes = wrapPlugin<GenerateNotesContext>(baseGenerateNotes);
 
-export { analyzeCommits, generateNotes };
+export { analyzeCommits, generateNotes, verifyConditions };

--- a/packages/nx-release/src/release-plugin/verify-conditions.spec.ts
+++ b/packages/nx-release/src/release-plugin/verify-conditions.spec.ts
@@ -1,0 +1,76 @@
+import { execFileSync } from 'child_process';
+import { mocked } from 'jest-mock';
+import { verifyConditions } from './verify-conditions';
+import type { VerifyConditionsContext } from 'semantic-release';
+
+jest.mock('child_process');
+const mockedExecFileSync = mocked(execFileSync);
+
+function makeContext(tags: { gitTag: string; channels: (string | null)[] }[]): VerifyConditionsContext {
+  return {
+    branch: { name: 'main', tags },
+    cwd: '/repo',
+    logger: { log: jest.fn(), error: jest.fn() },
+  } as unknown as VerifyConditionsContext;
+}
+
+describe('verifyConditions', () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+  });
+
+  it('corrects channels from the tag-specific note', async () => {
+    const tags = [{ gitTag: 'project-a@1.0.0', channels: [null] as (string | null)[] }];
+    mockedExecFileSync.mockReturnValue(Buffer.from('{"channels":["next"]}'));
+
+    await verifyConditions({} as any, makeContext(tags));
+
+    expect(tags[0].channels).toEqual(['next']);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'git',
+      ['notes', '--ref', 'semantic-release-project-a@1.0.0', 'show', 'project-a@1.0.0'],
+      expect.objectContaining({ cwd: '/repo' })
+    );
+  });
+
+  it('corrects channels for each tag independently', async () => {
+    const tags = [
+      { gitTag: 'project-a@1.0.0', channels: [null] as (string | null)[] },
+      { gitTag: 'project-b@1.0.0', channels: [null] as (string | null)[] },
+    ];
+    mockedExecFileSync
+      .mockReturnValueOnce(Buffer.from('{"channels":["next","null"]}'))
+      .mockReturnValueOnce(Buffer.from('{"channels":["next"]}'));
+
+    await verifyConditions({} as any, makeContext(tags));
+
+    expect(tags[0].channels).toEqual(['next', 'null']);
+    expect(tags[1].channels).toEqual(['next']);
+  });
+
+  it('leaves channels unchanged when no note exists for a tag', async () => {
+    const tags = [{ gitTag: 'project-a@1.0.0', channels: [null] as (string | null)[] }];
+    mockedExecFileSync.mockImplementation(() => {
+      throw Object.assign(new Error('no note'), { status: 1 });
+    });
+
+    await verifyConditions({} as any, makeContext(tags));
+
+    expect(tags[0].channels).toEqual([null]);
+  });
+
+  it('leaves channels unchanged when note content is invalid JSON', async () => {
+    const tags = [{ gitTag: 'project-a@1.0.0', channels: ['next'] as (string | null)[] }];
+    mockedExecFileSync.mockReturnValue(Buffer.from('not-valid-json'));
+
+    await verifyConditions({} as any, makeContext(tags));
+
+    expect(tags[0].channels).toEqual(['next']);
+  });
+
+  it('is a no-op when there are no tags', async () => {
+    await verifyConditions({} as any, makeContext([]));
+
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx-release/src/release-plugin/verify-conditions.ts
+++ b/packages/nx-release/src/release-plugin/verify-conditions.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from 'child_process';
+import type { VerifyConditionsContext } from 'semantic-release';
+import type { WrappedPluginConfig } from './wrap-plugin';
+
+const GIT_NOTE_REF = 'semantic-release';
+
+interface BranchTag {
+  gitTag: string;
+  channels: (string | null)[];
+}
+
+export async function verifyConditions(
+  _pluginConfig: WrappedPluginConfig,
+  context: VerifyConditionsContext
+): Promise<void> {
+  const { cwd, logger } = context;
+  const tags: BranchTag[] = context.branch['tags'] ?? [];
+
+  for (const branchTag of tags) {
+    const noteRef = `${GIT_NOTE_REF}-${branchTag.gitTag}`;
+    try {
+      const stdout = execFileSync(
+        'git',
+        ['notes', '--ref', noteRef, 'show', branchTag.gitTag],
+        { cwd, stdio: 'pipe' }
+      ).toString().trim();
+
+      const note = JSON.parse(stdout);
+      if (Array.isArray(note?.channels)) {
+        logger.log(
+          `Correcting channels for ${branchTag.gitTag}: ${JSON.stringify(note.channels)}`
+        );
+        branchTag.channels = note.channels;
+      }
+    } catch (e) {
+      // No note for this tag or unparseable — leave channels as-is
+    }
+  }
+}

--- a/packages/nx-release/src/release-plugin/verify-conditions.ts
+++ b/packages/nx-release/src/release-plugin/verify-conditions.ts
@@ -2,6 +2,8 @@ import { execFileSync } from 'child_process';
 import type { VerifyConditionsContext } from 'semantic-release';
 import type { WrappedPluginConfig } from './wrap-plugin';
 
+// Must match GIT_NOTE_REF in semantic-release/lib/definitions/constants.js.
+// If that constant changes, this fix breaks — see README for full explanation.
 const GIT_NOTE_REF = 'semantic-release';
 
 interface BranchTag {
@@ -9,6 +11,18 @@ interface BranchTag {
   channels: (string | null)[];
 }
 
+// Corrects context.branch.tags channel state before getReleaseToAdd reads it.
+//
+// When multiple projects release on the same commit, semantic-release's glob-
+// based note read (--notes=refs/notes/semantic-release*) conflates notes from
+// multiple per-tag note refs. After the first project is promoted to the latest
+// channel, all tags on that commit incorrectly appear to already be on the null
+// channel, preventing remaining projects from being promoted.
+//
+// This runs in the window between getBranches (which populates context.branch.tags
+// via the glob read) and getReleaseToAdd (which acts on channels). It re-reads
+// each tag's note via its specific ref to get the correct channel state.
+// See README for the semantic-release internals this depends on.
 export async function verifyConditions(
   _pluginConfig: WrappedPluginConfig,
   context: VerifyConditionsContext


### PR DESCRIPTION
Fixes #26

## Root cause

When multiple projects release on the same commit, semantic-release stores each tag's channel info in its own note ref (`refs/notes/semantic-release-<tagName>`). However, notes are stored on the **commit** the tag points to, not the tag object. The glob-based read in `getTagsNotes` (`--notes=refs/notes/semantic-release*`) combines all matching note refs for the same commit into a single git log line:

```
(tag: project-a@1.0.0-next.1, tag: project-b@1.0.0-next.1)	{"channels":["next", null]}
{"channels":["next"]}
```

Only the first line has tag decorations — the second note's tags are lost. After the first project is promoted to the latest channel (its note updated to `["next", null]`), both tags get mapped to that updated note. All subsequent projects on the same commit appear to already be on the null channel and are skipped.

## Fix

Add a `verifyConditions` plugin to nx-release that runs **between** `getBranches` (which populates the incorrect channel state) and `getReleaseToAdd` (which acts on it). It re-reads each tag's note directly via its specific note ref — bypassing the glob — and corrects `context.branch.tags` in place:

```
git notes --ref semantic-release-<tagName> show <tagName>
```

## Test plan

- [ ] All existing tests pass (`nx test nx-release`)
- [ ] New `verifyConditions` tests cover: correct channels read, per-tag independence, missing note (no-op), invalid JSON (no-op), empty tags (no-op)
- [ ] `verifyConditions` must be added to `.releaserc.json` plugin config for affected projects alongside `analyzeCommits` and `generateNotes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)