### PR TITLE
fix(nx-oc): package Dockerfile templates dropped by the asset glob

### DIFF
--- a/packages/nx-oc/project.json
+++ b/packages/nx-oc/project.json
@@ -39,6 +39,11 @@
             "output": "./src"
           },
           {
+            "input": "./packages/nx-oc/src",
+            "glob": "**/*__tmpl__",
+            "output": "./src"
+          },
+          {
             "input": "./packages/nx-oc",
             "glob": "generators.json",
             "output": "."


### PR DESCRIPTION
## Bug

Trying the freshly-released `@abgov/nx-oc@12.14.0` end-to-end surfaced this: a fresh `nx g @abgov/nx-oc:sandbox` (or `:deployment`) produces a BuildConfig that references `.openshift/<app>/Dockerfile`, but **no Dockerfile is written** — so the in-cluster build fails.

## Root cause

The build copies non-source assets with glob **`**/*.!(ts)`**, which only matches files with a **dotted** extension. PR #276 (dedupe Dockerfile templates) renamed:

- `Dockerfile.template` → `Dockerfile__tmpl__`

`Dockerfile.template` has a dot (`.template`) so it matched the glob and was packaged. `Dockerfile__tmpl__` has **no dot**, so `**/*.!(ts)` no longer matches it and it was silently dropped from the built package. Confirmed against published tarballs:

- `12.12.0` (pre-#276): ships `Dockerfile.template` ✅
- `12.14.0` (post-#276): ships **no** Dockerfile templates ❌

(`__projectName__.yml__tmpl__` kept working because it has a dotted `.yml__tmpl__`.)

## Fix

Add an explicit `**/*__tmpl__` asset glob so template files **without** a dotted extension are packaged too (additive — nothing currently shipped changes). The only dotless templates in the repo are the three `Dockerfile__tmpl__` (node/frontend/dotnet).

## Verification

Rebuilt and packed `dist/packages/nx-oc`; the tarball now contains:

```
package/src/generators/deployment/node-files/Dockerfile__tmpl__
package/src/generators/deployment/frontend-files/Dockerfile__tmpl__
package/src/generators/deployment/dotnet-files/Dockerfile__tmpl__
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)