### PR TITLE
feat(nx-oc): auto-trigger interactive oc login when not authenticated

### DIFF
--- a/packages/nx-oc/src/generators/apply-infra/apply-infra.spec.ts
+++ b/packages/nx-oc/src/generators/apply-infra/apply-infra.spec.ts
@@ -1,14 +1,16 @@
 import { createTree } from '@nx/devkit/testing';
 import { mocked } from 'jest-mock';
 import generator from './apply-infra';
-import { runOcCommand } from '../../utils/oc-utils';
+import { ensureOcLogin, runOcCommand } from '../../utils/oc-utils';
 import { writeJson } from '@nx/devkit';
 
 jest.mock('../../utils/oc-utils');
+const mockedEnsureOcLogin = mocked(ensureOcLogin);
 const mockedRunOcCommand = mocked(runOcCommand);
 
 describe('Apply Infra Generator', () => {
   beforeEach(() => {
+    mockedEnsureOcLogin.mockReset();
     mockedRunOcCommand.mockReset();
   });
 
@@ -21,9 +23,19 @@ describe('Apply Infra Generator', () => {
 
     await generator(host);
 
-    expect(mockedRunOcCommand.mock.calls.length).toBe(3);
-    expect(mockedRunOcCommand.mock.calls[0][0]).toBe('project');
+    expect(mockedEnsureOcLogin).toHaveBeenCalledTimes(1);
+    expect(mockedRunOcCommand.mock.calls.length).toBe(2);
+    expect(mockedRunOcCommand.mock.calls[0][0]).toBe('apply');
     expect(mockedRunOcCommand.mock.calls[1][0]).toBe('apply');
-    expect(mockedRunOcCommand.mock.calls[2][0]).toBe('apply');
+  });
+
+  it('propagates login error without running oc apply', async () => {
+    const host = createTree();
+    mockedEnsureOcLogin.mockImplementation(() => {
+      throw new Error('OpenShift login failed or was cancelled.');
+    });
+
+    await expect(generator(host)).rejects.toThrow('OpenShift login failed');
+    expect(mockedRunOcCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx-oc/src/generators/apply-infra/apply-infra.ts
+++ b/packages/nx-oc/src/generators/apply-infra/apply-infra.ts
@@ -1,5 +1,5 @@
 import { Tree } from '@nx/devkit';
-import { runOcCommand } from '../../utils/oc-utils';
+import { ensureOcLogin, runOcCommand } from '../../utils/oc-utils';
 
 function applyOcResources(host: Tree) {
   const { success: pipelineApplied, stdout: pipelineOut } = runOcCommand(
@@ -22,10 +22,6 @@ function applyOcResources(host: Tree) {
 }
 
 export default async function (host: Tree) {
-  const { success } = runOcCommand('project', []);
-  if (success) {
-    applyOcResources(host);
-  } else {
-    console.log(`Use oc login then run 'nx g @abgov/nx-oc:apply-infra'`);
-  }
+  ensureOcLogin();
+  applyOcResources(host);
 }

--- a/packages/nx-oc/src/utils/oc-utils.spec.ts
+++ b/packages/nx-oc/src/utils/oc-utils.spec.ts
@@ -1,9 +1,13 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { mocked } from 'jest-mock';
-import { runOcCommand } from './oc-utils';
+import { ensureOcLogin, runOcCommand } from './oc-utils';
 
 jest.mock('child_process');
 const mockedExecFileSync = mocked(execFileSync);
+const mockedSpawnSync = mocked(spawnSync);
+
+const SPAWN_OK = { status: 0, pid: 1, output: [], stdout: Buffer.from(''), stderr: Buffer.from(''), signal: null };
+const SPAWN_FAIL = { ...SPAWN_OK, status: 1 };
 
 describe('runOcCommand', () => {
   beforeEach(() => {
@@ -59,5 +63,66 @@ describe('runOcCommand', () => {
     const result = runOcCommand('start-build', ['my-pipeline']);
     expect(result.success).toBe(false);
     expect(result.stdout).toBeUndefined();
+  });
+});
+
+describe('ensureOcLogin', () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+    mockedSpawnSync.mockReset();
+  });
+
+  it('returns without spawning login when already logged in', () => {
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('Client Version: 4.14.0')); // oc version --client
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('developer'));               // oc whoami
+
+    ensureOcLogin();
+
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('throws a clear error when oc is not installed', () => {
+    mockedExecFileSync.mockImplementationOnce(() => {
+      throw new Error('oc: command not found');
+    });
+
+    expect(() => ensureOcLogin()).toThrow('oc CLI is not installed');
+  });
+
+  it('spawns oc login with server and --web when kubeconfig has a current context', () => {
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('Client Version: 4.14.0'));                  // oc version --client
+    mockedExecFileSync.mockImplementationOnce(() => { throw new Error('not logged in'); });         // oc whoami
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('https://api.example.openshift.com:6443')); // oc config view
+    mockedSpawnSync.mockReturnValue(SPAWN_OK);
+
+    ensureOcLogin();
+
+    expect(mockedSpawnSync).toHaveBeenCalledWith(
+      'oc',
+      ['login', 'https://api.example.openshift.com:6443', '--web'],
+      { stdio: 'inherit' }
+    );
+  });
+
+  it('spawns oc login with only --web when no kubeconfig exists', () => {
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('Client Version: 4.14.0'));          // oc version --client
+    mockedExecFileSync.mockImplementationOnce(() => { throw new Error('not logged in'); }); // oc whoami
+    mockedExecFileSync.mockImplementationOnce(() => { throw new Error('no config'); });     // oc config view
+
+    mockedSpawnSync.mockReturnValue(SPAWN_OK);
+
+    ensureOcLogin();
+
+    expect(mockedSpawnSync).toHaveBeenCalledWith('oc', ['login', '--web'], { stdio: 'inherit' });
+  });
+
+  it('throws when login is cancelled or fails', () => {
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('Client Version: 4.14.0'));          // oc version --client
+    mockedExecFileSync.mockImplementationOnce(() => { throw new Error('not logged in'); }); // oc whoami
+    mockedExecFileSync.mockImplementationOnce(() => { throw new Error('no config'); });     // oc config view
+
+    mockedSpawnSync.mockReturnValue(SPAWN_FAIL);
+
+    expect(() => ensureOcLogin()).toThrow('OpenShift login failed or was cancelled');
   });
 });

--- a/packages/nx-oc/src/utils/oc-utils.ts
+++ b/packages/nx-oc/src/utils/oc-utils.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 
 export function runOcCommand(
   command: 'project' | 'start-build' | 'process' | 'apply',
@@ -16,5 +16,42 @@ export function runOcCommand(
   } catch (e) {
     console.log(`Failed to execute command: oc ${args.join(' ')}`, e);
     return { success: false };
+  }
+}
+
+export function ensureOcLogin(): void {
+  try {
+    execFileSync('oc', ['version', '--client'], { stdio: 'pipe' });
+  } catch {
+    throw new Error(
+      "oc CLI is not installed or not on PATH. Install it from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ then re-run."
+    );
+  }
+
+  try {
+    execFileSync('oc', ['whoami'], { stdio: 'pipe' });
+    return;
+  } catch {
+    // not logged in — fall through to interactive login
+  }
+
+  let server: string | null = null;
+  try {
+    server =
+      execFileSync('oc', ['config', 'view', '--minify', '-o', 'jsonpath={.clusters[0].cluster.server}'], { stdio: 'pipe' })
+        .toString()
+        .trim() || null;
+  } catch {
+    // no kubeconfig — oc login will prompt for server
+  }
+
+  console.log('Not logged in to OpenShift. Starting interactive login...');
+  const loginArgs = server ? ['login', server, '--web'] : ['login', '--web'];
+  const result = spawnSync('oc', loginArgs, { stdio: 'inherit' });
+
+  if (result.status !== 0) {
+    throw new Error(
+      "OpenShift login failed or was cancelled. Run 'oc login' manually then re-run the generator."
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Adds `ensureOcLogin()` to `oc-utils.ts`: checks `oc` is installed, detects login state via `oc whoami`, and spawns `oc login <server> --web` interactively when not logged in
- Server URL is read from the existing kubeconfig (`oc config view --minify`); falls back to `oc login --web` with no server when no kubeconfig exists
- Replaces the silent fail in `apply-infra` — previously it printed "Use oc login then re-run" and exited; now it triggers the login flow automatically
- Throws with an actionable message if login is cancelled or fails

## Test plan

- [ ] `ensureOcLogin` — already logged in: returns without spawning login
- [ ] `ensureOcLogin` — oc not installed: throws with install URL
- [ ] `ensureOcLogin` — not logged in, kubeconfig has server: spawns `oc login <server> --web`
- [ ] `ensureOcLogin` — not logged in, no kubeconfig: spawns `oc login --web`
- [ ] `ensureOcLogin` — login cancelled/failed: throws actionable error
- [ ] `apply-infra` — login succeeds: proceeds to `oc apply` (2 calls)
- [ ] `apply-infra` — login throws: propagates error, no `oc apply` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)