### PR TITLE
feat(nx-oc): cache tenant realm tokens to avoid repeated browser logins

### DIFF
--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -6,6 +6,7 @@ import * as open from 'open';
 import { AccessToken, AuthorizationCode } from 'simple-oauth2';
 import { AdspConfiguration, AdspOptions } from './adsp';
 import { EnvironmentName, environments } from './environments';
+import { getCachedToken, isExpired, setCachedToken } from './token-cache';
 
 interface Package {
   dependencies: Record<string, string>;
@@ -36,6 +37,29 @@ export async function realmLogin(
       authorizePath: `/auth/realms/${realm}/protocol/openid-connect/auth`,
     },
   });
+
+  // Core realm is only used to fetch the tenant list — not worth caching.
+  if (realm !== 'core') {
+    const cached = getCachedToken(accessServiceUrl, realm);
+    if (cached) {
+      if (!isExpired(cached)) {
+        return cached.accessToken;
+      }
+
+      if (cached.refreshToken) {
+        try {
+          const { token } = await client
+            .createToken({ access_token: cached.accessToken, refresh_token: cached.refreshToken })
+            .refresh();
+          const expiresIn = (token['expires_in'] as number) ?? 300;
+          setCachedToken(accessServiceUrl, realm, token['access_token'] as string, token['refresh_token'] as string | undefined, expiresIn);
+          return token['access_token'] as string;
+        } catch {
+          // Refresh failed — fall through to browser login.
+        }
+      }
+    }
+  }
 
   const redirect_uri = 'http://localhost:3000/callback';
   const authorizationUri = client.authorizeURL({
@@ -76,6 +100,11 @@ export async function realmLogin(
       )
     ),
   ]).finally(() => server.close());
+
+  if (realm !== 'core') {
+    const expiresIn = (token['expires_in'] as number) ?? 300;
+    setCachedToken(accessServiceUrl, realm, token['access_token'] as string, token['refresh_token'] as string | undefined, expiresIn);
+  }
 
   return token['access_token'];
 }

--- a/packages/nx-oc/src/adsp/token-cache.spec.ts
+++ b/packages/nx-oc/src/adsp/token-cache.spec.ts
@@ -1,0 +1,117 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { getCacheFilePath, getCachedToken, isExpired, setCachedToken, CacheEntry } from './token-cache';
+
+jest.mock('fs');
+jest.mock('os');
+
+const mockedFs = jest.mocked(fs);
+const mockedOs = jest.mocked(os);
+
+const FAKE_HOME = '/home/testuser';
+const CACHE_PATH = path.join(FAKE_HOME, '.nx-adsp', 'token-cache.json');
+
+const ACCESS_URL = 'https://access.example.com/auth';
+const REALM = 'my-tenant';
+
+function futureIso(secondsFromNow: number): string {
+  return new Date(Date.now() + secondsFromNow * 1000).toISOString();
+}
+
+function pastIso(secondsAgo: number): string {
+  return new Date(Date.now() - secondsAgo * 1000).toISOString();
+}
+
+describe('getCacheFilePath', () => {
+  it('returns path under home directory', () => {
+    mockedOs.homedir.mockReturnValue(FAKE_HOME);
+    expect(getCacheFilePath()).toBe(CACHE_PATH);
+  });
+});
+
+describe('isExpired', () => {
+  it('returns false when token expires in the future (beyond buffer)', () => {
+    const entry: CacheEntry = { accessToken: 'tok', expiresAt: futureIso(120) };
+    expect(isExpired(entry)).toBe(false);
+  });
+
+  it('returns true when token is past its expiry', () => {
+    const entry: CacheEntry = { accessToken: 'tok', expiresAt: pastIso(10) };
+    expect(isExpired(entry)).toBe(true);
+  });
+
+  it('returns true when token expires within the 60-second buffer', () => {
+    const entry: CacheEntry = { accessToken: 'tok', expiresAt: futureIso(30) };
+    expect(isExpired(entry)).toBe(true);
+  });
+});
+
+describe('getCachedToken', () => {
+  beforeEach(() => {
+    mockedOs.homedir.mockReturnValue(FAKE_HOME);
+  });
+
+  it('returns null when cache file does not exist', () => {
+    mockedFs.readFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    expect(getCachedToken(ACCESS_URL, REALM)).toBeNull();
+  });
+
+  it('returns null when realm is not in cache', () => {
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify({ 'other::realm': { accessToken: 'x', expiresAt: futureIso(3600) } }));
+    expect(getCachedToken(ACCESS_URL, REALM)).toBeNull();
+  });
+
+  it('returns the cached entry when present', () => {
+    const entry: CacheEntry = { accessToken: 'abc', refreshToken: 'ref', expiresAt: futureIso(3600) };
+    const key = `${ACCESS_URL}::${REALM}`;
+    mockedFs.readFileSync.mockReturnValue(JSON.stringify({ [key]: entry }));
+
+    expect(getCachedToken(ACCESS_URL, REALM)).toEqual(entry);
+  });
+});
+
+describe('setCachedToken', () => {
+  beforeEach(() => {
+    mockedOs.homedir.mockReturnValue(FAKE_HOME);
+    mockedFs.existsSync.mockReturnValue(true);
+    mockedFs.readFileSync.mockImplementation(() => { throw new Error('ENOENT'); });
+    (mockedFs.writeFileSync as jest.Mock).mockReset();
+    (mockedFs.mkdirSync as jest.Mock).mockReset();
+  });
+
+  it('writes a new entry with correct fields', () => {
+    setCachedToken(ACCESS_URL, REALM, 'access-tok', 'refresh-tok', 3600);
+
+    expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      CACHE_PATH,
+      expect.stringContaining('"accessToken": "access-tok"'),
+      expect.objectContaining({ mode: 0o600 })
+    );
+
+    const written = JSON.parse((mockedFs.writeFileSync as jest.Mock).mock.calls[0][1] as string);
+    const entry = written[`${ACCESS_URL}::${REALM}`];
+    expect(entry.accessToken).toBe('access-tok');
+    expect(entry.refreshToken).toBe('refresh-tok');
+    expect(new Date(entry.expiresAt).getTime()).toBeGreaterThan(Date.now() + 3590 * 1000);
+  });
+
+  it('writes without refreshToken when not provided', () => {
+    setCachedToken(ACCESS_URL, REALM, 'access-tok', undefined, 3600);
+
+    const written = JSON.parse((mockedFs.writeFileSync as jest.Mock).mock.calls[0][1] as string);
+    const entry = written[`${ACCESS_URL}::${REALM}`];
+    expect(entry.refreshToken).toBeUndefined();
+  });
+
+  it('creates the cache directory if it does not exist', () => {
+    mockedFs.existsSync.mockReturnValue(false);
+
+    setCachedToken(ACCESS_URL, REALM, 'tok', undefined, 300);
+
+    expect(mockedFs.mkdirSync).toHaveBeenCalledWith(
+      path.dirname(CACHE_PATH),
+      expect.objectContaining({ recursive: true, mode: 0o700 })
+    );
+  });
+});

--- a/packages/nx-oc/src/adsp/token-cache.ts
+++ b/packages/nx-oc/src/adsp/token-cache.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface CacheEntry {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt: string; // ISO 8601
+}
+
+type TokenCache = Record<string, CacheEntry>;
+
+const EXPIRY_BUFFER_MS = 60_000;
+
+export function getCacheFilePath(): string {
+  return path.join(os.homedir(), '.nx-adsp', 'token-cache.json');
+}
+
+function readCache(): TokenCache {
+  try {
+    return JSON.parse(fs.readFileSync(getCacheFilePath(), 'utf-8')) as TokenCache;
+  } catch {
+    return {};
+  }
+}
+
+function writeCache(cache: TokenCache): void {
+  const filePath = getCacheFilePath();
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  fs.writeFileSync(filePath, JSON.stringify(cache, null, 2), { mode: 0o600, encoding: 'utf-8' });
+}
+
+function cacheKey(accessServiceUrl: string, realm: string): string {
+  return `${accessServiceUrl}::${realm}`;
+}
+
+export function isExpired(entry: CacheEntry): boolean {
+  return new Date(entry.expiresAt).getTime() - EXPIRY_BUFFER_MS < Date.now();
+}
+
+export function getCachedToken(accessServiceUrl: string, realm: string): CacheEntry | null {
+  return readCache()[cacheKey(accessServiceUrl, realm)] ?? null;
+}
+
+export function setCachedToken(
+  accessServiceUrl: string,
+  realm: string,
+  accessToken: string,
+  refreshToken: string | undefined,
+  expiresIn: number
+): void {
+  const cache = readCache();
+  cache[cacheKey(accessServiceUrl, realm)] = {
+    accessToken,
+    refreshToken,
+    expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
+  };
+  writeCache(cache);
+}


### PR DESCRIPTION
## Summary

- Adds `~/.nx-adsp/token-cache.json` (mode `0600`, directory `0700`) keyed by `accessServiceUrl::realm`
- On `realmLogin()` for a tenant realm: valid cached token → returned immediately; expired with refresh token → silent refresh; refresh failure or no cache → browser login as before, result cached
- Core realm tokens are intentionally not cached — the core realm is only used to fetch the tenant list and is always followed by an interactive tenant picker anyway
- After the first login per tenant realm, subsequent `nx generate` runs in the same session (and across sessions until the refresh token expires) require no browser interaction

## Security

- Cache file written with mode `0600` (owner read/write only)
- Cache directory created with mode `0700`
- Stored at `~/.nx-adsp/` (user-level, never in the project directory — no git commit risk)
- Pattern is consistent with `~/.kube/config`, `~/.config/gcloud/`, `~/.azure/` used by similar CLI tools

## Test plan

- [ ] Valid cached token returned without opening browser
- [ ] Expired token with refresh token → silent refresh, cache updated
- [ ] Refresh failure → falls through to browser login
- [ ] No cache entry → browser login, result written to cache
- [ ] Core realm (`realm === 'core'`) → browser login, nothing cached
- [ ] Cache directory created with `0700` if absent
- [ ] Cache file written with `0600`

🤖 Generated with [Claude Code](https://claude.com/claude-code)