### PR TITLE
fix(nx-oc): catch ensureOcLogin errors for graceful exit in apply-infra

### DIFF
--- a/packages/nx-oc/src/generators/apply-infra/apply-infra.spec.ts
+++ b/packages/nx-oc/src/generators/apply-infra/apply-infra.spec.ts
@@ -29,13 +29,14 @@ describe('Apply Infra Generator', () => {
     expect(mockedRunOcCommand.mock.calls[1][0]).toBe('apply');
   });
 
-  it('propagates login error without running oc apply', async () => {
+  it('logs login error and exits cleanly without running oc apply', async () => {
     const host = createTree();
     mockedEnsureOcLogin.mockImplementation(() => {
-      throw new Error('OpenShift login failed or was cancelled.');
+      throw new Error('oc CLI is not installed or not on PATH.');
     });
 
-    await expect(generator(host)).rejects.toThrow('OpenShift login failed');
+    await generator(host);
+
     expect(mockedRunOcCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx-oc/src/generators/apply-infra/apply-infra.ts
+++ b/packages/nx-oc/src/generators/apply-infra/apply-infra.ts
@@ -22,6 +22,11 @@ function applyOcResources(host: Tree) {
 }
 
 export default async function (host: Tree) {
-  ensureOcLogin();
+  try {
+    ensureOcLogin();
+  } catch (e) {
+    console.log(e instanceof Error ? e.message : String(e));
+    return;
+  }
   applyOcResources(host);
 }


### PR DESCRIPTION
## Summary

Fixes e2e failure introduced by #252. `ensureOcLogin()` throws when `oc` is not installed or login is cancelled. In CI environments without `oc`, this caused `apply-infra` to exit with an unhandled error rather than logging a message and returning cleanly.

The fix wraps `ensureOcLogin()` in a try-catch and logs the error message before returning — restoring the original graceful-exit behaviour while preserving the actionable error message for the developer.

## Test plan

- [ ] `oc` not installed → generator logs message, exits cleanly, no `oc apply` calls
- [ ] Login cancelled → same clean exit
- [ ] `oc` installed and logged in → proceeds to `oc apply` as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)