### PR TITLE
docs(nx-release): document channel promotion known issue and upstream fix

### DIFF
--- a/packages/nx-release/README.md
+++ b/packages/nx-release/README.md
@@ -15,12 +15,18 @@ There are multiple challenges with using semantic release in a monorepo:
 For (1), (2), and (3) in part this project uses the approach from [semantic-release-monorepo](https://github.com/pmowrer/semantic-release-monorepo) along with Nx capabilities: 
 - Each project uses a distinct `tagFormat`; 
 - A custom plugin wraps default plugins for `analyzeCommits` and `generateNotes` and filters for only relevant commits;
-- Nx `dep-graph` is used to determine dependency paths that should also be included.
+- Nx `graph` is used to determine dependency paths that should also be included.
 
 (4) is not currently handled, but a solution leveraging Nx capabilities is the general direction. For example, Nx supports ordered execution of tasks based on 'affected'.
 
+**KNOWN ISSUE** (5) Non-prerelease channel promotion (`next` → `latest`) only promotes the first project when multiple projects have release tags on the same commit. Prerelease channels (alpha, beta) are not affected — see below.
 
+### Why prerelease channels are not affected
 
-**KNOWN ISSUE** (5) from above is not handled, and non-prerelease channel upgrades will result in only the first project being upgraded when release tags from multiple projects are on the same commit. 
+Prerelease branches (those with `prerelease: true` in the semantic-release config) are assigned `type: "prerelease"` internally. The channel promotion logic in `getReleaseToAdd` only considers branches of `type !== "prerelease"` when determining which versions need to be added to the current branch's channel. This means alpha/beta releases are never candidates for `addChannel` promotion and are unaffected by this issue.
 
-In Semantic Release the channel upgrade is done separately from the next version analysis and there are no extension hooks to modify the behaviour. Prerelease channels with a distinct version format (e.g. 1.0.0-beta.x) are excluded from that process and appear to work.
+### Root cause
+
+Semantic-release v24.2.7 introduced a performance optimisation ([#3732](https://github.com/semantic-release/semantic-release/pull/3732)) that replaced per-tag note reads with a single `git log` command using a glob (`--notes=refs/notes/semantic-release*`). When multiple projects release on the same commit, each tag has its own note ref but all notes land on the same commit object. The glob causes git to emit all matching notes for that commit in a single log line where only the first note retains its tag association — subsequent notes appear on continuation lines with no tag decoration and are discarded. After the first project is promoted to `latest` (its note updated to include `null` channel), the combined output maps all tags on that commit to that updated note, making every remaining project appear to already be on the latest channel.
+
+A fix is tracked upstream at [semantic-release#4074](https://github.com/semantic-release/semantic-release/pull/4074). Until that merges and is released, the workaround is to ensure a commit exists between each project's release on the `next` branch so that no two project tags share the same commit.

--- a/packages/nx-release/README.md
+++ b/packages/nx-release/README.md
@@ -29,4 +29,13 @@ Prerelease branches (those with `prerelease: true` in the semantic-release confi
 
 Semantic-release v24.2.7 introduced a performance optimisation ([#3732](https://github.com/semantic-release/semantic-release/pull/3732)) that replaced per-tag note reads with a single `git log` command using a glob (`--notes=refs/notes/semantic-release*`). When multiple projects release on the same commit, each tag has its own note ref but all notes land on the same commit object. The glob causes git to emit all matching notes for that commit in a single log line where only the first note retains its tag association — subsequent notes appear on continuation lines with no tag decoration and are discarded. After the first project is promoted to `latest` (its note updated to include `null` channel), the combined output maps all tags on that commit to that updated note, making every remaining project appear to already be on the latest channel.
 
-A fix is tracked upstream at [semantic-release#4074](https://github.com/semantic-release/semantic-release/pull/4074). Until that merges and is released, the workaround is to ensure a commit exists between each project's release on the `next` branch so that no two project tags share the same commit.
+A fix is tracked upstream at [semantic-release#4074](https://github.com/semantic-release/semantic-release/pull/4074). Until that merges and is released there are two workarounds:
+
+**Option 1 — Pin semantic-release to the last unaffected version:**
+```json
+"semantic-release": "24.2.6"
+```
+v24.2.6 (released 2025-06-29) is the last version before the regression. v24.2.7 introduced it.
+
+**Option 2 — Ensure no two project tags share a commit on `next`:**
+Add a trivial commit between each project's release run on the `next` branch so that every release tag lands on a distinct commit.


### PR DESCRIPTION
Closes #26 (as won't fix — tracking upstream)

## Summary

- Clarifies the known issue only affects **non-prerelease channel promotion** (`next` → `latest`). Alpha/beta prerelease channels are not affected because `getReleaseToAdd` in semantic-release filters `type !== "prerelease"` from `higherChannels`, so prerelease releases are never candidates for `addChannel` promotion.
- Documents the root cause: semantic-release v24.2.7 ([#3732](https://github.com/semantic-release/semantic-release/pull/3732)) replaced per-tag note reads with a glob-based bulk `git log` read. When multiple tags share a commit, the glob combines notes from all matching refs and only the first note retains its tag association. After the first project is promoted, all remaining projects on that commit appear to already be on the latest channel.
- References the upstream fix [semantic-release#4074](https://github.com/semantic-release/semantic-release/pull/4074) which is open and unmerged.
- Documents the workaround: ensure a commit exists between each project's `next` release so no two tags share a commit.
- Updates stale `dep-graph` reference to `graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)