### PR TITLE
fix(nx-adsp): show hint when agent completes a turn without a text response

### DIFF
--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -387,6 +387,13 @@ export async function consultAgent(
       if (buffer.length > 0 && !buffer.endsWith('\n')) {
         process.stdout.write('\n');
       }
+      if (firstDeltaOfTurn) {
+        // Agent completed its turn (possibly doing tool work) without sending any
+        // text. Clear any active thinking indicator and show a dim hint so the
+        // user knows the turn ended and they can reply or press Enter to finish.
+        stopThinking();
+        process.stdout.write(`${DIM}[nx-adsp] Agent completed work without a response — reply or press Enter to apply files.${RESET}\n`);
+      }
       buffer = '';
       firstDeltaOfTurn = true;  // reset for the next turn
       promptUser();


### PR DESCRIPTION
## Summary

When the agent completed tool work (reading/writing files) without sending any text before `done:true`, the client showed only a blank `>` prompt. Users couldn't tell if the agent had finished, stalled, or was waiting for input.

When `done` fires and no `text-delta` was received in that turn (`firstDeltaOfTurn` still `true`), a dim hint is now shown:

```
[nx-adsp] Agent completed work without a response — reply or press Enter to apply files.
```

This covers:
- Agent gathers information silently (reads files, lists workspace) then stalls
- Agent writes files then skips the confirmation text (the "MUST send reply" instruction is still in place — this is a fallback for when it's ignored)

## Test plan

- [ ] In an agent interaction, verify that turns where the agent does tool work without responding now show the hint rather than a blank `>` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)