### PR TITLE
feat(nx-oc): automate pipeline secrets setup (GitHub + GHCR pull secret)

### DIFF
--- a/packages/nx-oc/generators.json
+++ b/packages/nx-oc/generators.json
@@ -13,6 +13,11 @@
       "schema": "./src/generators/apply-infra/schema.json",
       "description": "Generator that applies OpenShift manifests for pipeline."
     },
+    "setup-secrets": {
+      "factory": "./src/generators/setup-secrets/setup-secrets",
+      "schema": "./src/generators/setup-secrets/schema.json",
+      "description": "Sets GitHub Actions secrets and OpenShift GHCR pull secret for the pipeline."
+    },
     "deployment": {
       "factory": "./src/generators/deployment/deployment",
       "schema": "./src/generators/deployment/schema.json",

--- a/packages/nx-oc/src/generators/pipeline/pipeline.ts
+++ b/packages/nx-oc/src/generators/pipeline/pipeline.ts
@@ -1,8 +1,9 @@
 import { formatFiles, generateFiles, Tree } from '@nx/devkit';
 import * as path from 'path';
 import { pipelineEnvs as envs } from '../../pipeline-envs';
-import { getGitRemoteUrl } from '../../utils/git-utils';
+import { deriveRegistryFromRemote, getGitRemoteUrl } from '../../utils/git-utils';
 import applyInfraGenerator from '../apply-infra/apply-infra';
+import setupSecretsGenerator from '../setup-secrets/setup-secrets';
 import { NormalizedSchema, Schema } from './schema';
 
 function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
@@ -19,12 +20,33 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
 
   return {
     ...options,
+    registry: options.registry ?? '',
     ocPipelineName: options.pipeline,
     ocInfraProject: options.infra,
     ocEnvProjects: ocEnvProjects,
     applyPipeline: !!options.apply,
     pipelineType: options.type === 'jenkins' ? 'jenkins' : 'actions',
   };
+}
+
+// Resolves the container registry: CLI flag → derived from git remote → prompted.
+async function resolveRegistry(registry?: string): Promise<string> {
+  if (registry) return registry;
+
+  const remoteUrl = getGitRemoteUrl()?.trim();
+  const derived = deriveRegistryFromRemote(remoteUrl);
+  if (derived) {
+    console.log(`\n✓ Container registry: ${derived} (derived from git remote)\n`);
+    return derived;
+  }
+
+  const { prompt } = await import('enquirer');
+  const answer = await prompt<{ registry: string }>({
+    type: 'input',
+    name: 'registry',
+    message: 'What container registry should images be published to (e.g., ghcr.io/my-org)?',
+  });
+  return answer.registry;
 }
 
 function addFiles(host: Tree, options: NormalizedSchema) {
@@ -63,12 +85,24 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 }
 
 export default async function (host: Tree, options: Schema) {
-  const normalizedOptions = normalizeOptions(host, options);
+  const registry = await resolveRegistry(options.registry);
+  const normalizedOptions = normalizeOptions(host, { ...options, registry });
 
   addFiles(host, normalizedOptions);
   await formatFiles(host);
 
   if (normalizedOptions.applyPipeline) {
     await applyInfraGenerator(host);
+
+    const remoteUrl = getGitRemoteUrl()?.trim();
+    if (remoteUrl) {
+      await setupSecretsGenerator(host, { infra: normalizedOptions.ocInfraProject });
+    } else {
+      console.log(
+        '\n⚠  No git remote found — skipping GitHub secrets setup.\n' +
+        `   Push to GitHub first then run:\n` +
+        `   npx nx g @abgov/nx-oc:setup-secrets --infra ${normalizedOptions.ocInfraProject}\n`
+      );
+    }
   }
 }

--- a/packages/nx-oc/src/generators/pipeline/schema.d.ts
+++ b/packages/nx-oc/src/generators/pipeline/schema.d.ts
@@ -3,11 +3,12 @@ export interface Schema {
   type: string;
   infra: string;
   envs: string;
-  registry: string;
+  registry?: string;
   apply?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {
+  registry: string;
   ocPipelineName: string;
   ocInfraProject: string;
   ocEnvProjects: string[];

--- a/packages/nx-oc/src/generators/pipeline/schema.json
+++ b/packages/nx-oc/src/generators/pipeline/schema.json
@@ -37,9 +37,8 @@
     },
     "registry": {
       "type": "string",
-      "description": "Container registry to publish images to (e.g., ghcr.io/my-org).",
-      "alias": "r",
-      "x-prompt": "What container registry should images be published to (e.g., ghcr.io/my-org)?"
+      "description": "Container registry to publish images to (e.g., ghcr.io/my-org). Derived from the git remote when not provided.",
+      "alias": "r"
     },
     "apply": {
       "type": "boolean",
@@ -52,8 +51,7 @@
     "pipeline",
     "infra",
     "type",
-    "envs",
-    "registry"
+    "envs"
   ],
   "additionalProperties": false
 }

--- a/packages/nx-oc/src/generators/setup-secrets/schema.d.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/schema.d.ts
@@ -1,0 +1,3 @@
+export interface Schema {
+  infra: string;
+}

--- a/packages/nx-oc/src/generators/setup-secrets/schema.json
+++ b/packages/nx-oc/src/generators/setup-secrets/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxOcSetupSecrets",
+  "title": "Setup Pipeline Secrets",
+  "type": "object",
+  "properties": {
+    "infra": {
+      "type": "string",
+      "description": "Name of the OpenShift infra project containing the github-actions service account.",
+      "alias": "i",
+      "x-prompt": "What is the OpenShift infra project?"
+    }
+  },
+  "required": ["infra"],
+  "additionalProperties": false
+}

--- a/packages/nx-oc/src/generators/setup-secrets/setup-secrets.spec.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/setup-secrets.spec.ts
@@ -1,0 +1,78 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import * as ocUtils from '../../utils/oc-utils';
+import * as ghUtils from '../../utils/gh-utils';
+import * as gitUtils from '../../utils/git-utils';
+import { Schema } from './schema';
+import generator from './setup-secrets';
+
+jest.mock('../../utils/oc-utils');
+jest.mock('../../utils/gh-utils');
+jest.mock('../../utils/git-utils');
+jest.mock('enquirer', () => ({
+  prompt: jest.fn().mockResolvedValue({ pat: 'test-pat' }),
+}));
+
+const ocMock = ocUtils as jest.Mocked<typeof ocUtils>;
+const ghMock = ghUtils as jest.Mocked<typeof ghUtils>;
+const gitMock = gitUtils as jest.Mocked<typeof gitUtils>;
+
+describe('Setup Secrets Generator', () => {
+  const options: Schema = { infra: 'my-infra' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ocMock.ensureOcLogin.mockImplementation(() => undefined);
+    ocMock.getOcServerUrl.mockReturnValue('https://api.example.com:6443');
+    ocMock.getSaToken.mockReturnValue('test-sa-token');
+    ocMock.createDockerRegistrySecret.mockReturnValue(true);
+    ocMock.linkSecretToServiceAccount.mockReturnValue(true);
+    ghMock.checkGhCli.mockImplementation(() => undefined);
+    ghMock.setGhSecret.mockReturnValue(true);
+    gitMock.getGitRemoteUrl.mockReturnValue('https://github.com/GovAlta/nx-tools.git');
+    gitMock.getGitHubRepo.mockReturnValue('GovAlta/nx-tools');
+    gitMock.deriveRegistryFromRemote.mockReturnValue('ghcr.io/GovAlta');
+  });
+
+  it('sets GitHub secrets and creates GHCR pull secret', async () => {
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, options);
+
+    expect(ghMock.setGhSecret).toHaveBeenCalledWith('OPENSHIFT_SERVER', 'https://api.example.com:6443', 'GovAlta/nx-tools');
+    expect(ghMock.setGhSecret).toHaveBeenCalledWith('OPENSHIFT_TOKEN', 'test-sa-token', 'GovAlta/nx-tools');
+    expect(ocMock.createDockerRegistrySecret).toHaveBeenCalledWith(
+      'ghcr-pull-secret', 'ghcr.io', 'GovAlta', 'test-pat', 'my-infra'
+    );
+    expect(ocMock.linkSecretToServiceAccount).toHaveBeenCalledWith(
+      'ghcr-pull-secret', 'github-actions', 'my-infra'
+    );
+  });
+
+  it('skips secrets when no GitHub remote is found', async () => {
+    gitMock.getGitRemoteUrl.mockReturnValue(undefined);
+    gitMock.getGitHubRepo.mockReturnValue(undefined);
+
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, options);
+
+    expect(ghMock.setGhSecret).not.toHaveBeenCalled();
+    expect(ocMock.createDockerRegistrySecret).not.toHaveBeenCalled();
+  });
+
+  it('skips secrets when gh CLI is not available', async () => {
+    ghMock.checkGhCli.mockImplementation(() => { throw new Error('gh: not found'); });
+
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, options);
+
+    expect(ghMock.setGhSecret).not.toHaveBeenCalled();
+  });
+
+  it('skips GHCR secret when SA token cannot be retrieved', async () => {
+    ocMock.getSaToken.mockReturnValue(undefined);
+
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, options);
+
+    expect(ocMock.createDockerRegistrySecret).toHaveBeenCalled();
+  });
+});

--- a/packages/nx-oc/src/generators/setup-secrets/setup-secrets.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/setup-secrets.ts
@@ -1,0 +1,86 @@
+import { Tree } from '@nx/devkit';
+import {
+  createDockerRegistrySecret,
+  ensureOcLogin,
+  getOcServerUrl,
+  getSaToken,
+  linkSecretToServiceAccount,
+} from '../../utils/oc-utils';
+import { checkGhCli, setGhSecret } from '../../utils/gh-utils';
+import { deriveRegistryFromRemote, getGitHubRepo, getGitRemoteUrl } from '../../utils/git-utils';
+import { Schema } from './schema';
+
+export default async function (host: Tree, options: Schema) {
+  try {
+    ensureOcLogin();
+  } catch (e) {
+    console.log(e instanceof Error ? e.message : String(e));
+    return;
+  }
+
+  const remoteUrl = getGitRemoteUrl()?.trim();
+  const repo = getGitHubRepo(remoteUrl);
+
+  if (!repo) {
+    console.log(
+      '\n⚠  No GitHub remote found — skipping GitHub Actions secrets setup.\n' +
+      '   Push to GitHub first then re-run this generator.'
+    );
+    return;
+  }
+
+  try {
+    checkGhCli();
+  } catch (e) {
+    console.log(e instanceof Error ? e.message : String(e));
+    return;
+  }
+
+  console.log('\nSetting up pipeline secrets...');
+
+  const serverUrl = getOcServerUrl();
+  if (serverUrl) {
+    const ok = setGhSecret('OPENSHIFT_SERVER', serverUrl, repo);
+    console.log(ok ? '✓ OPENSHIFT_SERVER set' : '✗ Failed to set OPENSHIFT_SERVER');
+  } else {
+    console.log('⚠  Could not determine OpenShift server URL — set OPENSHIFT_SERVER manually.');
+  }
+
+  const saToken = getSaToken('github-actions', options.infra);
+  if (saToken) {
+    const ok = setGhSecret('OPENSHIFT_TOKEN', saToken, repo);
+    console.log(ok ? '✓ OPENSHIFT_TOKEN set' : '✗ Failed to set OPENSHIFT_TOKEN');
+  } else {
+    console.log('⚠  Could not retrieve github-actions token — set OPENSHIFT_TOKEN manually.');
+  }
+
+  const org = deriveRegistryFromRemote(remoteUrl)?.replace('ghcr.io/', '');
+  if (!org) {
+    console.log('⚠  Could not derive GitHub org from remote — create ghcr-pull-secret manually.');
+    return;
+  }
+
+  const { prompt } = await import('enquirer');
+  let pat: string;
+  try {
+    const answer = await prompt<{ pat: string }>({
+      type: 'password',
+      name: 'pat',
+      message: 'Enter a GitHub PAT with read:packages scope (for OpenShift image import):',
+    });
+    pat = answer.pat;
+  } catch {
+    return;
+  }
+
+  if (!pat) return;
+
+  const secretCreated = createDockerRegistrySecret('ghcr-pull-secret', 'ghcr.io', org, pat, options.infra);
+  if (secretCreated) {
+    console.log(`✓ ghcr-pull-secret created in ${options.infra}`);
+    const linked = linkSecretToServiceAccount('ghcr-pull-secret', 'github-actions', options.infra);
+    console.log(linked ? '✓ ghcr-pull-secret linked to github-actions service account' : '✗ Failed to link secret');
+  } else {
+    console.log(`✗ Failed to create ghcr-pull-secret in ${options.infra}`);
+  }
+}

--- a/packages/nx-oc/src/utils/gh-utils.spec.ts
+++ b/packages/nx-oc/src/utils/gh-utils.spec.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from 'child_process';
+import { mocked } from 'jest-mock';
+import { checkGhCli, setGhSecret } from './gh-utils';
+
+jest.mock('child_process');
+const mockedExecFileSync = mocked(execFileSync);
+
+describe('checkGhCli', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('does not throw when gh is authenticated', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from('Logged in to github.com'));
+    expect(() => checkGhCli()).not.toThrow();
+  });
+
+  it('throws a clear error when gh CLI is unavailable or unauthenticated', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('gh: command not found'); });
+    expect(() => checkGhCli()).toThrow('gh CLI is not installed or not authenticated');
+  });
+});
+
+describe('setGhSecret', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('returns true on success', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
+    expect(setGhSecret('OPENSHIFT_TOKEN', 'tok', 'GovAlta/nx-tools')).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['secret', 'set', 'OPENSHIFT_TOKEN', '--repo', 'GovAlta/nx-tools'],
+      expect.objectContaining({ input: Buffer.from('tok') })
+    );
+  });
+
+  it('returns false when gh command fails', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('gh: not found'); });
+    expect(setGhSecret('OPENSHIFT_TOKEN', 'tok', 'GovAlta/nx-tools')).toBe(false);
+  });
+});

--- a/packages/nx-oc/src/utils/gh-utils.ts
+++ b/packages/nx-oc/src/utils/gh-utils.ts
@@ -1,0 +1,23 @@
+import { execFileSync } from 'child_process';
+
+export function checkGhCli(): void {
+  try {
+    execFileSync('gh', ['auth', 'status'], { stdio: 'pipe' });
+  } catch {
+    throw new Error(
+      'gh CLI is not installed or not authenticated. Run `gh auth login` then re-try.'
+    );
+  }
+}
+
+export function setGhSecret(name: string, value: string, repo: string): boolean {
+  try {
+    execFileSync('gh', ['secret', 'set', name, '--repo', repo], {
+      input: Buffer.from(value),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/nx-oc/src/utils/git-utils.spec.ts
+++ b/packages/nx-oc/src/utils/git-utils.spec.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
 import { mocked } from 'jest-mock';
-import { getGitRemoteUrl } from './git-utils';
+import { getGitRemoteUrl, deriveRegistryFromRemote, getGitHubRepo } from './git-utils';
 
 jest.mock('child_process');
 const mockedExecSync = mocked(execSync);
@@ -30,5 +30,55 @@ describe('getGitRemoteUrl', () => {
 
     const url = getGitRemoteUrl();
     expect(url).toBeUndefined();
+  });
+});
+
+describe('deriveRegistryFromRemote', () => {
+  it('derives registry from HTTPS remote', () => {
+    expect(deriveRegistryFromRemote('https://github.com/GovAlta/nx-tools.git'))
+      .toBe('ghcr.io/GovAlta');
+  });
+
+  it('derives registry from SSH remote', () => {
+    expect(deriveRegistryFromRemote('git@github.com:GovAlta/nx-tools.git'))
+      .toBe('ghcr.io/GovAlta');
+  });
+
+  it('returns undefined for non-GitHub remote', () => {
+    expect(deriveRegistryFromRemote('https://gitlab.com/org/repo.git')).toBeUndefined();
+  });
+
+  it('returns undefined when remoteUrl is undefined', () => {
+    expect(deriveRegistryFromRemote(undefined)).toBeUndefined();
+  });
+
+  it('handles trailing newline from git output', () => {
+    expect(deriveRegistryFromRemote('https://github.com/GovAlta/nx-tools.git\n'))
+      .toBe('ghcr.io/GovAlta');
+  });
+});
+
+describe('getGitHubRepo', () => {
+  it('returns owner/repo from HTTPS remote', () => {
+    expect(getGitHubRepo('https://github.com/GovAlta/nx-tools.git'))
+      .toBe('GovAlta/nx-tools');
+  });
+
+  it('returns owner/repo from SSH remote', () => {
+    expect(getGitHubRepo('git@github.com:GovAlta/nx-tools.git'))
+      .toBe('GovAlta/nx-tools');
+  });
+
+  it('handles trailing newline from git output', () => {
+    expect(getGitHubRepo('https://github.com/GovAlta/nx-tools.git\n'))
+      .toBe('GovAlta/nx-tools');
+  });
+
+  it('returns undefined for non-GitHub remote', () => {
+    expect(getGitHubRepo('https://gitlab.com/org/repo.git')).toBeUndefined();
+  });
+
+  it('returns undefined when remoteUrl is undefined', () => {
+    expect(getGitHubRepo(undefined)).toBeUndefined();
   });
 });

--- a/packages/nx-oc/src/utils/git-utils.ts
+++ b/packages/nx-oc/src/utils/git-utils.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process'
 export function getGitRemoteUrl(): string | undefined {
   try {
     const stdout = execSync(
-      "git config --get remote.origin.url", 
+      "git config --get remote.origin.url",
       { stdio: "pipe" }
     ).toString()
 
@@ -11,4 +11,25 @@ export function getGitRemoteUrl(): string | undefined {
   } catch (e) {
     console.log(`Failed to execute git`, e)
   }
+}
+
+// Parses a GitHub remote URL and returns the ghcr.io registry for the org.
+// Handles both HTTPS (https://github.com/ORG/REPO.git) and
+// SSH (git@github.com:ORG/REPO.git) formats.
+export function deriveRegistryFromRemote(remoteUrl?: string): string | undefined {
+  if (!remoteUrl) return undefined;
+  const url = remoteUrl.trim();
+  const httpsMatch = url.match(/https:\/\/github\.com\/([^/]+)\//);
+  const sshMatch   = url.match(/git@github\.com:([^/]+)\//);
+  const org = httpsMatch?.[1] ?? sshMatch?.[1];
+  return org ? `ghcr.io/${org}` : undefined;
+}
+
+// Returns the "owner/repo" slug for use with `gh secret set --repo`.
+export function getGitHubRepo(remoteUrl?: string): string | undefined {
+  if (!remoteUrl) return undefined;
+  const url = remoteUrl.trim();
+  const httpsMatch = url.match(/https:\/\/github\.com\/(.+?)(?:\.git)?\s*$/);
+  const sshMatch   = url.match(/git@github\.com:(.+?)(?:\.git)?\s*$/);
+  return httpsMatch?.[1] ?? sshMatch?.[1];
 }

--- a/packages/nx-oc/src/utils/oc-utils.spec.ts
+++ b/packages/nx-oc/src/utils/oc-utils.spec.ts
@@ -1,6 +1,13 @@
 import { execFileSync, spawnSync } from 'child_process';
 import { mocked } from 'jest-mock';
-import { ensureOcLogin, runOcCommand } from './oc-utils';
+import {
+  ensureOcLogin,
+  runOcCommand,
+  getOcServerUrl,
+  getSaToken,
+  createDockerRegistrySecret,
+  linkSecretToServiceAccount,
+} from './oc-utils';
 
 jest.mock('child_process');
 const mockedExecFileSync = mocked(execFileSync);
@@ -124,5 +131,83 @@ describe('ensureOcLogin', () => {
     mockedSpawnSync.mockReturnValue(SPAWN_FAIL);
 
     expect(() => ensureOcLogin()).toThrow('OpenShift login failed or was cancelled');
+  });
+});
+
+describe('getOcServerUrl', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('returns the server URL from kubeconfig', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from('https://api.example.com:6443'));
+    expect(getOcServerUrl()).toBe('https://api.example.com:6443');
+  });
+
+  it('returns undefined when oc command fails', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('no config'); });
+    expect(getOcServerUrl()).toBeUndefined();
+  });
+});
+
+describe('getSaToken', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('returns token from oc create token', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from('eyJhbGciOi...'));
+    expect(getSaToken('github-actions', 'my-infra')).toBe('eyJhbGciOi...');
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'oc', ['create', 'token', 'github-actions', '-n', 'my-infra', '--duration=8760h'],
+      expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+
+  it('falls back to oc sa get-token when create token fails', () => {
+    mockedExecFileSync.mockImplementationOnce(() => { throw new Error('unsupported'); }); // oc create token
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('legacy-token'));                  // oc sa get-token
+    expect(getSaToken('github-actions', 'my-infra')).toBe('legacy-token');
+  });
+
+  it('returns undefined when both commands fail', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('not found'); });
+    expect(getSaToken('github-actions', 'my-infra')).toBeUndefined();
+  });
+});
+
+describe('createDockerRegistrySecret', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('returns true on success', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from('secret/ghcr-pull-secret created'));
+    expect(createDockerRegistrySecret('ghcr-pull-secret', 'ghcr.io', 'org', 'pat', 'my-infra')).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'oc',
+      ['create', 'secret', 'docker-registry', 'ghcr-pull-secret',
+       '--docker-server=ghcr.io', '--docker-username=org', '--docker-password=pat',
+       '-n', 'my-infra'],
+      expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+
+  it('returns false when oc command fails', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('already exists'); });
+    expect(createDockerRegistrySecret('ghcr-pull-secret', 'ghcr.io', 'org', 'pat', 'my-infra')).toBe(false);
+  });
+});
+
+describe('linkSecretToServiceAccount', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('returns true on success', () => {
+    mockedExecFileSync.mockReturnValue(Buffer.from(''));
+    expect(linkSecretToServiceAccount('ghcr-pull-secret', 'github-actions', 'my-infra')).toBe(true);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'oc',
+      ['secrets', 'link', 'github-actions', 'ghcr-pull-secret', '--for=pull', '-n', 'my-infra'],
+      expect.objectContaining({ stdio: 'pipe' })
+    );
+  });
+
+  it('returns false when oc command fails', () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error('not found'); });
+    expect(linkSecretToServiceAccount('ghcr-pull-secret', 'github-actions', 'my-infra')).toBe(false);
   });
 });

--- a/packages/nx-oc/src/utils/oc-utils.ts
+++ b/packages/nx-oc/src/utils/oc-utils.ts
@@ -1,5 +1,71 @@
 import { execFileSync, spawnSync } from 'child_process';
 
+export function getOcServerUrl(): string | undefined {
+  try {
+    return execFileSync(
+      'oc',
+      ['config', 'view', '--minify', '-o', 'jsonpath={.clusters[0].cluster.server}'],
+      { stdio: 'pipe' }
+    ).toString().trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Creates a bounded SA token valid for one year (OCP 4.11+ TokenRequest API).
+// Falls back to the legacy `oc sa get-token` on older clusters.
+export function getSaToken(saName: string, namespace: string): string | undefined {
+  try {
+    return execFileSync(
+      'oc', ['create', 'token', saName, '-n', namespace, '--duration=8760h'],
+      { stdio: 'pipe' }
+    ).toString().trim() || undefined;
+  } catch {
+    try {
+      return execFileSync(
+        'oc', ['sa', 'get-token', saName, '-n', namespace],
+        { stdio: 'pipe' }
+      ).toString().trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export function createDockerRegistrySecret(
+  name: string,
+  server: string,
+  username: string,
+  password: string,
+  namespace: string
+): boolean {
+  try {
+    execFileSync('oc', [
+      'create', 'secret', 'docker-registry', name,
+      `--docker-server=${server}`,
+      `--docker-username=${username}`,
+      `--docker-password=${password}`,
+      '-n', namespace,
+    ], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function linkSecretToServiceAccount(
+  secretName: string,
+  saName: string,
+  namespace: string
+): boolean {
+  try {
+    execFileSync('oc', ['secrets', 'link', saName, secretName, '--for=pull', '-n', namespace], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function runOcCommand(
   command: 'project' | 'start-build' | 'process' | 'apply',
   params: string[],


### PR DESCRIPTION
## Summary

- **`vue-app` generator** — Vue 3 frontend using GoA web components (`@abgov/web-components`) and `@dsb-norge/vue-keycloak-js` for Keycloak auth; `goa-*` custom elements wired via Vite `isCustomElement`
- **`pevn` generator** — composite PostgreSQL + Express + Vue + Node fullstack (Express + Prisma service, Vue 3 app, nginx + vite dev proxies wired automatically)
- **`mevn` generator** — same but MongoDB + Mongoose
- **Pipeline secrets automation** — `nx g @abgov/nx-oc:setup-secrets` sets `OPENSHIFT_SERVER` and `OPENSHIFT_TOKEN` via `gh` CLI and creates the GHCR pull secret in the infra namespace; runs automatically after `pipeline --apply` when a GitHub remote is present; container registry derived from git remote so `--registry` flag is no longer required
- **Docs** — prerequisites table and generator sections updated in `docs/nx-adsp/nx-adsp.md`

## Test plan

- [ ] Unit tests pass: `nx test nx-adsp` (34 tests), `nx test nx-oc` (69 tests)
- [ ] PEVN and MEVN generators scaffold correctly and Vue app builds
- [ ] `pipeline --apply` sets GitHub secrets and GHCR pull secret without manual steps
- [ ] `setup-secrets` standalone retry path works for existing pipelines
- [ ] Registry is derived from git remote when `--registry` is omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)