### PR TITLE
feat(nx-adsp): agent interaction for react-app, angular-app, and full-stack generators

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -1,4 +1,6 @@
 import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
+import { consultAgent } from '../../utils/agent';
+import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -162,6 +164,34 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
   updateProjectConfiguration(host, options.name, config);
 
   await formatFiles(host);
+
+  if (normalizedOptions.adsp && !options.skipAgent) {
+    const accessToken = normalizedOptions.adsp.accessToken ?? options.accessToken;
+    const appComponentTs = host.read(`${normalizedOptions.projectRoot}/src/app/app.component.ts`)?.toString() ?? '';
+    const appComponentHtml = host.read(`${normalizedOptions.projectRoot}/src/app/app.component.html`)?.toString() ?? '';
+    const appConfigTs = host.read(`${normalizedOptions.projectRoot}/src/app/app.config.ts`)?.toString() ?? '';
+    const appRoutesTs = host.read(`${normalizedOptions.projectRoot}/src/app/app.routes.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environments/environment.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      accessToken,
+      {
+        projectName: normalizedOptions.projectName,
+        projectType: 'angular-app',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/app/app.component.ts': appComponentTs,
+          'src/app/app.component.html': appComponentHtml,
+          'src/app/app.config.ts': appConfigTs,
+          'src/app/app.routes.ts': appRoutesTs,
+          'src/environments/environment.ts': environmentTs,
+        },
+      },
+      host,
+      normalizedOptions.projectRoot
+    );
+  }
 
   await deploymentGenerator(host, {
     ...normalizedOptions,

--- a/packages/nx-adsp/src/generators/angular-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/angular-app/schema.d.ts
@@ -1,10 +1,15 @@
 import type { AdspConfiguration, EnvironmentName } from '@abgov/nx-oc';
+import type { NginxProxyConfiguration } from '../../utils/nginx';
 
 export interface AngularAppGeneratorSchema {
   name: string;
   env: EnvironmentName;
   accessToken?: string;
+  tenant?: string;
+  tenantRealm?: string;
   proxy?: NginxProxyConfiguration | NginxProxyConfiguration[];
+  /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
+  skipAgent?: boolean;
 }
 
 export interface NormalizedSchema extends AngularAppGeneratorSchema {

--- a/packages/nx-adsp/src/generators/angular-app/schema.json
+++ b/packages/nx-adsp/src/generators/angular-app/schema.json
@@ -31,6 +31,16 @@
         ]
       }
     },
+    "tenant": {
+      "type": "string",
+      "description": "ADSP tenant name. Looks up the tenant realm and opens a single browser login, avoiding a separate interactive tenant selection.",
+      "alias": "t"
+    },
+    "tenantRealm": {
+      "type": "string",
+      "description": "Keycloak realm UUID. Optional when --tenant is provided — overrides the realm looked up from the tenant service.",
+      "alias": "tr"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -11,11 +11,8 @@ import {
 import { Linter } from '@nx/eslint';
 import * as path from 'path';
 import { consultAgent } from '../../utils/agent';
+import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import { Schema, NormalizedSchema } from './schema';
-
-// Version of nx-adsp passed to the agent for template compatibility checks.
-// Keep in sync with package.json version.
-const PLUGIN_VERSION = '12.x';
 
 async function normalizeOptions(
   host: Tree,
@@ -126,7 +123,7 @@ export default async function (host: Tree, options: Schema) {
   // files and modifications to integration files (main.ts, environment.ts)
   // which are applied directly to the Nx Tree.
   // Falls back silently if agent-service is unreachable or no accessToken.
-  if (normalizedOptions.adsp) {
+  if (normalizedOptions.adsp && !options.skipAgent) {
     // When --tenant was provided, normalizedOptions.accessToken holds the token
     // from the single realm login already performed during normalizeOptions.
     // token from the single realm login. Fall back to a new login only when the

--- a/packages/nx-adsp/src/generators/express-service/schema.d.ts
+++ b/packages/nx-adsp/src/generators/express-service/schema.d.ts
@@ -8,6 +8,8 @@ export interface Schema {
   tenantRealm?: string;
   /** ADSP tenant name (e.g. 'my-org'). Required when tenantRealm is provided. */
   tenant?: string;
+  /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
+  skipAgent?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/mean/mean.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.ts
@@ -1,8 +1,10 @@
-import { formatFiles, installPackagesTask, names, Tree } from '@nx/devkit';
+import { formatFiles, getWorkspaceLayout, installPackagesTask, names, Tree } from '@nx/devkit';
 import { getAdspConfiguration } from '@abgov/nx-oc';
 import initAngularApp from '../angular-app/angular-app';
 import initExpressService from '../express-service/express-service';
+import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import { NormalizedSchema, Schema } from './schema';
+import { consultAgent } from '../../utils/agent';
 
 async function normalizeOptions(
   host: Tree,
@@ -15,20 +17,81 @@ async function normalizeOptions(
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
   const projectName = names(options.name).fileName;
+  const serviceName = `${projectName}-service`;
+  const appName = `${projectName}-app`;
+  const serviceRoot = `${getWorkspaceLayout(host).appsDir}/${serviceName}`;
+  const appRoot = `${getWorkspaceLayout(host).appsDir}/${appName}`;
+
+  // When --tenant is provided, getAdspConfiguration returns a tenant-realm token
+  // that works for the agent-service. Use a shared thread so the agent carries
+  // context from the service discussion into the frontend interaction.
+  const sharedThreadId = options.tenant ? crypto.randomUUID() : undefined;
 
   await initExpressService(host, {
     ...normalizedOptions,
-    name: `${projectName}-service`,
+    name: serviceName,
+    skipAgent: !!sharedThreadId,
   });
+
+  if (sharedThreadId && normalizedOptions.adsp) {
+    const mainTs = host.read(`${serviceRoot}/src/main.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${serviceRoot}/src/environment.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      normalizedOptions.adsp.accessToken,
+      {
+        projectName: serviceName,
+        projectType: 'express-service',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/main.ts': mainTs,
+          'src/environment.ts': environmentTs,
+        },
+      },
+      host,
+      serviceRoot,
+      { threadId: sharedThreadId }
+    );
+  }
 
   await initAngularApp(host, {
     ...normalizedOptions,
-    name: `${projectName}-app`,
+    name: appName,
     proxy: {
       location: '/api/',
-      proxyPass: `http://${projectName}-service:3333/${projectName}-service/`,
+      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
     },
+    skipAgent: !!sharedThreadId,
   });
+
+  if (sharedThreadId && normalizedOptions.adsp) {
+    const appComponentTs = host.read(`${appRoot}/src/app/app.component.ts`)?.toString() ?? '';
+    const appComponentHtml = host.read(`${appRoot}/src/app/app.component.html`)?.toString() ?? '';
+    const appConfigTs = host.read(`${appRoot}/src/app/app.config.ts`)?.toString() ?? '';
+    const appRoutesTs = host.read(`${appRoot}/src/app/app.routes.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${appRoot}/src/environments/environment.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      normalizedOptions.adsp.accessToken,
+      {
+        projectName: appName,
+        projectType: 'angular-app',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/app/app.component.ts': appComponentTs,
+          'src/app/app.component.html': appComponentHtml,
+          'src/app/app.config.ts': appConfigTs,
+          'src/app/app.routes.ts': appRoutesTs,
+          'src/environments/environment.ts': environmentTs,
+        },
+      },
+      host,
+      appRoot,
+      { threadId: sharedThreadId }
+    );
+  }
 
   await formatFiles(host);
 

--- a/packages/nx-adsp/src/generators/mean/schema.d.ts
+++ b/packages/nx-adsp/src/generators/mean/schema.d.ts
@@ -4,6 +4,8 @@ export interface Schema {
   name: string;
   env: EnvironmentName;
   accessToken?: string;
+  tenant?: string;
+  tenantRealm?: string;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/mean/schema.json
+++ b/packages/nx-adsp/src/generators/mean/schema.json
@@ -17,6 +17,16 @@
       "enum": ["dev", "test", "prod"],
       "default": "prod"
     },
+    "tenant": {
+      "type": "string",
+      "description": "ADSP tenant name. Enables a single browser login for the full stack — service and frontend agent interactions both use the same tenant-realm token.",
+      "alias": "t"
+    },
+    "tenantRealm": {
+      "type": "string",
+      "description": "Keycloak realm UUID. Optional when --tenant is provided — overrides the realm looked up from the tenant service.",
+      "alias": "tr"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for ADSP tenant configuration (skips interactive login)."

--- a/packages/nx-adsp/src/generators/mern/mern.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.ts
@@ -1,8 +1,10 @@
-import { formatFiles, installPackagesTask, names, Tree } from '@nx/devkit';
+import { formatFiles, getWorkspaceLayout, installPackagesTask, names, Tree } from '@nx/devkit';
 import { getAdspConfiguration } from '@abgov/nx-oc';
 import initExpressService from '../express-service/express-service';
+import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import initReactApp from '../react-app/react-app';
 import { Schema, NormalizedSchema } from './schema';
+import { consultAgent } from '../../utils/agent';
 
 async function normalizeOptions(
   host: Tree,
@@ -15,20 +17,81 @@ async function normalizeOptions(
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
   const projectName = names(options.name).fileName;
+  const serviceName = `${projectName}-service`;
+  const appName = `${projectName}-app`;
+  const serviceRoot = `${getWorkspaceLayout(host).appsDir}/${serviceName}`;
+  const appRoot = `${getWorkspaceLayout(host).appsDir}/${appName}`;
+
+  // When --tenant is provided, getAdspConfiguration returns a tenant-realm token
+  // that works for the agent-service. Use a shared thread so the agent carries
+  // context from the service discussion into the frontend interaction.
+  const sharedThreadId = options.tenant ? crypto.randomUUID() : undefined;
 
   await initExpressService(host, {
     ...normalizedOptions,
-    name: `${projectName}-service`,
+    name: serviceName,
+    skipAgent: !!sharedThreadId,
   });
+
+  if (sharedThreadId && normalizedOptions.adsp) {
+    const mainTs = host.read(`${serviceRoot}/src/main.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${serviceRoot}/src/environment.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      normalizedOptions.adsp.accessToken,
+      {
+        projectName: serviceName,
+        projectType: 'express-service',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/main.ts': mainTs,
+          'src/environment.ts': environmentTs,
+        },
+      },
+      host,
+      serviceRoot,
+      { threadId: sharedThreadId }
+    );
+  }
 
   await initReactApp(host, {
     ...normalizedOptions,
-    name: `${projectName}-app`,
+    name: appName,
     proxy: {
       location: '/api/',
-      proxyPass: `http://${projectName}-service:3333/${projectName}-service/`,
+      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
     },
+    skipAgent: !!sharedThreadId,
   });
+
+  if (sharedThreadId && normalizedOptions.adsp) {
+    const appTs = host.read(`${appRoot}/src/app/app.tsx`)?.toString() ?? '';
+    const storeTs = host.read(`${appRoot}/src/store.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${appRoot}/src/environments/environment.ts`)?.toString() ?? '';
+    const configSliceTs = host.read(`${appRoot}/src/app/config.slice.ts`)?.toString() ?? '';
+    const intakeSliceTs = host.read(`${appRoot}/src/app/intake.slice.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      normalizedOptions.adsp.accessToken,
+      {
+        projectName: appName,
+        projectType: 'react-app',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/app/app.tsx': appTs,
+          'src/store.ts': storeTs,
+          'src/environments/environment.ts': environmentTs,
+          'src/app/config.slice.ts': configSliceTs,
+          'src/app/intake.slice.ts': intakeSliceTs,
+        },
+      },
+      host,
+      appRoot,
+      { threadId: sharedThreadId }
+    );
+  }
 
   await formatFiles(host);
 

--- a/packages/nx-adsp/src/generators/mern/schema.d.ts
+++ b/packages/nx-adsp/src/generators/mern/schema.d.ts
@@ -4,6 +4,8 @@ export interface Schema {
   name: string;
   env: EnvironmentName;
   accessToken?: string;
+  tenant?: string;
+  tenantRealm?: string;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/mern/schema.json
+++ b/packages/nx-adsp/src/generators/mern/schema.json
@@ -31,6 +31,16 @@
         ]
       }
     },
+    "tenant": {
+      "type": "string",
+      "description": "ADSP tenant name. Enables a single browser login for the full stack — service and frontend agent interactions both use the same tenant-realm token.",
+      "alias": "t"
+    },
+    "tenantRealm": {
+      "type": "string",
+      "description": "Keycloak realm UUID. Optional when --tenant is provided — overrides the realm looked up from the tenant service.",
+      "alias": "tr"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -1,4 +1,6 @@
 import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
+import { consultAgent } from '../../utils/agent';
+import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -167,6 +169,34 @@ export default async function (host: Tree, options: Schema) {
   updateProjectConfiguration(host, options.name, config);
 
   await formatFiles(host);
+
+  if (normalizedOptions.adsp && !options.skipAgent) {
+    const accessToken = normalizedOptions.adsp.accessToken ?? options.accessToken;
+    const appTs = host.read(`${normalizedOptions.projectRoot}/src/app/app.tsx`)?.toString() ?? '';
+    const storeTs = host.read(`${normalizedOptions.projectRoot}/src/store.ts`)?.toString() ?? '';
+    const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environments/environment.ts`)?.toString() ?? '';
+    const configSliceTs = host.read(`${normalizedOptions.projectRoot}/src/app/config.slice.ts`)?.toString() ?? '';
+    const intakeSliceTs = host.read(`${normalizedOptions.projectRoot}/src/app/intake.slice.ts`)?.toString() ?? '';
+    await consultAgent(
+      normalizedOptions.adsp.directoryServiceUrl,
+      accessToken,
+      {
+        projectName: normalizedOptions.projectName,
+        projectType: 'react-app',
+        tenant: normalizedOptions.adsp.tenant,
+        pluginVersion: PLUGIN_VERSION,
+        existingFiles: {
+          'src/app/app.tsx': appTs,
+          'src/store.ts': storeTs,
+          'src/environments/environment.ts': environmentTs,
+          'src/app/config.slice.ts': configSliceTs,
+          'src/app/intake.slice.ts': intakeSliceTs,
+        },
+      },
+      host,
+      normalizedOptions.projectRoot
+    );
+  }
 
   await deploymentGenerator(host, {
     ...normalizedOptions,

--- a/packages/nx-adsp/src/generators/react-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/react-app/schema.d.ts
@@ -5,7 +5,11 @@ export interface Schema {
   name: string;
   env: EnvironmentName;
   accessToken?: string;
+  tenant?: string;
+  tenantRealm?: string;
   proxy?: NginxProxyConfiguration | NginxProxyConfiguration[];
+  /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
+  skipAgent?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/react-app/schema.json
+++ b/packages/nx-adsp/src/generators/react-app/schema.json
@@ -31,6 +31,16 @@
         ]
       }
     },
+    "tenant": {
+      "type": "string",
+      "description": "ADSP tenant name. Looks up the tenant realm and opens a single browser login, avoiding a separate interactive tenant selection.",
+      "alias": "t"
+    },
+    "tenantRealm": {
+      "type": "string",
+      "description": "Keycloak realm UUID. Optional when --tenant is provided — overrides the realm looked up from the tenant service.",
+      "alias": "tr"
+    },
     "accessToken": {
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -57,7 +57,16 @@ export async function consultAgent(
     existingFiles: Record<string, string>;
   },
   host: Tree,
-  projectRoot: string
+  projectRoot: string,
+  options?: {
+    /**
+     * When provided, join an existing thread rather than starting a new one.
+     * The description prompt is skipped and a continuation message is sent instead,
+     * allowing the agent to carry context from a prior service interaction.
+     * Used by composite generators (mern, mean) to run service + frontend in one session.
+     */
+    threadId?: string;
+  }
 ): Promise<AgentResult | null> {
   if (!accessToken) {
     process.stdout.write('\n[nx-adsp] No access token — skipping agent interaction.\n');
@@ -70,9 +79,10 @@ export async function consultAgent(
     return null;
   }
 
-  process.stdout.write(`\n[nx-adsp] Connecting to agent at ${agentServiceUrl}...\n`);
+  const isContinuation = !!options?.threadId;
+  const threadId = options?.threadId ?? crypto.randomUUID();
 
-  const threadId = crypto.randomUUID();
+  process.stdout.write(`\n[nx-adsp] Connecting to agent at ${agentServiceUrl}...\n`);
 
   // Start socket connection immediately so file upload overlaps with the description prompt.
   const socket = io(agentServiceUrl, {
@@ -125,6 +135,13 @@ export async function consultAgent(
 
   const buildInitialMessage = () => {
     const fileNames = Object.keys(projectContext.existingFiles).join(', ');
+    if (isContinuation) {
+      return (
+        `I've also scaffolded a ${projectContext.projectType} called "${projectContext.projectName}" ` +
+        `for the same tenant. The frontend files (${fileNames}) have been uploaded to your workspace. ` +
+        `Based on the ADSP capabilities we discussed for the service, what frontend integrations would be useful?`
+      );
+    }
     const descriptionLine = description
       ? `It is described as: "${description}". `
       : '';
@@ -285,21 +302,28 @@ export async function consultAgent(
     requestWorkspaceState();
   });
 
-  // Show description prompt while socket connects and uploads files in the background.
-  try {
-    const { prompt } = await import('enquirer');
-    const answer = await prompt<{ description: string }>({
-      type: 'input',
-      name: 'description',
-      message: `Briefly describe what ${projectContext.projectName} does:`,
-    });
-    description = answer.description?.trim() || undefined;
+  // For continuation calls (shared thread from composite generator), skip the
+  // description prompt — the agent already has context from the prior service
+  // interaction on the same thread.
+  if (isContinuation) {
     descriptionReady = true;
-  } catch {
-    // Ctrl+C or cancellation during the description prompt.
-    interrupted = true;
-    cleanup(0);
-    return conversationPromise;
+  } else {
+    // Show description prompt while socket connects and uploads files in the background.
+    try {
+      const { prompt } = await import('enquirer');
+      const answer = await prompt<{ description: string }>({
+        type: 'input',
+        name: 'description',
+        message: `Briefly describe what ${projectContext.projectName} does:`,
+      });
+      description = answer.description?.trim() || undefined;
+      descriptionReady = true;
+    } catch {
+      // Ctrl+C or cancellation during the description prompt.
+      interrupted = true;
+      cleanup(0);
+      return conversationPromise;
+    }
   }
 
   // Create readline after enquirer has fully released stdin so the two

--- a/packages/nx-adsp/src/utils/plugin-version.ts
+++ b/packages/nx-adsp/src/utils/plugin-version.ts
@@ -1,0 +1,3 @@
+// Passed to the agent-service for template compatibility checks.
+// Keep in sync with the nx-adsp package.json version.
+export const PLUGIN_VERSION = '12.x';

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -118,23 +118,45 @@ export async function selectTenant(tenantServiceUrl: string, token: string) {
 
 export async function getAdspConfiguration(
   _host: Tree,
-  options: { env: EnvironmentName; accessToken?: string }
+  options: { env: EnvironmentName; accessToken?: string; tenant?: string; tenantRealm?: string }
 ): Promise<AdspConfiguration> {
   const { env, accessToken } = options;
   const environment = environments[env || 'prod'];
 
   if (isAdspOptions(options)) {
-    // If Adsp configuration is already been resolved, then no need to retrieve gain.
+    // Adsp configuration already resolved — return it directly.
     return options.adsp;
+  }
+
+  const urls = await getServiceUrls(environment.directoryServiceUrl);
+  const tenantServiceUrl = urls['urn:ads:platform:tenant-service:v2'];
+
+  if (options.tenant) {
+    // --tenant <name>: look up the realm anonymously, then do a single login
+    // to that realm. The resulting token works for both ADSP configuration
+    // access and the agent-service (which requires a tenant-realm token).
+    const { data } = await axios.get<{ results: { name: string; realm: string }[] }>(
+      new URL('v2/tenants', tenantServiceUrl).href,
+      { params: { name: options.tenant } },
+    );
+    const found = data.results[0];
+    if (!found) {
+      throw new Error(`Tenant '${options.tenant}' not found.`);
+    }
+
+    const realm = options.tenantRealm ?? found.realm;
+    const token = accessToken || (await realmLogin(environment.accessServiceUrl, realm));
+    return {
+      tenant: names(found.name).fileName,
+      tenantRealm: realm,
+      accessServiceUrl: environment.accessServiceUrl,
+      directoryServiceUrl: environment.directoryServiceUrl,
+      accessToken: token,
+    };
   } else {
-    const urls = await getServiceUrls(environment.directoryServiceUrl);
-
-    const token =
-      accessToken || (await realmLogin(environment.accessServiceUrl, 'core'));
-
-    const tenantServiceUrl = urls['urn:ads:platform:tenant-service:v2'];
+    // Interactive flow: login to core realm, then let the user pick a tenant.
+    const token = accessToken || (await realmLogin(environment.accessServiceUrl, 'core'));
     const tenant = await selectTenant(tenantServiceUrl, token);
-
     return {
       tenant: names(tenant.name).fileName,
       tenantRealm: tenant.realm,

--- a/packages/nx-oc/src/adsp/adsp.d.ts
+++ b/packages/nx-oc/src/adsp/adsp.d.ts
@@ -3,6 +3,8 @@ export interface AdspConfiguration {
   tenantRealm: string;
   accessServiceUrl: string;
   directoryServiceUrl: string;
+  /** Access token from the login performed during configuration retrieval (set by --tenant flow). */
+  accessToken?: string;
 }
 
 export type AdspOptions = {


### PR DESCRIPTION
## Summary

Extends the nx-adsp agent template model to cover frontend generators, with full-stack composite support using a shared conversation thread.

### `--tenant` flag (react-app, angular-app, mern, mean)

`getAdspConfiguration` now accepts `--tenant <name>` — looks up the tenant realm anonymously and does a single browser login to that realm. The resulting token is stored in `adsp.accessToken` and works for both ADSP configuration access and the agent-service (`agent-user` role is in the tenant realm).

express-service already had its own `--tenant` implementation; other generators now benefit consistently through `getAdspConfiguration`.

### Agent interaction for standalone react-app / angular-app

After scaffolding, uploads key files to the agent workspace and conducts a conversation:

| Generator | Files uploaded |
|-----------|---------------|
| react-app | app.tsx, store.ts, environment.ts, config.slice.ts, intake.slice.ts |
| angular-app | app.component.ts, app.component.html, app.config.ts, app.routes.ts, environment.ts |

Requires adsp-monorepo PR #5497 for the `react-app-*` and `angular-app-*` templates.

### Composite generator agent interaction (mern / mean)

With `--tenant`: single login, shared thread across service + frontend:
1. Scaffold service (`skipAgent: true`)
2. Service agent conversation — developer describes the project, agent generates service files
3. Scaffold frontend (`skipAgent: true`)
4. Frontend agent conversation on **same thread** — agent carries service context, sends continuation message, no description prompt shown again

Without `--tenant`: sub-generators handle their own agents (existing behavior).

### `consultAgent` API extension

New `options?: { threadId? }` parameter. When `threadId` is provided:
- Joins the existing thread (continuation)
- Sends a "I've also scaffolded a {type}..." message referencing the prior service discussion
- Skips the description prompt

## Test plan

- [ ] All nx-adsp tests pass
- [ ] `nx generate @abgov/nx-adsp:react-app my-app --env dev --tenant <name>` — description prompt, agent recommends react-app-* capabilities
- [ ] `nx generate @abgov/nx-adsp:mern my-project --env dev --tenant <name>` — single login, two agent conversations (service then frontend), second references first
- [ ] `nx generate @abgov/nx-adsp:mern my-project --env dev` (no --tenant) — express-service handles its own agent as before, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)