### PR TITLE
feat(nx-adsp): wire authorize, createValidationHandler, and example route into express-service template

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -60,6 +60,26 @@ npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 
 When `--database postgres` is selected the generator also scaffolds a `prisma/schema.prisma`, a `PrismaClient` singleton, an idempotent Podman script for a local Postgres container, and Nx targets (`db:generate`, `db:migrate`, `db:migrate:deploy`, `db:studio`, `dev-db`). When `--database mongo` is selected it scaffolds a Mongoose connection helper and an equivalent Podman script for a local MongoDB container. See [Database setup](#database-setup) below.
 
+The generated `src/main.ts` includes `authorize`, `createValidationHandler`, and `createErrorHandler` from `@abgov/adsp-service-sdk`, and an example `POST /v1/example` route that shows the full pattern: role check → input validation (Zod schema) → domain event publish → error forwarding to `createErrorHandler`. Replace or remove the example route once you have real business logic.
+
+```typescript
+// Pattern used in the generated example route — adapt for your routes:
+app.post(
+  '/my-service/v1/resource',
+  authorize('my-role'),
+  createValidationHandler(MySchema),      // validates req.body; 400 on failure
+  async (req, res, next) => {
+    try {
+      const { id } = req.body as z.infer<typeof MySchema>;
+      eventService.send(createMyEvent(id));
+      res.json({ id });
+    } catch (err) {
+      next(err);                          // createErrorHandler maps to 500
+    }
+  }
+);
+```
+
 ---
 
 ### mern

--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -35,6 +35,18 @@ describe('Express Service Generator', () => {
     expect(host.exists('apps/test/src/environments/environment.ts')).toBeFalsy();
   }, 60000);
 
+  it('includes authorize, createValidationHandler, and example route in main.ts', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    const mainTs = host.read('apps/test/src/main.ts').toString();
+    expect(mainTs).toContain('authorize');
+    expect(mainTs).toContain('createValidationHandler');
+    expect(mainTs).toContain('createErrorHandler');
+    expect(mainTs).toContain('/v1/example');
+    expect(mainTs).toContain('eventService.send');
+  }, 60000);
+
   it('scaffolds postgres database files and targets', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, { ...options, database: 'postgres' });

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -109,7 +109,7 @@ export default async function (host: Tree, options: Schema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/adsp-service-sdk': '^2.5.0',
+      '@abgov/adsp-service-sdk': '^2.23.0',
       compression: '^1.8.1',
       cors: '^2.8.5',
       dotenv: '^16.4.7',
@@ -117,6 +117,7 @@ export default async function (host: Tree, options: Schema) {
       helmet: '^8.0.0',
       passport: '^0.7.0',
       'passport-anonymous': '^1.0.1',
+      zod: '^3.0.0',
       ...(normalizedOptions.database === 'postgres' ? { '@prisma/client': '^6.0.0' } : {}),
       ...(normalizedOptions.database === 'mongo' ? { mongoose: '^8.0.0' } : {}),
     },
@@ -218,6 +219,11 @@ export default async function (host: Tree, options: Schema) {
 
     const mainTs = host.read(`${normalizedOptions.projectRoot}/src/main.ts`)?.toString() ?? '';
     const environmentTs = host.read(`${normalizedOptions.projectRoot}/src/environment.ts`)?.toString() ?? '';
+    const eventsTs = host.read(`${normalizedOptions.projectRoot}/src/events.ts`)?.toString() ?? '';
+    const databaseTs =
+      normalizedOptions.database !== 'none'
+        ? host.read(`${normalizedOptions.projectRoot}/src/database.ts`)?.toString() ?? ''
+        : undefined;
 
     const agentResult = await consultAgent(
       normalizedOptions.adsp.directoryServiceUrl,
@@ -230,6 +236,8 @@ export default async function (host: Tree, options: Schema) {
         existingFiles: {
           'src/main.ts': mainTs,
           'src/environment.ts': environmentTs,
+          'src/events.ts': eventsTs,
+          ...(databaseTs ? { 'src/database.ts': databaseTs } : {}),
         },
       },
       host,

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -53,18 +53,46 @@ const token = await tokenProvider.getAccessToken();
 
 ## Adding routes
 
-Add route handlers in `main.ts` under the `/<%= projectName %>/v1` path prefix:
+Add route handlers in `main.ts` under the `/<%= projectName %>/v1` path prefix.
+`passport.authenticate(['tenant', 'anonymous'])` is applied to the entire prefix —
+`req.user` is null for anonymous requests and populated for authenticated ones.
 
+**Public route:**
 ```typescript
 app.get('/<%= projectName %>/v1/my-resource', (req, res) => {
-  const user = req.user; // null for anonymous, populated for authenticated
   res.json({ ... });
 });
 ```
 
-`passport.authenticate(['tenant', 'anonymous'])` is applied to the entire
-`/<%= projectName %>/v1` prefix — check `req.user` inside handlers to
-distinguish authenticated from anonymous access.
+**Protected route** (requires a role, validates input, publishes an event):
+```typescript
+import { authorize, createValidationHandler } from '@abgov/adsp-service-sdk';
+import { z } from 'zod';
+
+const MySchema = z.object({ name: z.string().min(1) });
+
+app.post(
+  '/<%= projectName %>/v1/my-resource',
+  authorize('my-role'),                   // 403 if authenticated user lacks role
+  createValidationHandler(MySchema),      // 400 if body fails schema
+  async (req, res, next) => {
+    try {
+      const { name } = req.body as z.infer<typeof MySchema>;
+      eventService.send(createMyEvent(name));
+      res.json({ name });
+    } catch (err) {
+      next(err);                          // createErrorHandler maps to 500
+    }
+  }
+);
+```
+
+Both `authorize` and `createValidationHandler` pass errors to `next()` —
+`createErrorHandler(logger)` at the bottom of `main.ts` translates them to
+structured HTTP responses (401/403 and 400 respectively).
+
+See the `ExampleRequestSchema` and example route already in `main.ts` as a
+starting point — replace or remove it once you have real business logic.
 <% if (database === 'postgres') { %>
 
 ## Local database

--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -1,17 +1,22 @@
-import { AdspId, createErrorHandler, initializeService } from '@abgov/adsp-service-sdk';
+import { AdspId, authorize, createErrorHandler, createValidationHandler, initializeService } from '@abgov/adsp-service-sdk';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import passport from 'passport';
 import { Strategy as AnonymousStrategy } from 'passport-anonymous';
+import { z } from 'zod';
 <% if (database === 'postgres') { %>
 import { prisma } from './database';
 <% } else if (database === 'mongo') { %>
 import { connectDatabase, disconnectDatabase } from './database';
 <% } %>
 import { environment } from './environment';
-import { exampleEventDefinition } from './events';
+import { createExampleEvent, exampleEventDefinition } from './events';
+
+const ExampleRequestSchema = z.object({
+  id: z.string().min(1),
+});
 
 async function initializeApp() {
   const serviceId = AdspId.parse(environment.CLIENT_ID);
@@ -80,6 +85,24 @@ async function initializeApp() {
       },
     });
   });
+
+  // Example: protected route demonstrating authorize, input validation, and a domain event.
+  // Require 'example-role' — replace with a role relevant to your service.
+  // Remove or replace this route once you have real business logic.
+  app.post(
+    '/<%= projectName %>/v1/example',
+    authorize('example-role'),
+    createValidationHandler(ExampleRequestSchema),
+    async (req, res, next) => {
+      try {
+        const { id } = req.body as z.infer<typeof ExampleRequestSchema>;
+        eventService.send(createExampleEvent(id));
+        res.json({ id });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
 
   // Mount error handler last — after all routes and middleware.
   app.use(createErrorHandler(logger));


### PR DESCRIPTION
## Summary

- Bumps `@abgov/adsp-service-sdk` to `^2.23.0` (includes `authorize` and `createValidationHandler` from PRs #5562 and #5575)
- Adds `zod ^3.0.0` to generated project dependencies (matches SDK's own zod peer)
- Wires `authorize`, `createValidationHandler`, and `createErrorHandler` into the generated `main.ts` import
- Adds `ExampleRequestSchema` and a `POST /v1/example` route demonstrating the full pattern: role check → input validation → domain event publish → error forwarding to `createErrorHandler`
- Expands `AGENTS.md` route section with a protected-route pattern snippet
- Fixes `consultAgent` context: `events.ts` (and `database.ts` when applicable) are now included in `existingFiles` so AI assistance has full context of the generated project
- Documents the included handlers and example route in `nx-adsp.md`

## Test plan

- [ ] All existing express-service generator tests pass
- [ ] New test verifies `authorize`, `createValidationHandler`, `createErrorHandler`, example route, and `eventService.send` are present in generated `main.ts`
- [ ] Run `nx g @abgov/nx-adsp:express-service my-svc --env dev` and confirm generated `main.ts` compiles cleanly with the new imports and example route

🤖 Generated with [Claude Code](https://claude.com/claude-code)