### PR TITLE
fix(nx-adsp): propagate access token from getAdspConfiguration to agent interaction

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -94,9 +94,13 @@ export default async function (host: Tree, options: Schema) {
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
 
+    // Prefer the token from adsp config (set by getAdspConfiguration's login),
+    // falling back to an explicitly provided accessToken (e.g. --tenant flow).
+    const accessToken = normalizedOptions.adsp.accessToken ?? options.accessToken;
+
     await consultAgent(
       normalizedOptions.adsp.directoryServiceUrl,
-      options.accessToken,
+      accessToken,
       {
         projectName: normalizedOptions.projectName,
         projectType: 'express-service',

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -140,6 +140,7 @@ export async function getAdspConfiguration(
       tenantRealm: tenant.realm,
       accessServiceUrl: environment.accessServiceUrl,
       directoryServiceUrl: environment.directoryServiceUrl,
+      accessToken: token,
     };
   }
 }

--- a/packages/nx-oc/src/adsp/adsp.d.ts
+++ b/packages/nx-oc/src/adsp/adsp.d.ts
@@ -3,6 +3,8 @@ export interface AdspConfiguration {
   tenantRealm: string;
   accessServiceUrl: string;
   directoryServiceUrl: string;
+  /** Access token from the login performed during configuration retrieval. */
+  accessToken?: string;
 }
 
 export type AdspOptions = {


### PR DESCRIPTION
## Summary

`getAdspConfiguration` performed a `realmLogin` to retrieve a token for tenant selection but discarded it, returning only the tenant config. Composite generators (`mern`, `mean`) that call `express-service` as a sub-generator had `adsp` config available but no `accessToken`, so `consultAgent` silently skipped the agent interaction.

- Added `accessToken?: string` to `AdspConfiguration` 
- `getAdspConfiguration` now includes the token in the returned config
- `express-service` prefers `adsp.accessToken` (set by `getAdspConfiguration`) and falls back to `options.accessToken` (set by the `--tenant` flag flow)

This makes the agent interaction available in `mern` and `mean` generators without any schema changes — the token from the initial login is simply preserved and reused.

## Test plan

- [ ] Run `nx generate @abgov/nx-adsp:mern my-project --env dev` and verify agent description prompt appears
- [ ] Run `nx generate @abgov/nx-adsp:express-service` with `--tenant` and verify agent interaction still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)