### PR TITLE
feat(nx-adsp): add agent-service client for workspace-based capability generation

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -127,11 +127,12 @@ export default async function (host: Tree, options: Schema) {
   // which are applied directly to the Nx Tree.
   // Falls back silently if agent-service is unreachable or no accessToken.
   if (normalizedOptions.adsp) {
-    // getAdspConfiguration authenticates but doesn't return the token.
-    // Re-authenticate with the tenant realm to get a token for the agent call.
-    process.stdout.write('\nSigning in to connect to the ADSP agent...\n');
+    // When --tenant was provided, normalizedOptions.accessToken holds the token
+    // from the single realm login already performed during normalizeOptions.
+    // token from the single realm login. Fall back to a new login only when the
+    // full interactive flow was used and no token is available.
     const accessToken =
-      options.accessToken ??
+      normalizedOptions.accessToken ??
       (await realmLogin(
         normalizedOptions.adsp.accessServiceUrl,
         normalizedOptions.adsp.tenantRealm
@@ -160,15 +161,16 @@ export default async function (host: Tree, options: Schema) {
       normalizedOptions.projectRoot
     );
 
-    // When the user was in an active conversation but it ended without the
-    // agent generating files, confirm whether to proceed with base scaffolding.
-    if (agentResult?.userInteracted && agentResult.filesWritten === 0) {
+    // When the agent interaction ended without generating files — whether the
+    // user was in a conversation or Ctrl+C'd before the agent responded —
+    // confirm whether to proceed. Default to false when Ctrl+C was used.
+    if (agentResult && agentResult.filesWritten === 0) {
       const { prompt } = await import('enquirer');
       const { proceed } = await prompt<{ proceed: boolean }>({
         type: 'confirm',
         name: 'proceed',
         message: 'Agent interaction ended without generating files. Continue with base scaffolding?',
-        initial: true,
+        initial: !agentResult.interrupted,
       });
       if (!proceed) {
         throw new Error('Generation aborted.');

--- a/packages/nx-adsp/src/utils/agent.spec.ts
+++ b/packages/nx-adsp/src/utils/agent.spec.ts
@@ -92,7 +92,7 @@ describe('consultAgent', () => {
     });
 
     const result = await resultPromise;
-    expect(result).toEqual({ filesWritten: 2, userInteracted: true });
+    expect(result).toEqual({ filesWritten: 2, userInteracted: true, interrupted: false });
     expect(mockHost.write).toHaveBeenCalledWith('apps/test-service/src/roles.ts', 'export enum ServiceRoles {}');
     expect(mockHost.write).toHaveBeenCalledWith('apps/test-service/src/main.ts', 'updated main.ts');
   });

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -27,6 +27,8 @@ export interface AgentResult {
   filesWritten: number;
   /** True when the user was in an active conversation before it ended. */
   userInteracted: boolean;
+  /** True when the conversation ended via Ctrl+C (SIGINT). */
+  interrupted?: boolean;
 }
 
 /**
@@ -163,10 +165,15 @@ export async function consultAgent(
       conversationDone = true;
       rl.close();
       socket.disconnect();
-      // Return null for silent skips (no agent, no token, connection failed).
-      // Return a result with userInteracted:true when the user was in a
-      // conversation so the caller can ask whether to proceed.
-      resolve(agentHasResponded ? { filesWritten, userInteracted: true } : null);
+      // Return null only for truly silent skips (no agent, no token, connection failed).
+      // Return a result whenever the user was actively engaged (agent responded)
+      // OR when they explicitly interrupted (Ctrl+C), so the caller always gets
+      // a chance to confirm before proceeding.
+      resolve(
+        agentHasResponded || interrupted
+          ? { filesWritten, userInteracted: agentHasResponded, interrupted }
+          : null
+      );
     };
 
     socket.on('workspace-updated', () => {
@@ -200,6 +207,10 @@ export async function consultAgent(
     socket.on('stream', ({ chunk, done }) => {
       if (chunk?.type === 'text-delta') {
         const text: string = chunk.payload?.text ?? '';
+        if (!agentHasResponded) {
+          // Clear the dots line before the first response starts.
+          process.stdout.write('\n');
+        }
         buffer += text;
         agentHasResponded = true;
         process.stdout.write(text);


### PR DESCRIPTION
Adds the infrastructure for the nx-adsp generator to consult the ADSP `nxAdspAgent` during express-service scaffolding. See adsp-monorepo PR #5492 (merged) for the companion agent definition and template tools.

**Key behaviours:**
- `>` prompt after each agent turn — type a reply to continue, blank/Ctrl+D to apply files, Ctrl+C to abort (defaults confirm to no)
- Silent fallback when agent-service is unreachable
- `--tenant <name>` resolves realm via public tenant service API — one browser login instead of two

🤖 Generated with [Claude Code](https://claude.com/claude-code)