### PR TITLE
feat(nx-adsp): expose --skipAgent flag on express-service, mern, and mean

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -57,6 +57,7 @@ npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 | `tenantRealm` | `-tr` | No | Keycloak realm UUID; overrides the realm resolved from `--tenant` |
 | `accessToken` | `-at` | No | Access token for non-interactive retrieval of ADSP configuration |
 | `database` | — | No | Database to scaffold: `none` (default), `postgres` (Prisma), or `mongo` (Mongoose) |
+| `skipAgent` | — | No | Skip the consultAgent interaction and generate base scaffolding only |
 
 When `--database postgres` is selected the generator also scaffolds a `prisma/schema.prisma`, a `PrismaClient` singleton, an idempotent Podman script for a local Postgres container, and Nx targets (`db:generate`, `db:migrate`, `db:migrate:deploy`, `db:studio`, `dev-db`). When `--database mongo` is selected it scaffolds a Mongoose connection helper and an equivalent Podman script for a local MongoDB container. See [Database setup](#database-setup) below.
 
@@ -99,6 +100,7 @@ Generates `my-app-service` (Express + Mongoose) and `my-app-app` (React), with a
 | `tenant` | `-t` | No | ADSP tenant name |
 | `tenantRealm` | `-tr` | No | Keycloak realm UUID |
 | `accessToken` | `-at` | No | Access token for non-interactive use |
+| `skipAgent` | — | No | Skip the consultAgent interaction and generate base scaffolding only |
 
 ---
 
@@ -112,7 +114,7 @@ npx nx g @abgov/nx-adsp:mean my-app --env dev --tenant my-tenant
 
 Generates `my-app-service` (Express + Mongoose) and `my-app-app` (Angular), with a dev proxy and nginx production proxy wired between them.
 
-Accepts the same options as `mern`.
+Accepts the same options as `mern` (including `--skipAgent`).
 
 ---
 

--- a/packages/nx-adsp/src/generators/express-service/schema.json
+++ b/packages/nx-adsp/src/generators/express-service/schema.json
@@ -60,6 +60,11 @@
           { "value": "mongo", "label": "MongoDB (Mongoose)" }
         ]
       }
+    },
+    "skipAgent": {
+      "type": "boolean",
+      "description": "Skip the consultAgent interaction and generate base scaffolding only.",
+      "default": false
     }
   },
   "required": [

--- a/packages/nx-adsp/src/generators/mean/mean.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.ts
@@ -38,7 +38,7 @@ export default async function (host: Tree, options: Schema) {
     skipAgent: true,
   });
 
-  if (normalizedOptions.adsp) {
+  if (normalizedOptions.adsp && !normalizedOptions.skipAgent) {
     // Single conversation covering the full stack. Files from both projects are
     // uploaded with service/ and app/ prefixes so the agent can write to both,
     // and are routed to the correct project root when applied.

--- a/packages/nx-adsp/src/generators/mean/schema.d.ts
+++ b/packages/nx-adsp/src/generators/mean/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   accessToken?: string;
   tenant?: string;
   tenantRealm?: string;
+  skipAgent?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/mean/schema.json
+++ b/packages/nx-adsp/src/generators/mean/schema.json
@@ -30,6 +30,11 @@
     "accessToken": {
       "type": "string",
       "description": "Access token for ADSP tenant configuration (skips interactive login)."
+    },
+    "skipAgent": {
+      "type": "boolean",
+      "description": "Skip the consultAgent interaction and generate base scaffolding only.",
+      "default": false
     }
   },
   "required": ["name"]

--- a/packages/nx-adsp/src/generators/mern/mern.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.ts
@@ -38,7 +38,7 @@ export default async function (host: Tree, options: Schema) {
     skipAgent: true,
   });
 
-  if (normalizedOptions.adsp) {
+  if (normalizedOptions.adsp && !normalizedOptions.skipAgent) {
     // Single conversation covering the full stack. Files from both projects are
     // uploaded with service/ and app/ prefixes so the agent can write to both,
     // and are routed to the correct project root when applied.

--- a/packages/nx-adsp/src/generators/mern/schema.d.ts
+++ b/packages/nx-adsp/src/generators/mern/schema.d.ts
@@ -6,6 +6,7 @@ export interface Schema {
   accessToken?: string;
   tenant?: string;
   tenantRealm?: string;
+  skipAgent?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/mern/schema.json
+++ b/packages/nx-adsp/src/generators/mern/schema.json
@@ -45,6 +45,11 @@
       "type": "string",
       "description": "Access token for retrieving configuration from ADSP APIs.",
       "alias": "at"
+    },
+    "skipAgent": {
+      "type": "boolean",
+      "description": "Skip the consultAgent interaction and generate base scaffolding only.",
+      "default": false
     }
   },
   "required": [


### PR DESCRIPTION
## Summary

- Adds `--skipAgent` CLI option to `express-service`, `mern`, and `mean` generators
- `express-service/schema.json` had `additionalProperties: false` so the flag was silently rejected at the CLI even though the TypeScript interface already had `skipAgent?: boolean`
- `mern` and `mean` consultAgent blocks are now gated on `!skipAgent` — same as express-service already was
- `mern/schema.d.ts` and `mean/schema.d.ts` updated to include `skipAgent?: boolean`
- Docs updated for all three generators

## Test plan

- [ ] `npx nx g @abgov/nx-adsp:express-service test-svc --env dev --tenant autotest --skipAgent` — generator completes without prompting for agent interaction
- [ ] `npx nx g @abgov/nx-adsp:mern test-app --env dev --tenant autotest --skipAgent` — same for fullstack
- [ ] Without `--skipAgent`, agent interaction still triggers as before
- [ ] `npx nx build nx-adsp` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)