### PR TITLE
feat(nx-oc): add liveness and readiness probes to deployment manifests

### DIFF
--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -90,6 +90,10 @@ describe('Deployment Generator', () => {
 
     const dockerfile = host.read('.openshift/test/Dockerfile').toString();
     expect(dockerfile).toContain('nginx');
+
+    const manifest = host.read('.openshift/test/test.yml').toString();
+    expect(manifest).toContain('readinessProbe');
+    expect(manifest).toContain('livenessProbe');
   });
 
   it('can generate deployment for angular', async () => {
@@ -150,6 +154,10 @@ describe('Deployment Generator', () => {
 
     const dockerfile = host.read('.openshift/test/Dockerfile').toString();
     expect(dockerfile).toContain('node');
+
+    const manifest = host.read('.openshift/test/test.yml').toString();
+    expect(manifest).toContain('readinessProbe');
+    expect(manifest).toContain('livenessProbe');
   });
 
   it('can generate deployment for dotnet', async () => {
@@ -178,6 +186,10 @@ describe('Deployment Generator', () => {
 
     const dockerfile = host.read('.openshift/test/Dockerfile').toString();
     expect(dockerfile).toContain('dotnet');
+
+    const manifest = host.read('.openshift/test/test.yml').toString();
+    expect(manifest).toContain('readinessProbe');
+    expect(manifest).toContain('livenessProbe');
   });
 
   it('includes DATABASE_URL secretKeyRef and init container for postgres node deployment', async () => {

--- a/packages/nx-oc/src/generators/deployment/dotnet-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/dotnet-files/__projectName__.yml__tmpl__
@@ -112,6 +112,20 @@ objects:
                 requests:
                   cpu: 20m
                   memory: 200Mi
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: 5000
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                failureThreshold: 3
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 5000
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                failureThreshold: 3
               volumeMounts:
                 - mountPath: /opt/app-root/app/appsettings.json
                   name: config-volume

--- a/packages/nx-oc/src/generators/deployment/frontend-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/frontend-files/__projectName__.yml__tmpl__
@@ -96,6 +96,20 @@ objects:
                 requests:
                   cpu: 20m
                   memory: 50Mi
+              readinessProbe:
+                httpGet:
+                  path: /
+                  port: 8080
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                failureThreshold: 3
+              livenessProbe:
+                httpGet:
+                  path: /
+                  port: 8080
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                failureThreshold: 3
               volumeMounts:
                 - mountPath: /opt/app-root/src/config
                   name: config-volume

--- a/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
@@ -128,6 +128,20 @@ objects:
                 requests:
                   cpu: 20m
                   memory: 50Mi
+              readinessProbe:
+                httpGet:
+                  path: /health
+                  port: 3333
+                initialDelaySeconds: 10
+                periodSeconds: 10
+                failureThreshold: 3
+              livenessProbe:
+                httpGet:
+                  path: /health
+                  port: 3333
+                initialDelaySeconds: 30
+                periodSeconds: 30
+                failureThreshold: 3
   - apiVersion: v1
     kind: Service
     metadata:


### PR DESCRIPTION
## Summary

- Adds `readinessProbe` and `livenessProbe` to all three generated Deployment templates (node, frontend, dotnet)
- Node and .NET probe `GET /health` on their respective container ports (3333 / 5000)
- Nginx frontend probes `GET /` on port 8080
- All probes use `initialDelaySeconds: 10/30`, `periodSeconds: 10/30`, `failureThreshold: 3`
- Adds probe-presence assertions to the deployment generator unit tests

## Test plan

- [x] `npx nx test nx-oc --testFile=packages/nx-oc/src/generators/deployment/deployment.spec.ts` — all 8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)