### PR TITLE
fix(nx-adsp): suppress socket status messages during description prompt

### DIFF
--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -214,14 +214,10 @@ export async function consultAgent(
   });
 
   socket.on('connect', () => {
-    process.stdout.write('[nx-adsp] Connected to agent-service.\n');
-    process.stdout.write('[nx-adsp] Uploading project files to workspace...\n');
-    // The server registers its 'workspace-update' handler only after an async
-    // getServiceConfiguration() call completes (router.ts:215). It signals
-    // readiness by calling socket.send() (router.ts:217), which arrives as a
-    // 'message' event on the client — by then all server handlers are registered.
-    // Emitting workspace-update immediately on 'connect' races that await and
-    // the event is silently dropped when the server wins.
+    // Connect and upload silently — stdout writes here would interleave with
+    // the description prompt that is active concurrently.
+    // The server signals handler readiness via socket.send() after its async
+    // getServiceConfiguration() resolves; wait for that before uploading.
     socket.once('message', () => {
       socket.emit('workspace-update', {
         agent: AGENT_ID,
@@ -317,8 +313,12 @@ export async function consultAgent(
   if (workspaceReady) {
     // Upload finished while the user was typing — send immediately.
     sendInitialMessage();
+  } else {
+    // Rare: user typed faster than the upload completed. Show a brief status
+    // so the prompt doesn't appear to hang.
+    process.stdout.write('[nx-adsp] Uploading project files to workspace...\n');
+    // workspace-updated handler will call sendInitialMessage once upload completes.
   }
-  // else: workspace-updated handler will call sendInitialMessage once upload completes.
 
   return conversationPromise;
 }


### PR DESCRIPTION
## Summary

stdout writes in the `connect` socket handler fired while the enquirer description prompt was active, interleaving with the prompt text and corrupting the display. Two symptoms:

- `[nx-adsp] Connected to agent-service.` and `[nx-adsp] Uploading project files to workspace...` appeared inline with the `Briefly describe what <project> does:` question
- On the happy path the upload message was shown at the point where the user was expected to provide the description

Fix: remove the status messages from the parallel connect/upload phase entirely — the `[nx-adsp] Connecting to agent at ...` line printed before the prompt is sufficient context. A brief `Uploading project files to workspace...` line is shown only on the rare slow path where the upload is still in progress when the user hits Enter.

## Test plan

- [ ] Run `nx generate @abgov/nx-adsp:express-service` with `--tenant` flag
- [ ] Verify description prompt appears cleanly with no interleaved status messages
- [ ] Verify agent responds after entering description

🤖 Generated with [Claude Code](https://claude.com/claude-code)