### PR TITLE
feat(nx-adsp): add agent-service client for workspace-based capability generation

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -14,6 +14,8 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+utilsMock.deploymentGenerator.mockResolvedValue(undefined);
+utilsMock.realmLogin.mockResolvedValue('test-token');
 
 describe('Express Service Generator', () => {
   const options: Schema = {

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -1,4 +1,4 @@
-import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
+import { deploymentGenerator, environments, getAdspConfiguration, getServiceUrls, realmLogin } from '@abgov/nx-oc';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -24,7 +24,43 @@ async function normalizeOptions(
   const projectName = names(options.name).fileName;
   const projectRoot = `${getWorkspaceLayout(host).appsDir}/${projectName}`;
 
-  const adsp = await getAdspConfiguration(host, options);
+  let adsp: import('@abgov/nx-oc').AdspConfiguration;
+
+  if (options.tenant) {
+    // Resolve realm from tenant name via the public tenant service API (no auth required),
+    // then do a single browser login for the tenant realm.
+    const env = environments[options.env ?? 'prod'];
+    const tenantServiceUrl = (await getServiceUrls(env.directoryServiceUrl))['urn:ads:platform:tenant-service'];
+
+    const { default: axios } = await import('axios');
+    const { data } = await axios.get<{ results: { name: string; realm: string }[] }>(
+      new URL('/api/tenant/v2/tenants', tenantServiceUrl).href,
+      { params: { name: options.tenant } }
+    );
+
+    const tenantInfo = data?.results?.[0];
+    if (!tenantInfo) {
+      throw new Error(`Tenant "${options.tenant}" not found in ${env.directoryServiceUrl}.`);
+    }
+
+    const tenantRealm = options.tenantRealm ?? tenantInfo.realm;
+
+    if (!options.accessToken) {
+      options = {
+        ...options,
+        accessToken: await realmLogin(env.accessServiceUrl, tenantRealm).catch(() => undefined),
+      };
+    }
+
+    adsp = {
+      tenant: tenantInfo.name,
+      tenantRealm,
+      accessServiceUrl: env.accessServiceUrl,
+      directoryServiceUrl: env.directoryServiceUrl,
+    };
+  } else {
+    adsp = await getAdspConfiguration(host, options);
+  }
 
   return {
     ...options,
@@ -91,12 +127,25 @@ export default async function (host: Tree, options: Schema) {
   // which are applied directly to the Nx Tree.
   // Falls back silently if agent-service is unreachable or no accessToken.
   if (normalizedOptions.adsp) {
+    // getAdspConfiguration authenticates but doesn't return the token.
+    // Re-authenticate with the tenant realm to get a token for the agent call.
+    process.stdout.write('\nSigning in to connect to the ADSP agent...\n');
+    const accessToken =
+      options.accessToken ??
+      (await realmLogin(
+        normalizedOptions.adsp.accessServiceUrl,
+        normalizedOptions.adsp.tenantRealm
+      ).catch((err) => {
+        process.stdout.write(`Agent sign-in failed (${err?.message ?? err}) — skipping agent interaction.\n`);
+        return undefined;
+      }));
+
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
 
-    await consultAgent(
+    const agentResult = await consultAgent(
       normalizedOptions.adsp.directoryServiceUrl,
-      options.accessToken,
+      accessToken,
       {
         projectName: normalizedOptions.projectName,
         projectType: 'express-service',
@@ -110,6 +159,21 @@ export default async function (host: Tree, options: Schema) {
       host,
       normalizedOptions.projectRoot
     );
+
+    // When the user was in an active conversation but it ended without the
+    // agent generating files, confirm whether to proceed with base scaffolding.
+    if (agentResult?.userInteracted && agentResult.filesWritten === 0) {
+      const { prompt } = await import('enquirer');
+      const { proceed } = await prompt<{ proceed: boolean }>({
+        type: 'confirm',
+        name: 'proceed',
+        message: 'Agent interaction ended without generating files. Continue with base scaffolding?',
+        initial: true,
+      });
+      if (!proceed) {
+        throw new Error('Generation aborted.');
+      }
+    }
   }
 
   await deploymentGenerator(host, {

--- a/packages/nx-adsp/src/generators/express-service/schema.d.ts
+++ b/packages/nx-adsp/src/generators/express-service/schema.d.ts
@@ -4,6 +4,10 @@ export interface Schema {
   name: string;
   env: EnvironmentName;
   accessToken?: string;
+  /** Keycloak realm UUID. When provided with tenant, skips interactive tenant selection. */
+  tenantRealm?: string;
+  /** ADSP tenant name (e.g. 'my-org'). Required when tenantRealm is provided. */
+  tenant?: string;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/express-service/schema.json
+++ b/packages/nx-adsp/src/generators/express-service/schema.json
@@ -35,6 +35,16 @@
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",
       "alias": "at"
+    },
+    "tenantRealm": {
+      "type": "string",
+      "description": "Keycloak realm UUID. Optional when --tenant is provided \u2014 overrides the realm looked up from the tenant service.",
+      "alias": "tr"
+    },
+    "tenant": {
+      "type": "string",
+      "description": "ADSP tenant name. When provided, the realm is looked up anonymously and a single browser login is used instead of the full interactive flow.",
+      "alias": "t"
     }
   },
   "required": [

--- a/packages/nx-adsp/src/generators/mean/mean.spec.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.spec.ts
@@ -14,6 +14,7 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
 utilsMock.deploymentGenerator.mockResolvedValue(undefined);
+utilsMock.realmLogin.mockResolvedValue('test-token');
 
 describe('MEAN Generator', () => {
   const options: Schema = {

--- a/packages/nx-adsp/src/generators/mern/mern.spec.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.spec.ts
@@ -14,6 +14,7 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+utilsMock.realmLogin.mockResolvedValue('test-token');
 
 describe('MERN Generator', () => {
   const options: Schema = {

--- a/packages/nx-adsp/src/utils/agent.spec.ts
+++ b/packages/nx-adsp/src/utils/agent.spec.ts
@@ -80,6 +80,9 @@ describe('consultAgent', () => {
     await flushPromises();
 
     socket._handlers['connect']?.();
+    socket._handlers['workspace-updated']?.();
+    // Simulate agent responding with text (sets agentHasResponded = true)
+    socket._handlers['stream']?.({ chunk: { type: 'text-delta', payload: { text: 'I will add events.' } }, done: false });
     socket._handlers['stream']?.({ chunk: null, done: true });
     socket._handlers['workspace-state']?.({
       files: [
@@ -89,12 +92,12 @@ describe('consultAgent', () => {
     });
 
     const result = await resultPromise;
-    expect(result).toEqual({ filesWritten: 2 });
+    expect(result).toEqual({ filesWritten: 2, userInteracted: true });
     expect(mockHost.write).toHaveBeenCalledWith('apps/test-service/src/roles.ts', 'export enum ServiceRoles {}');
     expect(mockHost.write).toHaveBeenCalledWith('apps/test-service/src/main.ts', 'updated main.ts');
   });
 
-  it('includes existing file content in the initial message', async () => {
+  it('uploads existing files to workspace before sending the initial message', async () => {
     mockedGetServiceUrls.mockResolvedValue({
       'urn:ads:platform:agent-service:v1': 'https://agent.example.com',
     });
@@ -102,15 +105,27 @@ describe('consultAgent', () => {
     const resultPromise = consultAgent('https://directory.example.com', 'token', PROJECT_CONTEXT, mockHost, 'apps/test-service');
     await flushPromises();
 
+    // connect → workspace-update emitted, then workspace-updated → message emitted
     socket._handlers['connect']?.();
+    socket._handlers['workspace-updated']?.();
+    socket._handlers['stream']?.({ chunk: { type: 'text-delta', payload: { text: 'What does this service do?' } }, done: false });
     socket._handlers['stream']?.({ chunk: null, done: true });
     socket._handlers['workspace-state']?.({ files: [] });
     await resultPromise;
 
     expect(socket.emit).toHaveBeenCalledWith(
+      'workspace-update',
+      expect.objectContaining({
+        agent: 'nxAdspAgent',
+        writes: expect.arrayContaining([
+          expect.objectContaining({ path: 'src/main.ts' }),
+        ]),
+      })
+    );
+    expect(socket.emit).toHaveBeenCalledWith(
       'message',
       expect.objectContaining({
-        agent: 'nx-adsp-agent',
+        agent: 'nxAdspAgent',
         content: expect.stringContaining('src/main.ts'),
       })
     );

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -4,7 +4,7 @@ import { io } from 'socket.io-client';
 import { getServiceUrls } from '@abgov/nx-oc';
 
 const AGENT_SERVICE_URN = 'urn:ads:platform:agent-service:v1';
-const AGENT_ID = 'nx-adsp-agent';
+const AGENT_ID = 'nxAdspAgent';
 
 // Keep CapabilitySpec exported for backward compatibility and tests,
 // but the primary flow now uses the workspace approach.
@@ -25,6 +25,8 @@ export interface CapabilitySpec {
  */
 export interface AgentResult {
   filesWritten: number;
+  /** True when the user was in an active conversation before it ended. */
+  userInteracted: boolean;
 }
 
 /**
@@ -50,14 +52,25 @@ export async function consultAgent(
   host: Tree,
   projectRoot: string
 ): Promise<AgentResult | null> {
-  const agentServiceUrl = await resolveAgentServiceUrl(directoryServiceUrl);
-  if (!agentServiceUrl) {
+  if (!accessToken) {
+    process.stdout.write('\n[nx-adsp] No access token — skipping agent interaction.\n');
     return null;
   }
+
+  const agentServiceUrl = await resolveAgentServiceUrl(directoryServiceUrl);
+  if (!agentServiceUrl) {
+    process.stdout.write('\n[nx-adsp] Agent-service not found in directory — skipping agent interaction.\n');
+    return null;
+  }
+
+  process.stdout.write(`\n[nx-adsp] Connecting to agent at ${agentServiceUrl}...\n`);
 
   return new Promise((resolve) => {
     const socket = io(agentServiceUrl, {
       auth: { token: accessToken },
+      // Skip polling — go directly to WebSocket to avoid ARO ingress rejecting
+      // the polling POST with HTTP 400.
+      transports: ['websocket'],
       timeout: 30000,
       reconnection: false,
     });
@@ -66,24 +79,29 @@ export async function consultAgent(
     const threadId = crypto.randomUUID();
     let buffer = '';
     let conversationDone = false;
+    let agentHasResponded = false;
+    let interrupted = false;
 
-    // If stdin closes while waiting for user input, apply whatever the agent
-    // wrote to the workspace and continue generation.
+    // Ctrl+C — abort the interaction without applying generated files.
+    rl.on('SIGINT', () => {
+      interrupted = true;
+      process.stdout.write('\n');
+      cleanup(0);
+    });
+
+    // Ctrl+D / stdin EOF — intentional finish: fetch workspace and apply files.
     rl.on('close', () => {
-      if (!conversationDone) {
+      if (!conversationDone && !interrupted) {
         requestWorkspaceState();
       }
     });
 
     const buildInitialMessage = () => {
-      const fileSection = Object.entries(projectContext.existingFiles)
-        .map(([path, content]) => `${path}:\n\`\`\`typescript\n${content}\n\`\`\``)
-        .join('\n\n');
-
+      const fileNames = Object.keys(projectContext.existingFiles).join(', ');
       return (
         `I am setting up a new ${projectContext.projectType} called "${projectContext.projectName}" ` +
-        `for ADSP tenant "${projectContext.tenant}" (nx-adsp plugin version ${projectContext.pluginVersion}).\n\n` +
-        `Existing project files:\n\n${fileSection}\n\n` +
+        `for ADSP tenant "${projectContext.tenant}" (nx-adsp plugin version ${projectContext.pluginVersion}). ` +
+        `The project files (${fileNames}) have been uploaded to your workspace. ` +
         `What ADSP capabilities would be useful to integrate into this service?`
       );
     };
@@ -101,14 +119,26 @@ export async function consultAgent(
       socket.emit('workspace-read', { agent: AGENT_ID, threadId });
     };
 
+    const uploadFilesToWorkspace = () => {
+      socket.emit('workspace-update', {
+        agent: AGENT_ID,
+        threadId,
+        writes: Object.entries(projectContext.existingFiles).map(([path, content]) => ({
+          path,
+          content,
+        })),
+        deletes: [],
+      });
+    };
+
     const promptUser = () => {
       rl.question('\n> ', (input) => {
         const trimmed = input.trim();
         if (trimmed) {
           sendMessage(trimmed);
         } else {
-          // Empty input — user is skipping; resolve without files.
-          cleanup(0);
+          // Empty input — apply whatever the agent has generated.
+          requestWorkspaceState();
         }
       });
     };
@@ -116,6 +146,12 @@ export async function consultAgent(
     const applyWorkspaceFiles = (files: { path: string; content: string }[]) => {
       let count = 0;
       for (const file of files) {
+        // Skip files we uploaded that the agent hasn't modified — only apply
+        // new files and agent-modified versions of existing files.
+        const original = projectContext.existingFiles[file.path];
+        if (original !== undefined && original === file.content) {
+          continue;
+        }
         const fullPath = `${projectRoot}/${file.path}`;
         host.write(fullPath, file.content);
         count++;
@@ -127,17 +163,45 @@ export async function consultAgent(
       conversationDone = true;
       rl.close();
       socket.disconnect();
-      resolve(filesWritten > 0 ? { filesWritten } : null);
+      // Return null for silent skips (no agent, no token, connection failed).
+      // Return a result with userInteracted:true when the user was in a
+      // conversation so the caller can ask whether to proceed.
+      resolve(agentHasResponded ? { filesWritten, userInteracted: true } : null);
     };
 
-    socket.on('connect', () => {
+    socket.on('workspace-updated', () => {
+      process.stdout.write('[nx-adsp] Project files uploaded to workspace.\n');
+      process.stdout.write('[nx-adsp] Type your replies at the > prompt. Press Ctrl+D or leave blank to apply generated files.\n\n');
       sendMessage(buildInitialMessage());
+    });
+
+    socket.on('connect', () => {
+      process.stdout.write('[nx-adsp] Connected to agent-service.\n');
+      process.stdout.write('[nx-adsp] Uploading project files to workspace...\n');
+      uploadFilesToWorkspace();
+
+      // Show periodic dots while waiting for first response, then a warning at 2 minutes.
+      const dotInterval = setInterval(() => {
+        if (!conversationDone && !agentHasResponded) process.stdout.write('.');
+        else clearInterval(dotInterval);
+      }, 3000);
+      setTimeout(() => {
+        clearInterval(dotInterval);
+        if (!conversationDone && !agentHasResponded) {
+          process.stdout.write(
+            '\n[nx-adsp] No response after 2 minutes. ' +
+            'The nxAdspAgent may still be deploying or the LLM is unresponsive. ' +
+            'Press Ctrl+C to skip and continue generation.\n'
+          );
+        }
+      }, 120000);
     });
 
     socket.on('stream', ({ chunk, done }) => {
       if (chunk?.type === 'text-delta') {
         const text: string = chunk.payload?.text ?? '';
         buffer += text;
+        agentHasResponded = true;
         process.stdout.write(text);
       }
 
@@ -146,21 +210,21 @@ export async function consultAgent(
           process.stdout.write('\n');
         }
         buffer = '';
-        // Agent has finished its response — request workspace state to get
-        // any files it wrote, or ask user for follow-up if needed.
-        requestWorkspaceState();
+        // Agent finished its turn — prompt the user to continue the conversation
+        // or press Enter to apply whatever the agent has written so far.
+        promptUser();
       }
     });
 
     socket.on('workspace-state', ({ files }: { files: { path: string; content: string }[] }) => {
-      if (files?.length > 0) {
-        const written = applyWorkspaceFiles(files);
+      // Only apply files the agent added or modified — not unchanged uploaded files.
+      const written = applyWorkspaceFiles(files ?? []);
+      if (written > 0) {
         process.stdout.write(`\nApplied ${written} file(s) from agent workspace.\n`);
-        cleanup(written);
       } else {
-        // No files written yet — agent may need more input.
-        promptUser();
+        process.stdout.write('\nNo files generated by agent.\n');
       }
+      cleanup(written);
     });
 
     socket.on('session-expired', () => {
@@ -168,8 +232,17 @@ export async function consultAgent(
       requestWorkspaceState();
     });
 
-    socket.on('connect_error', () => cleanup(0));
-    socket.on('error', () => requestWorkspaceState());
+    socket.on('connect_error', (err) => {
+      // Log the full error object so we can diagnose the root cause.
+      const errAny = err as unknown as Record<string, unknown>;
+      process.stdout.write(`\n[nx-adsp] Connection failed: ${err?.message ?? err}\n`);
+      process.stdout.write(`[nx-adsp] Error detail: ${JSON.stringify(errAny?.description ?? errAny?.context ?? errAny?.cause ?? 'none')}\n`);
+      cleanup(0);
+    });
+    socket.on('error', (err) => {
+      process.stdout.write(`\n[nx-adsp] Agent error: ${JSON.stringify(err)}\n`);
+      requestWorkspaceState();
+    });
   });
 }
 
@@ -178,7 +251,11 @@ async function resolveAgentServiceUrl(
 ): Promise<string | null> {
   try {
     const urls = await getServiceUrls(directoryServiceUrl);
-    return urls[AGENT_SERVICE_URN] ?? null;
+    const apiUrl = urls[AGENT_SERVICE_URN];
+    if (!apiUrl) return null;
+    // The directory URL includes the REST API path (e.g. /agent/v1).
+    // Socket.io attaches at the server root, so use only the origin.
+    return new URL(apiUrl).origin;
   } catch {
     return null;
   }


### PR DESCRIPTION
Adds the infrastructure for the nx-adsp generator to consult the ADSP `nxAdspAgent` during express-service scaffolding. See adsp-monorepo PR #5488 (merged) for the companion agent definition and template tools.

## What it does

After scaffolding, the generator connects to agent-service via WebSocket, uploads the generated project files to the agent workspace, and starts a multi-turn terminal conversation. The agent uses its workspace tools to write new files and modify integration points (e.g. `main.ts`). The generator applies all agent-written files to the Nx Tree.

## Key behaviours

- **`> ` prompt** after each agent turn — type a reply to continue, blank/Ctrl+D to apply files, Ctrl+C to abort
- **Silent fallback** when agent-service is unreachable, no token, or connection fails — generation always completes
- **Confirmation prompt** when the user was in a conversation but no files were generated
- **`--tenant <name>`** flag: resolves realm via the public tenant service API, then does a single browser login instead of the full interactive flow

## Changes

- `src/utils/agent.ts` — WebSocket client, workspace-update upload, multi-turn conversation loop, file application
- `express-service` generator — token acquisition, `--tenant`/`--tenantRealm` params, agent invocation
- `socket.io-client ^4.7.5` added as dependency

## Test plan

- [ ] `nx test nx-adsp` — all passing
- [ ] `nx lint nx-adsp` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)