### PR TITLE
fix(nx-adsp): use SDK Express.User augmentation instead of cast in private route

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -98,8 +98,7 @@ async function initializeApp() {
     '/<%= projectName %>/v1/private',
     passport.authenticate(['tenant'], { session: false }),
     (req, res) => {
-      const user = req.user as { name?: string } | undefined;
-      res.json({ message: `Hello, ${user?.name ?? 'authenticated user'}.` });
+      res.json({ message: `Hello, ${req.user!.name}.` });
     }
   );
 


### PR DESCRIPTION
## Summary

- The `adsp-service-sdk` already augments `Express.User` via `declare global { namespace Express { interface User extends BaseUser {} } }` in its access module
- `req.user` is therefore typed as the ADSP `User` (with `name: string`) whenever the SDK is imported — no manual cast is needed
- Replaced `req.user as { name?: string } | undefined` and the dead `?? 'authenticated user'` fallback with `req.user!.name` in the generated private route handler
- Verified with `tsc --noEmit` against a project with `@abgov/adsp-service-sdk` installed — no type errors

## Test plan

- [ ] Run the express-service or mern/mean generator
- [ ] Confirm the generated `main.ts` private route compiles cleanly (`tsc --noEmit`)
- [ ] Sign in and call `GET /v1/private` — response includes the authenticated user's name

🤖 Generated with [Claude Code](https://claude.com/claude-code)