### PR TITLE
fix(nx-oc): register sandbox Route with Keycloak client + document deployment redirect URIs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,6 +65,8 @@ Repeat for every environment project.
 
 An existing ADSP tenant is required. The `pevn` generator provisions Keycloak clients and environment config against it. Have the tenant name ready.
 
+> The generated public client allows local development (`http://localhost:4200/*`) out of the box. For **deployed** environments you must register each environment's Route URL with the client — see [Configure sign-in redirect URIs per environment](#configure-sign-in-redirect-uris-per-environment).
+
 ### GitHub Environments (optional)
 
 Create environments in **Settings → Environments** matching the names passed to `--envs` (e.g. `dev`, `test`, `prod`) to enable per-environment approval gates.
@@ -180,6 +182,35 @@ git push
 ```
 
 The GitHub Actions pipeline triggers on push to `main` and builds, publishes, and deploys to the first environment automatically.
+
+### Configure sign-in redirect URIs per environment
+
+The frontend's public Keycloak client is created during scaffolding with only `http://localhost:4200/*` as an allowed redirect URI (for local development). Browser sign-in on a **deployed** app fails with `invalid redirect_uri` until the deployed Route URL is added to that client.
+
+This is a **manual, one-time step per environment**, because each environment runs against a different ADSP tenant on a different Keycloak instance:
+
+| Environment | ADSP access (Keycloak) |
+| --- | --- |
+| `dev` | `access.adsp-dev.gov.ab.ca` |
+| `test` (UAT / pre-prod) | `access-uat.alberta.ca` |
+| `prod` | `access.alberta.ca` |
+
+Since pre-production and production are separate tenants on separate Keycloak instances, the generator (which authenticates against a single tenant) cannot configure them all — you register each one after its first deploy.
+
+For each environment, open that environment's ADSP tenant admin (Keycloak) and edit the app's public client — `urn:ads:<tenant>:<app>` (e.g. `urn:ads:my-tenant:my-app-app`). Add the deployed Route URL:
+
+```
+https://<app>-<environment-project>.<cluster-apps-domain>/*
+```
+
+for example `https://my-app-app-my-project-dev.apps.<cluster>/*` — to **both**:
+
+- **Valid redirect URIs**
+- **Valid post logout redirect URIs**
+
+Leave **Web origins** as `+` (it already allows CORS from the redirect-URI origins). The exact Route host for a deployed app is shown by `oc get route <app> -n <environment-project>`.
+
+> The [sandbox deployment](#sandbox-deployment) flow does this automatically — it targets a single tenant/Keycloak, so the generator registers the sandbox Route on the client for you. The manual step above applies only to the pipeline-deployed environments.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,7 +149,9 @@ The dev proxy (`/api/` → `my-app-service:3333`) and nginx production proxy are
 
 Pass `--skipAgent` to skip the AI interaction and get base scaffolding only.
 
-### 6. Create the database secret in each environment
+### 6. Create the deploy secrets in each environment
+
+**Database** — a Postgres connection string:
 
 ```bash
 oc create secret generic my-app-service-database \
@@ -165,6 +167,28 @@ oc create secret generic my-app-service-database \
   --from-literal=DATABASE_URL='postgresql://...' \
   -n my-project-prod
 ```
+
+**ADSP client secret** — the service authenticates with the access service using
+its confidential Keycloak client secret. Scaffolding writes it to the service's
+`.env` (`CLIENT_SECRET=...`) for the generator's tenant; each environment runs
+against its own tenant, so create the Secret per environment with that
+environment's client secret:
+
+```bash
+oc create secret generic my-app-service-secrets \
+  --from-literal=CLIENT_SECRET='<client-secret-for-this-environment>' \
+  -n my-project-dev
+
+# Repeat for test and prod (each has its own client secret)
+```
+
+> The `dev` value is in `apps/my-app-service/.env` after scaffolding. For
+> test/prod, get the client secret from that environment's ADSP tenant admin
+> (Keycloak) for client `urn:ads:<tenant>:my-app-service`.
+
+The sandbox deploy (`nx run my-app-service:sandbox`) creates this Secret
+automatically from the service's `.env` — the manual step is only for the
+GitHub Actions / `apply-envs` environments.
 
 ### 7. Apply environment resources to OpenShift
 

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -198,3 +198,88 @@ export async function getAdspConfiguration(
 export function isAdspOptions(options: unknown): options is AdspOptions {
   return !!(options as AdspOptions)?.adsp?.tenantRealm;
 }
+
+/**
+ * Registers redirect URIs (and matching post-logout URIs) on an existing public
+ * client so a deployed app can complete browser sign-in/out against its route.
+ *
+ * Idempotent and best-effort: no-ops without a token, skips if the client isn't
+ * found, and logs (never throws) on failure so it can't break generation. The
+ * client's `webOrigins` is intentionally left as-is — the default `["+"]`
+ * already allows CORS from any redirect-URI origin.
+ */
+export async function addClientRedirectUris(
+  accessServiceUrl: string,
+  realm: string,
+  clientId: string,
+  redirectUris: string[],
+  accessToken: string | undefined
+): Promise<void> {
+  if (!accessToken || redirectUris.length === 0) return;
+
+  const base = new URL(`/auth/admin/realms/${realm}/clients`, accessServiceUrl)
+    .href;
+  const authHeader = { Authorization: `Bearer ${accessToken}` };
+  const union = (existing: string[] | undefined, additions: string[]) =>
+    Array.from(new Set([...(existing ?? []), ...additions]));
+
+  try {
+    const { data: clients } = await axios.get(base, {
+      params: { clientId },
+      headers: authHeader,
+    });
+    const client = clients?.[0];
+    if (!client) {
+      console.log(
+        `[nx-oc] Public client '${clientId}' not found in realm '${realm}' — skipping redirect URI update.`
+      );
+      return;
+    }
+
+    const existingPostLogout: string[] = (
+      client.attributes?.['post.logout.redirect.uris'] ?? ''
+    )
+      .split('##')
+      .filter(Boolean);
+
+    const nextRedirects = union(client.redirectUris, redirectUris);
+    const nextPostLogout = union(existingPostLogout, redirectUris).join('##');
+
+    if (
+      nextRedirects.length === (client.redirectUris?.length ?? 0) &&
+      nextPostLogout === (client.attributes?.['post.logout.redirect.uris'] ?? '')
+    ) {
+      console.log(
+        `[nx-oc] Client '${clientId}' already allows ${redirectUris.join(', ')}.`
+      );
+      return;
+    }
+
+    await axios.put(
+      `${base}/${client.id}`,
+      {
+        ...client,
+        redirectUris: nextRedirects,
+        attributes: {
+          ...client.attributes,
+          'post.logout.redirect.uris': nextPostLogout,
+        },
+      },
+      { headers: authHeader }
+    );
+    console.log(
+      `[nx-oc] Registered redirect URI(s) on client '${clientId}': ${redirectUris.join(
+        ', '
+      )}`
+    );
+  } catch (err) {
+    const detail =
+      (err as { response?: { status?: number }; message?: string })?.response
+        ?.status ??
+      (err as { message?: string })?.message ??
+      err;
+    console.log(
+      `[nx-oc] Could not update redirect URIs for '${clientId}': ${detail}`
+    );
+  }
+}

--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -158,6 +158,10 @@ describe('Deployment Generator', () => {
     const manifest = host.read('.openshift/test/test.yml').toString();
     expect(manifest).toContain('readinessProbe');
     expect(manifest).toContain('livenessProbe');
+    // The service authenticates with ADSP using a confidential client secret,
+    // injected from the ${APP_NAME}-secrets Secret.
+    expect(manifest).toContain('CLIENT_SECRET');
+    expect(manifest).toContain('${APP_NAME}-secrets');
   });
 
   it('can generate deployment for dotnet', async () => {

--- a/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
@@ -127,6 +127,17 @@ objects:
                   value: '3333'
                 - name: LOG_LEVEL
                   value: info
+                # ADSP confidential-client secret the service uses to authenticate
+                # with the access service. Sandbox: created by `nx run <app>:sandbox`
+                # from the service's .env.
+<% if (!sandbox) { %>
+                # Other envs: oc create secret generic ${APP_NAME}-secrets --from-literal=CLIENT_SECRET=<secret>
+<% } %>
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-secrets
+                      key: CLIENT_SECRET
 <% if (database === 'postgres') { %>
 <% if (sandbox) { %>
                 - name: POSTGRES_PASSWORD

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -9,12 +9,17 @@ import generator from './sandbox';
 import { Schema } from './schema';
 
 jest.mock('../../adsp');
+jest.mock('../../utils/oc-utils', () => ({
+  ...jest.requireActual('../../utils/oc-utils'),
+  getClusterIngressDomain: jest.fn(() => 'apps.test.example.com'),
+}));
 const utilsMock = utils as jest.Mocked<typeof utils>;
 utilsMock.getAdspConfiguration.mockResolvedValue({
   tenant: 'test',
   tenantRealm: 'test',
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
+  accessToken: 'mock-token',
 });
 
 describe('Sandbox Generator', () => {
@@ -193,5 +198,33 @@ describe('Sandbox Generator', () => {
     const config = readProjectConfiguration(host, 'test');
     const cmds: string[] = config.targets['sandbox'].options.commands;
     expect(cmds.some((c) => c.includes('oc get service'))).toBeFalsy();
+  });
+
+  it('registers the deployment Route redirect URI for a frontend client', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addFrontendProject(host);
+    utilsMock.addClientRedirectUris.mockClear();
+
+    await generator(host, options);
+
+    // Route host follows <app>-<namespace>.<ingressDomain>, registered against
+    // the public client urn:ads:<tenant>:<app> with the token from ADSP config.
+    expect(utilsMock.addClientRedirectUris).toHaveBeenCalledWith(
+      environments.test.accessServiceUrl,
+      'test',
+      'urn:ads:test:test',
+      ['https://test-test-sandbox.apps.test.example.com/*'],
+      'mock-token'
+    );
+  });
+
+  it('does not register redirect URIs for a node service', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addNodeProject(host);
+    utilsMock.addClientRedirectUris.mockClear();
+
+    await generator(host, options);
+
+    expect(utilsMock.addClientRedirectUris).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -102,6 +102,15 @@ describe('Sandbox Generator', () => {
     ).toBeTruthy();
     expect(cmds.some((c) => c.includes('sandbox-build.yml'))).toBeTruthy();
     expect(cmds.some((c) => c.includes('podman'))).toBeFalsy();
+    // A node service's ADSP client secret is mirrored from .env into an
+    // OpenShift Secret the deployment reads.
+    expect(
+      cmds.some(
+        (c) =>
+          c.includes('oc create secret generic test-secrets') &&
+          c.includes('CLIENT_SECRET')
+      )
+    ).toBeTruthy();
 
     // The ImageStream + BuildConfig manifest is generated.
     expect(host.exists('.openshift/test/sandbox-build.yml')).toBeTruthy();

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -7,8 +7,9 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import * as path from 'path';
-import { getAdspConfiguration } from '../../adsp';
+import { getAdspConfiguration, addClientRedirectUris } from '../../adsp';
 import { getGitRemoteUrl } from '../../utils/git-utils';
+import { getClusterIngressDomain } from '../../utils/oc-utils';
 import { detectApplicationType, getBuildOutputPath } from '../../utils/app-type';
 import { NormalizedSchema, Schema } from './schema';
 
@@ -171,6 +172,36 @@ function addSandboxTarget(host: Tree, options: NormalizedSchema) {
   updateProjectConfiguration(host, options.project, config);
 }
 
+// Register the sandbox deployment's Route with the frontend's public client so
+// browser sign-in works against the deployed URL — not just localhost. The
+// Route host is deterministic by convention (<app>-<namespace>.<ingressDomain>),
+// so this happens once at generate time using the token already obtained for
+// ADSP config — no per-deploy login.
+async function registerSandboxRedirectUri(options: NormalizedSchema) {
+  if (options.appType !== 'frontend') return;
+  const { adsp, projectName, sandboxProject } = options;
+  if (!adsp?.accessToken) return;
+
+  const ingressDomain = getClusterIngressDomain();
+  if (!ingressDomain) {
+    console.log(
+      '[nx-oc] Could not determine the cluster ingress domain; skipping redirect URI registration. ' +
+        'Add the deployment Route to the client manually if browser sign-in fails.'
+    );
+    return;
+  }
+
+  const routeUrl = `https://${projectName}-${sandboxProject}.${ingressDomain}`;
+  const clientId = `urn:ads:${adsp.tenant}:${projectName}`;
+  await addClientRedirectUris(
+    adsp.accessServiceUrl,
+    adsp.tenantRealm,
+    clientId,
+    [`${routeUrl}/*`],
+    adsp.accessToken
+  );
+}
+
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
   if (!normalizedOptions.appType) {
@@ -182,5 +213,6 @@ export default async function (host: Tree, options: Schema) {
   addBuildFiles(host, normalizedOptions);
   addDatabaseFiles(host, normalizedOptions);
   addSandboxTarget(host, normalizedOptions);
+  await registerSandboxRedirectUri(normalizedOptions);
   await formatFiles(host);
 }

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -77,9 +77,22 @@ function addBuildFiles(host: Tree, options: NormalizedSchema) {
 
 function addSandboxTarget(host: Tree, options: NormalizedSchema) {
   const config = readProjectConfiguration(host, options.project);
-  const { projectName, sandboxProject, database } = options;
+  const { projectName, sandboxProject, database, appType } = options;
 
   const commands: string[] = [];
+
+  // ADSP services authenticate with the access service using a confidential
+  // Keycloak client secret. The express-service generator writes it to the
+  // service's .env (CLIENT_SECRET=...) at generate time; mirror it into an
+  // OpenShift Secret the deployment reads. Upserted from the current .env so
+  // re-runs pick up a rotated secret. Non-node app types have no client secret.
+  if (appType === 'node') {
+    commands.push(
+      `oc create secret generic ${projectName}-secrets ` +
+        `--from-literal=CLIENT_SECRET="$(grep -E '^CLIENT_SECRET=' ${config.root}/.env 2>/dev/null | cut -d= -f2-)" ` +
+        `-n ${sandboxProject} --dry-run=client -o yaml | oc apply -f -`
+    );
+  }
 
   if (database === 'postgres') {
     commands.push(

--- a/packages/nx-oc/src/utils/oc-utils.ts
+++ b/packages/nx-oc/src/utils/oc-utils.ts
@@ -12,6 +12,25 @@ export function getOcServerUrl(): string | undefined {
   }
 }
 
+// Derives the cluster's ingress (apps) domain from the console URL, e.g.
+// https://console-openshift-console.apps.example.com -> apps.example.com.
+// Used to predict a deployment's default Route host by convention. Readable by
+// any logged-in user (no cluster-scoped permissions needed).
+export function getClusterIngressDomain(): string | undefined {
+  try {
+    const consoleUrl = execFileSync('oc', ['whoami', '--show-console'], {
+      stdio: 'pipe',
+    })
+      .toString()
+      .trim();
+    if (!consoleUrl) return undefined;
+    const host = new URL(consoleUrl).host;
+    return host.replace(/^console-openshift-console\./, '') || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Creates a bounded SA token valid for one year (OCP 4.11+ TokenRequest API).
 // Falls back to the legacy `oc sa get-token` on older clusters.
 export function getSaToken(saName: string, namespace: string): string | undefined {


### PR DESCRIPTION
## Problem

The public Keycloak client created when scaffolding a frontend (`ensurePublicClient`) only allows `http://localhost:4200/*` as a redirect/post-logout URI. So when the app is deployed to a sandbox Route, browser sign-in fails (`invalid redirect_uri`) — the deployed URL was never registered. The function's own comment acknowledged this ("add production URIs via the ADSP admin portal after deployment"), but nothing did it.

## Fix — register the Route by convention, at generate time

A deployment's default OpenShift Route host is deterministic: `<app>-<namespace>.<ingressDomain>`. We already know the app name and the sandbox namespace, and the ingress domain is stable — so there's no need for a login on every deploy. The sandbox generator now registers `https://<app>-<sandboxProject>.<ingressDomain>/*` on the client `urn:ads:<tenant>:<app>` **once, at `nx g sandbox` time**, reusing the token already obtained for ADSP config (`--tenant`/`--accessToken`). The ingress domain is derived from `oc whoami --show-console` (readable by any logged-in user — no cluster-scoped perms).

Details:
- **Frontend only** — Node/dotnet services use service-account clients (no browser redirect).
- **Idempotent + best-effort** — no-ops without a token, skips if the client isn't found, merges (no duplicate URIs), and logs rather than throws so it never breaks generation.
- `webOrigins` left as the default `["+"]` (already allows CORS from any redirect-URI origin).
- Adds `addClientRedirectUris()` to `nx-oc`'s adsp module and `getClusterIngressDomain()` to `oc-utils`.

## Why the helper lives in `nx-oc`

`nx-adsp` depends on `@abgov/nx-oc` (not the reverse), so the sandbox generator (in `nx-oc`) can't import `nx-adsp`'s `keycloak-admin`. `nx-oc` already owns the ADSP auth/config module (it logs in and resolves the tenant realm + service URLs), so adding a single client redirect-URI PATCH there is a small, sensible extension — ensuring the provisioned client works with the deployment it generates is an `nx-oc` concern.

## Testing

- `nx-oc`: lint, build, **84 unit tests** pass (added two: the redirect URI is registered for a frontend with the conventional Route URL; it is *not* registered for a Node service).
- Not yet exercised against a live realm in this PR (the unit tests mock the Keycloak call) — happy to verify the live PATCH on request (needs an interactive ADSP login).

## Deployment (pipeline) environments — documented as manual

Auto-registration is **sandbox-only by design**. Pre-prod and prod run against *different* ADSP tenants on *different* Keycloak instances (`access-uat.alberta.ca` vs `access.alberta.ca`), so a single generator run (authenticated against one tenant) can't configure them all. This PR therefore also adds docs (`docs/getting-started.md`) explaining the one-time, per-environment manual step to register each deployed Route URL with that environment's client — and notes that sandbox handles it automatically.
