### PR TITLE
fix(nx-adsp): prevent second browser login in mern/mean generators

### DIFF
--- a/packages/nx-adsp/src/generators/mean/mean.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.ts
@@ -11,7 +11,10 @@ async function normalizeOptions(
   options: Schema
 ): Promise<NormalizedSchema> {
   const adsp = await getAdspConfiguration(host, options);
-  return { ...options, adsp };
+  // Propagate the token from adsp to the Schema-level accessToken so that
+  // sub-generators (express-service, angular-app) that check options.accessToken
+  // see it and skip their own realmLogin fallback.
+  return { ...options, accessToken: adsp.accessToken ?? options.accessToken, adsp };
 }
 
 export default async function (host: Tree, options: Schema) {

--- a/packages/nx-adsp/src/generators/mern/mern.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.ts
@@ -11,7 +11,10 @@ async function normalizeOptions(
   options: Schema
 ): Promise<NormalizedSchema> {
   const adsp = await getAdspConfiguration(host, options);
-  return { ...options, adsp };
+  // Propagate the token from adsp to the Schema-level accessToken so that
+  // sub-generators (express-service, react-app) that check options.accessToken
+  // see it and skip their own realmLogin fallback.
+  return { ...options, accessToken: adsp.accessToken ?? options.accessToken, adsp };
 }
 
 export default async function (host: Tree, options: Schema) {


### PR DESCRIPTION
## Summary

Running `mern` or `mean` with `--tenant` triggered two browser logins.

**Root cause**: `express-service`'s `normalizeOptions` checks `options.tenant` before `isAdspOptions`. When mern passes `{ ...normalizedOptions, tenant: 'my-tenant' }` to `initExpressService`, it finds `options.tenant` is set but `options.accessToken` is `undefined` (the token is in `adsp.accessToken`, not the Schema-level field), and fires a second `realmLogin` for the tenant realm.

**Fix**: In mern/mean `normalizeOptions`, propagate `adsp.accessToken` to the Schema-level `accessToken` field so sub-generators see it and skip their own login fallback.

## Test plan

- [ ] `nx generate @abgov/nx-adsp:mern my-project --env dev --tenant <name>` — only one browser login

🤖 Generated with [Claude Code](https://claude.com/claude-code)