### PR TITLE
fix(nx-adsp): restore skipped react-app and mern test suites

### DIFF
--- a/packages/nx-adsp/src/generators/mern/mern.spec.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.spec.ts
@@ -15,7 +15,7 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
 
-describe.skip('React App Generator', () => {
+describe('MERN Generator', () => {
   const options: Schema = {
     name: 'test',
     env: 'dev',

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -15,7 +15,7 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
 
-describe.skip('React App Generator', () => {
+describe('React App Generator', () => {
   const options: Schema = {
     name: 'test',
     env: 'dev',


### PR DESCRIPTION
## Summary

Removes `describe.skip` from `react-app.spec.ts` and `mern.spec.ts`. All tests pass — the skip was not needed. Also corrects the mern describe block label which was incorrectly named `'React App Generator'`.

This is baseline hygiene before the planned nx-adsp template redesign work.

## Test plan

- [ ] `nx test nx-adsp` — 9 suites, 15 tests, all passing, no skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)