### PR TITLE
feat(nx-adsp): --tenant flag and single agent interaction for composite generators

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -94,9 +94,13 @@ export default async function (host: Tree, options: Schema) {
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
 
+    // Prefer the token from adsp config (set by getAdspConfiguration's login),
+    // falling back to an explicitly provided accessToken (e.g. --tenant flow).
+    const accessToken = normalizedOptions.adsp.accessToken ?? options.accessToken;
+
     await consultAgent(
       normalizedOptions.adsp.directoryServiceUrl,
-      options.accessToken,
+      accessToken,
       {
         projectName: normalizedOptions.projectName,
         projectType: 'express-service',

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -15,7 +15,7 @@ import { Schema, NormalizedSchema } from './schema';
 
 // Version of nx-adsp passed to the agent for template compatibility checks.
 // Keep in sync with package.json version.
-const PLUGIN_VERSION = '12.x';
+export const PLUGIN_VERSION = '12.x';
 
 async function normalizeOptions(
   host: Tree,
@@ -90,7 +90,7 @@ export default async function (host: Tree, options: Schema) {
   // files and modifications to integration files (main.ts, environment.ts)
   // which are applied directly to the Nx Tree.
   // Falls back silently if agent-service is unreachable or no accessToken.
-  if (normalizedOptions.adsp) {
+  if (normalizedOptions.adsp && !options.skipAgent) {
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
 

--- a/packages/nx-adsp/src/generators/express-service/schema.d.ts
+++ b/packages/nx-adsp/src/generators/express-service/schema.d.ts
@@ -3,7 +3,10 @@ import type { AdspConfiguration, EnvironmentName } from '@abgov/nx-oc';
 export interface Schema {
   name: string;
   env: EnvironmentName;
+  tenant?: string;
   accessToken?: string;
+  /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
+  skipAgent?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/express-service/schema.json
+++ b/packages/nx-adsp/src/generators/express-service/schema.json
@@ -31,6 +31,11 @@
         ]
       }
     },
+    "tenant": {
+      "type": "string",
+      "description": "Tenant name. Looks up the tenant realm and opens a single browser login to that realm, avoiding a separate interactive tenant selection.",
+      "alias": "t"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",

--- a/packages/nx-adsp/src/generators/mean/mean.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.ts
@@ -1,8 +1,9 @@
-import { formatFiles, installPackagesTask, names, Tree } from '@nx/devkit';
+import { formatFiles, getWorkspaceLayout, installPackagesTask, names, Tree } from '@nx/devkit';
 import { getAdspConfiguration } from '@abgov/nx-oc';
 import initAngularApp from '../angular-app/angular-app';
-import initExpressService from '../express-service/express-service';
+import initExpressService, { PLUGIN_VERSION } from '../express-service/express-service';
 import { NormalizedSchema, Schema } from './schema';
+import { consultAgent } from '../../utils/agent';
 
 async function normalizeOptions(
   host: Tree,
@@ -15,18 +16,45 @@ async function normalizeOptions(
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
   const projectName = names(options.name).fileName;
+  const serviceName = `${projectName}-service`;
+  const serviceRoot = `${getWorkspaceLayout(host).appsDir}/${serviceName}`;
 
+  // Scaffold the service first so the agent can read the generated files.
   await initExpressService(host, {
     ...normalizedOptions,
-    name: `${projectName}-service`,
+    name: serviceName,
+    skipAgent: true,
   });
+
+  // Agent interaction runs once for the composite — after service scaffold,
+  // before frontend scaffold.
+  if (normalizedOptions.adsp) {
+    const mainTs = host.read(`${serviceRoot}/src/main.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${serviceRoot}/src/environment.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      normalizedOptions.adsp.accessToken,
+      {
+        projectName: serviceName,
+        projectType: 'express-service',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/main.ts': mainTs,
+          'src/environment.ts': environmentTs,
+        },
+      },
+      host,
+      serviceRoot
+    );
+  }
 
   await initAngularApp(host, {
     ...normalizedOptions,
     name: `${projectName}-app`,
     proxy: {
       location: '/api/',
-      proxyPass: `http://${projectName}-service:3333/${projectName}-service/`,
+      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
     },
   });
 

--- a/packages/nx-adsp/src/generators/mean/schema.d.ts
+++ b/packages/nx-adsp/src/generators/mean/schema.d.ts
@@ -3,6 +3,7 @@ import { AdspConfiguration, EnvironmentName } from '@abgov/nx-oc';
 export interface Schema {
   name: string;
   env: EnvironmentName;
+  tenant?: string;
   accessToken?: string;
 }
 

--- a/packages/nx-adsp/src/generators/mean/schema.json
+++ b/packages/nx-adsp/src/generators/mean/schema.json
@@ -17,6 +17,11 @@
       "enum": ["dev", "test", "prod"],
       "default": "prod"
     },
+    "tenant": {
+      "type": "string",
+      "description": "Tenant name. Looks up the tenant realm and opens a single browser login to that realm, avoiding a separate interactive tenant selection.",
+      "alias": "t"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for ADSP tenant configuration (skips interactive login)."

--- a/packages/nx-adsp/src/generators/mern/mern.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.ts
@@ -1,8 +1,9 @@
-import { formatFiles, installPackagesTask, names, Tree } from '@nx/devkit';
+import { formatFiles, getWorkspaceLayout, installPackagesTask, names, Tree } from '@nx/devkit';
 import { getAdspConfiguration } from '@abgov/nx-oc';
-import initExpressService from '../express-service/express-service';
+import initExpressService, { PLUGIN_VERSION } from '../express-service/express-service';
 import initReactApp from '../react-app/react-app';
 import { Schema, NormalizedSchema } from './schema';
+import { consultAgent } from '../../utils/agent';
 
 async function normalizeOptions(
   host: Tree,
@@ -15,18 +16,46 @@ async function normalizeOptions(
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
   const projectName = names(options.name).fileName;
+  const serviceName = `${projectName}-service`;
+  const serviceRoot = `${getWorkspaceLayout(host).appsDir}/${serviceName}`;
 
+  // Scaffold the service first so the agent can read the generated files.
   await initExpressService(host, {
     ...normalizedOptions,
-    name: `${projectName}-service`,
+    name: serviceName,
+    skipAgent: true,
   });
+
+  // Agent interaction runs once for the composite — after service scaffold,
+  // before frontend scaffold, so any generated files are applied before the
+  // rest of the project is written.
+  if (normalizedOptions.adsp) {
+    const mainTs = host.read(`${serviceRoot}/src/main.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${serviceRoot}/src/environment.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      normalizedOptions.adsp.accessToken,
+      {
+        projectName: serviceName,
+        projectType: 'express-service',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/main.ts': mainTs,
+          'src/environment.ts': environmentTs,
+        },
+      },
+      host,
+      serviceRoot
+    );
+  }
 
   await initReactApp(host, {
     ...normalizedOptions,
     name: `${projectName}-app`,
     proxy: {
       location: '/api/',
-      proxyPass: `http://${projectName}-service:3333/${projectName}-service/`,
+      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
     },
   });
 

--- a/packages/nx-adsp/src/generators/mern/schema.d.ts
+++ b/packages/nx-adsp/src/generators/mern/schema.d.ts
@@ -3,6 +3,7 @@ import { AdspConfiguration, EnvironmentName } from '@abgov/nx-oc';
 export interface Schema {
   name: string;
   env: EnvironmentName;
+  tenant?: string;
   accessToken?: string;
 }
 

--- a/packages/nx-adsp/src/generators/mern/schema.json
+++ b/packages/nx-adsp/src/generators/mern/schema.json
@@ -31,6 +31,11 @@
         ]
       }
     },
+    "tenant": {
+      "type": "string",
+      "description": "Tenant name. Looks up the tenant realm and opens a single browser login to that realm, avoiding a separate interactive tenant selection.",
+      "alias": "t"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -118,23 +118,44 @@ export async function selectTenant(tenantServiceUrl: string, token: string) {
 
 export async function getAdspConfiguration(
   _host: Tree,
-  options: { env: EnvironmentName; accessToken?: string }
+  options: { env: EnvironmentName; accessToken?: string; tenant?: string }
 ): Promise<AdspConfiguration> {
   const { env, accessToken } = options;
   const environment = environments[env || 'prod'];
 
   if (isAdspOptions(options)) {
-    // If Adsp configuration is already been resolved, then no need to retrieve gain.
+    // Adsp configuration already resolved — return it directly.
     return options.adsp;
+  }
+
+  const urls = await getServiceUrls(environment.directoryServiceUrl);
+  const tenantServiceUrl = urls['urn:ads:platform:tenant-service:v2'];
+
+  if (options.tenant) {
+    // --tenant <name>: look up the realm anonymously, then login to that realm
+    // once. The resulting token works for both configuration access and the
+    // agent-service (which requires a tenant-realm token for role checks).
+    const { data } = await axios.get<{ results: { name: string; realm: string }[] }>(
+      new URL('v2/tenants', tenantServiceUrl).href,
+      { params: { name: options.tenant } },
+    );
+    const found = data.results[0];
+    if (!found) {
+      throw new Error(`Tenant '${options.tenant}' not found.`);
+    }
+
+    const token = accessToken || (await realmLogin(environment.accessServiceUrl, found.realm));
+    return {
+      tenant: names(found.name).fileName,
+      tenantRealm: found.realm,
+      accessServiceUrl: environment.accessServiceUrl,
+      directoryServiceUrl: environment.directoryServiceUrl,
+      accessToken: token,
+    };
   } else {
-    const urls = await getServiceUrls(environment.directoryServiceUrl);
-
-    const token =
-      accessToken || (await realmLogin(environment.accessServiceUrl, 'core'));
-
-    const tenantServiceUrl = urls['urn:ads:platform:tenant-service:v2'];
+    // Interactive flow: login to core realm, then let the user pick a tenant.
+    const token = accessToken || (await realmLogin(environment.accessServiceUrl, 'core'));
     const tenant = await selectTenant(tenantServiceUrl, token);
-
     return {
       tenant: names(tenant.name).fileName,
       tenantRealm: tenant.realm,

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -140,6 +140,7 @@ export async function getAdspConfiguration(
       tenantRealm: tenant.realm,
       accessServiceUrl: environment.accessServiceUrl,
       directoryServiceUrl: environment.directoryServiceUrl,
+      accessToken: token,
     };
   }
 }

--- a/packages/nx-oc/src/adsp/adsp.d.ts
+++ b/packages/nx-oc/src/adsp/adsp.d.ts
@@ -3,6 +3,8 @@ export interface AdspConfiguration {
   tenantRealm: string;
   accessServiceUrl: string;
   directoryServiceUrl: string;
+  /** Access token from the login performed during configuration retrieval. */
+  accessToken?: string;
 }
 
 export type AdspOptions = {


### PR DESCRIPTION
## Summary

**`--tenant <name>` flag (express-service, mern, mean)**

Without `--tenant`, the existing flow requires a core-realm browser login followed by an interactive tenant selection prompt. The resulting core-realm token does not carry the `agent-user` role, so the agent-service rejects it.

With `--tenant <name>`:
1. Tenant realm is looked up anonymously from the tenant service
2. A single browser login opens to that tenant realm
3. The resulting token is used for both ADSP configuration access and the agent-service interaction (which requires a tenant-realm token for `agent-user` role checks)

**Single agent interaction for composite generators (mern, mean)**

Previously `mern`/`mean` called `initExpressService` which triggered the agent mid-flow (after service scaffold, mid-generation). Now:
1. Service is scaffolded with `skipAgent: true`
2. `consultAgent` is called once by the composite generator itself — after service files exist, before the frontend scaffold
3. Token flows from `adsp.accessToken` (set by `getAdspConfiguration`) — no extra login

**Token propagation** (from prerequisite PR #236)

`getAdspConfiguration` now includes the login token in the returned `AdspConfiguration.accessToken`, so it's available throughout the generation without re-authenticating.

## Experience with `--tenant`

```
nx generate @abgov/nx-adsp:mern my-project --env dev --tenant my-tenant
```

1. Tenant realm looked up anonymously
2. **Single browser login** to the tenant realm
3. Service scaffolded
4. **"Briefly describe what my-project-service does:"** — description prompt while upload runs
5. Agent conversation
6. Frontend scaffolded

## Test plan

- [ ] `nx generate @abgov/nx-adsp:express-service my-service --env dev --tenant <name>` — single browser login, agent works
- [ ] `nx generate @abgov/nx-adsp:mern my-project --env dev --tenant <name>` — single login, agent fires once after service scaffold
- [ ] Without `--tenant` — existing interactive flow still works
- [ ] `skipAgent` is not in schema.json and cannot be passed from CLI (programmatic only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)