### PR TITLE
feat(nx-adsp): agent interaction improvements from beta testing

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -141,6 +141,13 @@ export default async function (host: Tree, options: Schema) {
         return undefined;
       }));
 
+    const { prompt } = await import('enquirer');
+    const { description } = await prompt<{ description: string }>({
+      type: 'input',
+      name: 'description',
+      message: `Briefly describe what ${normalizedOptions.projectName} does:`,
+    });
+
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
 
@@ -150,6 +157,7 @@ export default async function (host: Tree, options: Schema) {
       {
         projectName: normalizedOptions.projectName,
         projectType: 'express-service',
+        description: description?.trim() || undefined,
         tenant: normalizedOptions.adsp.tenant,
         pluginVersion: PLUGIN_VERSION,
         existingFiles: {

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -141,13 +141,6 @@ export default async function (host: Tree, options: Schema) {
         return undefined;
       }));
 
-    const { prompt } = await import('enquirer');
-    const { description } = await prompt<{ description: string }>({
-      type: 'input',
-      name: 'description',
-      message: `Briefly describe what ${normalizedOptions.projectName} does:`,
-    });
-
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
 
@@ -157,7 +150,6 @@ export default async function (host: Tree, options: Schema) {
       {
         projectName: normalizedOptions.projectName,
         projectType: 'express-service',
-        description: description?.trim() || undefined,
         tenant: normalizedOptions.adsp.tenant,
         pluginVersion: PLUGIN_VERSION,
         existingFiles: {

--- a/packages/nx-adsp/src/utils/agent.spec.ts
+++ b/packages/nx-adsp/src/utils/agent.spec.ts
@@ -12,6 +12,12 @@ jest.mock('socket.io-client');
 jest.mock('@abgov/nx-oc', () => ({ getServiceUrls: jest.fn() }));
 jest.mock('@nx/devkit', () => ({ Tree: jest.fn() }));
 
+// Enquirer is dynamically imported inside consultAgent; mock it here so the
+// prompt resolves immediately with an empty description in all tests.
+jest.mock('enquirer', () => ({
+  prompt: jest.fn().mockResolvedValue({ description: '' }),
+}));
+
 import { io } from 'socket.io-client';
 import { getServiceUrls } from '@abgov/nx-oc';
 
@@ -46,6 +52,9 @@ function makeMockSocket() {
   return socket;
 }
 
+// Flush the microtask queue so async operations inside consultAgent settle.
+// One tick is enough: the dynamic import and the enquirer mock both resolve
+// as microtasks, so after this all handlers are registered and descriptionReady=true.
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('consultAgent', () => {
@@ -66,6 +75,7 @@ describe('consultAgent', () => {
     });
     const socket = makeMockSocket();
     const resultPromise = consultAgent('https://directory.example.com', 'token', PROJECT_CONTEXT, mockHost, 'apps/test-service');
+    // After one tick: enquirer mock resolves, descriptionReady=true, conversationPromise returned.
     await flushPromises();
     socket._handlers['connect_error']?.();
     expect(await resultPromise).toBeNull();
@@ -79,6 +89,7 @@ describe('consultAgent', () => {
     const resultPromise = consultAgent('https://directory.example.com', 'token', PROJECT_CONTEXT, mockHost, 'apps/test-service');
     await flushPromises();
 
+    // descriptionReady=true at this point; workspace-updated fires last → triggers sendInitialMessage.
     socket._handlers['connect']?.();
     socket._handlers['workspace-updated']?.();
     // Simulate agent responding with text (sets agentHasResponded = true)
@@ -105,7 +116,7 @@ describe('consultAgent', () => {
     const resultPromise = consultAgent('https://directory.example.com', 'token', PROJECT_CONTEXT, mockHost, 'apps/test-service');
     await flushPromises();
 
-    // connect → workspace-update emitted, then workspace-updated → message emitted
+    // connect → workspace-update emitted; workspace-updated → message emitted (descriptionReady=true)
     socket._handlers['connect']?.();
     socket._handlers['workspace-updated']?.();
     socket._handlers['stream']?.({ chunk: { type: 'text-delta', payload: { text: 'What does this service do?' } }, done: false });

--- a/packages/nx-adsp/src/utils/agent.spec.ts
+++ b/packages/nx-adsp/src/utils/agent.spec.ts
@@ -43,6 +43,9 @@ function makeMockSocket() {
     on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
       handlers[event] = handler;
     }),
+    once: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers[event] = handler;
+    }),
     emit: jest.fn(),
     disconnect: jest.fn(),
     _handlers: handlers,
@@ -91,6 +94,8 @@ describe('consultAgent', () => {
 
     // descriptionReady=true at this point; workspace-updated fires last → triggers sendInitialMessage.
     socket._handlers['connect']?.();
+    // Server signals readiness via 'message' before workspace-update is safe to send.
+    socket._handlers['message']?.('Connected as user...');
     socket._handlers['workspace-updated']?.();
     // Simulate agent responding with text (sets agentHasResponded = true)
     socket._handlers['stream']?.({ chunk: { type: 'text-delta', payload: { text: 'I will add events.' } }, done: false });
@@ -116,8 +121,9 @@ describe('consultAgent', () => {
     const resultPromise = consultAgent('https://directory.example.com', 'token', PROJECT_CONTEXT, mockHost, 'apps/test-service');
     await flushPromises();
 
-    // connect → workspace-update emitted; workspace-updated → message emitted (descriptionReady=true)
+    // connect → server sends 'message' readiness signal → workspace-update emitted → workspace-updated → initial message sent
     socket._handlers['connect']?.();
+    socket._handlers['message']?.('Connected as user...');
     socket._handlers['workspace-updated']?.();
     socket._handlers['stream']?.({ chunk: { type: 'text-delta', payload: { text: 'What does this service do?' } }, done: false });
     socket._handlers['stream']?.({ chunk: null, done: true });

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -48,6 +48,8 @@ export async function consultAgent(
     projectType: 'express-service' | 'react-app' | 'angular-app';
     tenant: string;
     pluginVersion: string;
+    /** Brief description of what the service does, provided by the developer. */
+    description?: string;
     /** Content of key integration files for the agent to read and potentially modify. */
     existingFiles: Record<string, string>;
   },
@@ -100,9 +102,13 @@ export async function consultAgent(
 
     const buildInitialMessage = () => {
       const fileNames = Object.keys(projectContext.existingFiles).join(', ');
+      const descriptionLine = projectContext.description
+        ? `It is described as: "${projectContext.description}". `
+        : '';
       return (
         `I am setting up a new ${projectContext.projectType} called "${projectContext.projectName}" ` +
         `for ADSP tenant "${projectContext.tenant}" (nx-adsp plugin version ${projectContext.pluginVersion}). ` +
+        descriptionLine +
         `The project files (${fileNames}) have been uploaded to your workspace. ` +
         `What ADSP capabilities would be useful to integrate into this service?`
       );

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -37,6 +37,11 @@ export interface AgentResult {
  * generated and modified files; this function retrieves the workspace state
  * after the conversation and applies all files to the Nx Tree.
  *
+ * The socket connection and file upload start immediately. While the files
+ * are uploading, the developer is prompted for a brief project description.
+ * The initial message is sent as soon as both the upload and the description
+ * are ready — whichever finishes last.
+ *
  * Returns null if agent-service is unavailable — callers should skip the
  * agent step gracefully in that case.
  */
@@ -48,8 +53,6 @@ export async function consultAgent(
     projectType: 'express-service' | 'react-app' | 'angular-app';
     tenant: string;
     pluginVersion: string;
-    /** Brief description of what the service does, provided by the developer. */
-    description?: string;
     /** Content of key integration files for the agent to read and potentially modify. */
     existingFiles: Record<string, string>;
   },
@@ -69,198 +72,247 @@ export async function consultAgent(
 
   process.stdout.write(`\n[nx-adsp] Connecting to agent at ${agentServiceUrl}...\n`);
 
-  return new Promise((resolve) => {
-    const socket = io(agentServiceUrl, {
-      auth: { token: accessToken },
-      // Skip polling — go directly to WebSocket to avoid ARO ingress rejecting
-      // the polling POST with HTTP 400.
-      transports: ['websocket'],
-      timeout: 30000,
-      reconnection: false,
+  const threadId = crypto.randomUUID();
+
+  // Start socket connection immediately so file upload overlaps with the description prompt.
+  const socket = io(agentServiceUrl, {
+    auth: { token: accessToken },
+    // Skip polling — go directly to WebSocket to avoid ARO ingress rejecting
+    // the polling POST with HTTP 400.
+    transports: ['websocket'],
+    timeout: 30000,
+    reconnection: false,
+  });
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  // Coordination: sendInitialMessage is called once BOTH conditions are met:
+  //   1. description prompt has been answered (descriptionReady = true)
+  //   2. workspace files have been uploaded (workspaceReady = true)
+  // Whichever condition is satisfied last triggers the send.
+  let description: string | undefined;
+  let descriptionReady = false;
+  let workspaceReady = false;
+  let conversationStarted = false;
+
+  let buffer = '';
+  let conversationDone = false;
+  let agentHasResponded = false;
+  let interrupted = false;
+
+  let resolveConversation: (result: AgentResult | null) => void;
+  const conversationPromise = new Promise<AgentResult | null>((r) => {
+    resolveConversation = r;
+  });
+
+  const cleanup = (filesWritten: number) => {
+    conversationDone = true;
+    rl.close();
+    socket.disconnect();
+    // Return null only for truly silent skips (no agent, no token, connection failed).
+    // Return a result whenever the user was actively engaged (agent responded)
+    // OR when they explicitly interrupted (Ctrl+C), so the caller always gets
+    // a chance to confirm before proceeding.
+    resolveConversation(
+      agentHasResponded || interrupted
+        ? { filesWritten, userInteracted: agentHasResponded, interrupted }
+        : null
+    );
+  };
+
+  const buildInitialMessage = () => {
+    const fileNames = Object.keys(projectContext.existingFiles).join(', ');
+    const descriptionLine = description
+      ? `It is described as: "${description}". `
+      : '';
+    return (
+      `I am setting up a new ${projectContext.projectType} called "${projectContext.projectName}" ` +
+      `for ADSP tenant "${projectContext.tenant}" (nx-adsp plugin version ${projectContext.pluginVersion}). ` +
+      descriptionLine +
+      `The project files (${fileNames}) have been uploaded to your workspace. ` +
+      `What ADSP capabilities would be useful to integrate into this service?`
+    );
+  };
+
+  const sendInitialMessage = () => {
+    if (conversationStarted) return;
+    conversationStarted = true;
+    process.stdout.write('[nx-adsp] Type your replies at the > prompt. Press Ctrl+D or leave blank to apply generated files.\n\n');
+    socket.emit('message', {
+      agent: AGENT_ID,
+      threadId,
+      content: buildInitialMessage(),
+      rawChunks: true,
     });
+    // Show periodic dots while waiting for first agent response, then warn at 2 minutes.
+    const dotInterval = setInterval(() => {
+      if (!conversationDone && !agentHasResponded) process.stdout.write('.');
+      else clearInterval(dotInterval);
+    }, 3000);
+    setTimeout(() => {
+      clearInterval(dotInterval);
+      if (!conversationDone && !agentHasResponded) {
+        process.stdout.write(
+          '\n[nx-adsp] No response after 2 minutes. ' +
+            'The nxAdspAgent may still be deploying or the LLM is unresponsive. ' +
+            'Press Ctrl+C to skip and continue generation.\n'
+        );
+      }
+    }, 120000);
+  };
 
-    const rl = createInterface({ input: process.stdin, output: process.stdout });
-    const threadId = crypto.randomUUID();
-    let buffer = '';
-    let conversationDone = false;
-    let agentHasResponded = false;
-    let interrupted = false;
+  const requestWorkspaceState = () => {
+    socket.emit('workspace-read', { agent: AGENT_ID, threadId });
+  };
 
-    // Ctrl+C — abort the interaction without applying generated files.
-    rl.on('SIGINT', () => {
-      interrupted = true;
-      process.stdout.write('\n');
-      cleanup(0);
-    });
-
-    // Ctrl+D / stdin EOF — intentional finish: fetch workspace and apply files.
-    rl.on('close', () => {
-      if (!conversationDone && !interrupted) {
+  const promptUser = () => {
+    rl.question('\n> ', (input) => {
+      const trimmed = input.trim();
+      if (trimmed) {
+        socket.emit('message', {
+          agent: AGENT_ID,
+          threadId,
+          content: trimmed,
+          rawChunks: true,
+        });
+      } else {
+        // Empty input — apply whatever the agent has generated.
         requestWorkspaceState();
       }
     });
+  };
 
-    const buildInitialMessage = () => {
-      const fileNames = Object.keys(projectContext.existingFiles).join(', ');
-      const descriptionLine = projectContext.description
-        ? `It is described as: "${projectContext.description}". `
-        : '';
-      return (
-        `I am setting up a new ${projectContext.projectType} called "${projectContext.projectName}" ` +
-        `for ADSP tenant "${projectContext.tenant}" (nx-adsp plugin version ${projectContext.pluginVersion}). ` +
-        descriptionLine +
-        `The project files (${fileNames}) have been uploaded to your workspace. ` +
-        `What ADSP capabilities would be useful to integrate into this service?`
-      );
-    };
+  const applyWorkspaceFiles = (files: { path: string; content: string }[]) => {
+    let count = 0;
+    for (const file of files) {
+      // Skip files we uploaded that the agent hasn't modified — only apply
+      // new files and agent-modified versions of existing files.
+      const original = projectContext.existingFiles[file.path];
+      if (original !== undefined && original === file.content) {
+        continue;
+      }
+      const fullPath = `${projectRoot}/${file.path}`;
+      host.write(fullPath, file.content);
+      count++;
+    }
+    return count;
+  };
 
-    const sendMessage = (content: string) => {
-      socket.emit('message', {
-        agent: AGENT_ID,
-        threadId,
+  // Register all socket and readline handlers upfront so they are active
+  // while the description prompt is being shown.
+
+  rl.on('SIGINT', () => {
+    interrupted = true;
+    process.stdout.write('\n');
+    cleanup(0);
+  });
+
+  rl.on('close', () => {
+    if (!conversationDone && !interrupted) {
+      requestWorkspaceState();
+    }
+  });
+
+  socket.on('connect', () => {
+    process.stdout.write('[nx-adsp] Connected to agent-service.\n');
+    process.stdout.write('[nx-adsp] Uploading project files to workspace...\n');
+    socket.emit('workspace-update', {
+      agent: AGENT_ID,
+      threadId,
+      writes: Object.entries(projectContext.existingFiles).map(([path, content]) => ({
+        path,
         content,
-        rawChunks: true,
-      });
-    };
-
-    const requestWorkspaceState = () => {
-      socket.emit('workspace-read', { agent: AGENT_ID, threadId });
-    };
-
-    const uploadFilesToWorkspace = () => {
-      socket.emit('workspace-update', {
-        agent: AGENT_ID,
-        threadId,
-        writes: Object.entries(projectContext.existingFiles).map(([path, content]) => ({
-          path,
-          content,
-        })),
-        deletes: [],
-      });
-    };
-
-    const promptUser = () => {
-      rl.question('\n> ', (input) => {
-        const trimmed = input.trim();
-        if (trimmed) {
-          sendMessage(trimmed);
-        } else {
-          // Empty input — apply whatever the agent has generated.
-          requestWorkspaceState();
-        }
-      });
-    };
-
-    const applyWorkspaceFiles = (files: { path: string; content: string }[]) => {
-      let count = 0;
-      for (const file of files) {
-        // Skip files we uploaded that the agent hasn't modified — only apply
-        // new files and agent-modified versions of existing files.
-        const original = projectContext.existingFiles[file.path];
-        if (original !== undefined && original === file.content) {
-          continue;
-        }
-        const fullPath = `${projectRoot}/${file.path}`;
-        host.write(fullPath, file.content);
-        count++;
-      }
-      return count;
-    };
-
-    const cleanup = (filesWritten: number) => {
-      conversationDone = true;
-      rl.close();
-      socket.disconnect();
-      // Return null only for truly silent skips (no agent, no token, connection failed).
-      // Return a result whenever the user was actively engaged (agent responded)
-      // OR when they explicitly interrupted (Ctrl+C), so the caller always gets
-      // a chance to confirm before proceeding.
-      resolve(
-        agentHasResponded || interrupted
-          ? { filesWritten, userInteracted: agentHasResponded, interrupted }
-          : null
-      );
-    };
-
-    socket.on('workspace-updated', () => {
-      process.stdout.write('[nx-adsp] Project files uploaded to workspace.\n');
-      process.stdout.write('[nx-adsp] Type your replies at the > prompt. Press Ctrl+D or leave blank to apply generated files.\n\n');
-      sendMessage(buildInitialMessage());
-    });
-
-    socket.on('connect', () => {
-      process.stdout.write('[nx-adsp] Connected to agent-service.\n');
-      process.stdout.write('[nx-adsp] Uploading project files to workspace...\n');
-      uploadFilesToWorkspace();
-
-      // Show periodic dots while waiting for first response, then a warning at 2 minutes.
-      const dotInterval = setInterval(() => {
-        if (!conversationDone && !agentHasResponded) process.stdout.write('.');
-        else clearInterval(dotInterval);
-      }, 3000);
-      setTimeout(() => {
-        clearInterval(dotInterval);
-        if (!conversationDone && !agentHasResponded) {
-          process.stdout.write(
-            '\n[nx-adsp] No response after 2 minutes. ' +
-            'The nxAdspAgent may still be deploying or the LLM is unresponsive. ' +
-            'Press Ctrl+C to skip and continue generation.\n'
-          );
-        }
-      }, 120000);
-    });
-
-    socket.on('stream', ({ chunk, done }) => {
-      if (chunk?.type === 'text-delta') {
-        const text: string = chunk.payload?.text ?? '';
-        if (!agentHasResponded) {
-          // Clear the dots line before the first response starts.
-          process.stdout.write('\n');
-        }
-        buffer += text;
-        agentHasResponded = true;
-        process.stdout.write(text);
-      }
-
-      if (done) {
-        if (buffer.length > 0 && !buffer.endsWith('\n')) {
-          process.stdout.write('\n');
-        }
-        buffer = '';
-        // Agent finished its turn — prompt the user to continue the conversation
-        // or press Enter to apply whatever the agent has written so far.
-        promptUser();
-      }
-    });
-
-    socket.on('workspace-state', ({ files }: { files: { path: string; content: string }[] }) => {
-      // Only apply files the agent added or modified — not unchanged uploaded files.
-      const written = applyWorkspaceFiles(files ?? []);
-      if (written > 0) {
-        process.stdout.write(`\nApplied ${written} file(s) from agent workspace.\n`);
-      } else {
-        process.stdout.write('\nNo files generated by agent.\n');
-      }
-      cleanup(written);
-    });
-
-    socket.on('session-expired', () => {
-      process.stdout.write('\nAgent session expired.\n');
-      requestWorkspaceState();
-    });
-
-    socket.on('connect_error', (err) => {
-      // Log the full error object so we can diagnose the root cause.
-      const errAny = err as unknown as Record<string, unknown>;
-      process.stdout.write(`\n[nx-adsp] Connection failed: ${err?.message ?? err}\n`);
-      process.stdout.write(`[nx-adsp] Error detail: ${JSON.stringify(errAny?.description ?? errAny?.context ?? errAny?.cause ?? 'none')}\n`);
-      cleanup(0);
-    });
-    socket.on('error', (err) => {
-      process.stdout.write(`\n[nx-adsp] Agent error: ${JSON.stringify(err)}\n`);
-      requestWorkspaceState();
+      })),
+      deletes: [],
     });
   });
+
+  socket.on('workspace-updated', () => {
+    workspaceReady = true;
+    if (descriptionReady) {
+      // Description was entered before upload finished — send now.
+      sendInitialMessage();
+    }
+    // else: description prompt is still open — post-prompt code will call sendInitialMessage.
+  });
+
+  socket.on('stream', ({ chunk, done }) => {
+    if (chunk?.type === 'text-delta') {
+      const text: string = chunk.payload?.text ?? '';
+      if (!agentHasResponded) {
+        // Clear the dots line before the first response starts.
+        process.stdout.write('\n');
+      }
+      buffer += text;
+      agentHasResponded = true;
+      process.stdout.write(text);
+    }
+
+    if (done) {
+      if (buffer.length > 0 && !buffer.endsWith('\n')) {
+        process.stdout.write('\n');
+      }
+      buffer = '';
+      // Agent finished its turn — prompt the user to continue the conversation
+      // or press Enter to apply whatever the agent has written so far.
+      promptUser();
+    }
+  });
+
+  socket.on('workspace-state', ({ files }: { files: { path: string; content: string }[] }) => {
+    // Only apply files the agent added or modified — not unchanged uploaded files.
+    const written = applyWorkspaceFiles(files ?? []);
+    if (written > 0) {
+      process.stdout.write(`\nApplied ${written} file(s) from agent workspace.\n`);
+    } else {
+      process.stdout.write('\nNo files generated by agent.\n');
+    }
+    cleanup(written);
+  });
+
+  socket.on('session-expired', () => {
+    process.stdout.write('\nAgent session expired.\n');
+    requestWorkspaceState();
+  });
+
+  socket.on('connect_error', (err) => {
+    const errAny = err as unknown as Record<string, unknown>;
+    process.stdout.write(`\n[nx-adsp] Connection failed: ${err?.message ?? err}\n`);
+    process.stdout.write(
+      `[nx-adsp] Error detail: ${JSON.stringify(errAny?.description ?? errAny?.context ?? errAny?.cause ?? 'none')}\n`
+    );
+    cleanup(0);
+  });
+
+  socket.on('error', (err) => {
+    process.stdout.write(`\n[nx-adsp] Agent error: ${JSON.stringify(err)}\n`);
+    requestWorkspaceState();
+  });
+
+  // Show description prompt while socket connects and uploads files in the background.
+  try {
+    const { prompt } = await import('enquirer');
+    const answer = await prompt<{ description: string }>({
+      type: 'input',
+      name: 'description',
+      message: `Briefly describe what ${projectContext.projectName} does:`,
+    });
+    description = answer.description?.trim() || undefined;
+    descriptionReady = true;
+  } catch {
+    // Ctrl+C or cancellation during the description prompt.
+    interrupted = true;
+    cleanup(0);
+    return conversationPromise;
+  }
+
+  if (workspaceReady) {
+    // Upload finished while the user was typing — send immediately.
+    sendInitialMessage();
+  }
+  // else: workspace-updated handler will call sendInitialMessage once upload completes.
+
+  return conversationPromise;
 }
 
 async function resolveAgentServiceUrl(

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -216,14 +216,22 @@ export async function consultAgent(
   socket.on('connect', () => {
     process.stdout.write('[nx-adsp] Connected to agent-service.\n');
     process.stdout.write('[nx-adsp] Uploading project files to workspace...\n');
-    socket.emit('workspace-update', {
-      agent: AGENT_ID,
-      threadId,
-      writes: Object.entries(projectContext.existingFiles).map(([path, content]) => ({
-        path,
-        content,
-      })),
-      deletes: [],
+    // The server registers its 'workspace-update' handler only after an async
+    // getServiceConfiguration() call completes (router.ts:215). It signals
+    // readiness by calling socket.send() (router.ts:217), which arrives as a
+    // 'message' event on the client — by then all server handlers are registered.
+    // Emitting workspace-update immediately on 'connect' races that await and
+    // the event is silently dropped when the server wins.
+    socket.once('message', () => {
+      socket.emit('workspace-update', {
+        agent: AGENT_ID,
+        threadId,
+        writes: Object.entries(projectContext.existingFiles).map(([path, content]) => ({
+          path,
+          content,
+        })),
+        deletes: [],
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Improvements to the agent-service client based on beta testing of the nx-adsp express-service generator.

- **Prompt developer to describe the service** before the agent conversation starts — the description is included in the initial message so the agent has domain context up front
- **Parallelize workspace upload with the description prompt** — socket connection and file upload begin immediately; the initial message is sent as soon as both the upload and the description are ready, so the agent can respond with no additional delay after the user hits Enter
- **Fix workspace upload getting stuck** — the server's `onIoConnection` handler awaits `getServiceConfiguration()` before registering its `workspace-update` listener; events emitted immediately on `connect` were silently dropped. Fix: wait for the server's `socket.send()` readiness signal (emitted after async init completes) before uploading files

## Test plan

- [ ] Run `nx generate @abgov/nx-adsp:express-service` with `--tenant` flag
- [ ] Verify description prompt appears and connection/upload start in background
- [ ] Verify agent responds promptly after description is entered (no stuck "Uploading..." state)
- [ ] Verify Ctrl+C during description prompt exits cleanly without applying files

🤖 Generated with [Claude Code](https://claude.com/claude-code)