### PR TITLE
test(nx-adsp-e2e): verify sandbox generator emits Dockerfile + manifests

### DIFF
--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -38,6 +38,15 @@ function setupE2eWorkspace(mockUrl: string) {
   });
   // npm caches file: deps by tarball hash and may install a stale compiled version.
   // Directly overwrite environments.js so the generator always uses the mock URLs.
+  writeMockEnvironments(mockUrl);
+}
+
+// Overwrite @abgov/nx-oc's compiled environments.js so ADSP calls hit the mock
+// server. Generators that finish with installPackagesTask reinstall the file:
+// dep and restore the real URLs, so this must be re-applied before any later
+// generate that resolves ADSP config (e.g. the sandbox generator run after an
+// app generate).
+function writeMockEnvironments(mockUrl: string) {
   writeFileSync(
     join(tmpProjPath(), 'node_modules/@abgov/nx-oc/src/adsp/environments.js'),
     `"use strict";
@@ -176,6 +185,9 @@ describe('nx-adsp e2e', () => {
       await runNxCommandAsync(
         `generate @abgov/nx-adsp:express-service ${svc} dev --tenant=test --accessToken=mock-token --skipAgent --database=none`
       );
+      // The app generate reinstalls @abgov/nx-oc (installPackagesTask), restoring
+      // the real ADSP URLs — re-point them at the mock before the sandbox generate.
+      writeMockEnvironments(mockUrl);
       await runNxCommandAsync(
         `generate @abgov/nx-oc:sandbox ${svc} --sandboxProject=test-build --tenant=test --accessToken=mock-token`
       );
@@ -196,6 +208,7 @@ describe('nx-adsp e2e', () => {
       await runNxCommandAsync(
         `generate @abgov/nx-adsp:vue-app ${app} dev --tenant=test --accessToken=mock-token --skipAgent`
       );
+      writeMockEnvironments(mockUrl);
       await runNxCommandAsync(
         `generate @abgov/nx-oc:sandbox ${app} --sandboxProject=test-build --tenant=test --accessToken=mock-token`
       );

--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -1,7 +1,7 @@
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { AddressInfo } from 'net';
 import { execSync } from 'child_process';
-import { mkdirSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import {
   checkFilesExist,
@@ -162,6 +162,53 @@ describe('nx-adsp e2e', () => {
       );
       checkFilesExist(`${plugin}/src/main.ts`);
     }, 90000);
+  });
+
+  // Runs the nx-oc sandbox generator against the *installed* plugin (dist), not
+  // the source tree, so it guards template files that only exist as packaged
+  // assets — e.g. the Dockerfile templates, which a dist packaging bug once
+  // dropped without any test noticing (the BuildConfig referenced a Dockerfile
+  // that was never written). Behaviour, not dist layout: the manifests must
+  // actually be produced.
+  describe('sandbox deployment', () => {
+    it('writes a Dockerfile and manifests for a node service', async () => {
+      const svc = uniq('sbx-svc');
+      await runNxCommandAsync(
+        `generate @abgov/nx-adsp:express-service ${svc} dev --tenant=test --accessToken=mock-token --skipAgent --database=none`
+      );
+      await runNxCommandAsync(
+        `generate @abgov/nx-oc:sandbox ${svc} --sandboxProject=test-build --tenant=test --accessToken=mock-token`
+      );
+      checkFilesExist(
+        `.openshift/${svc}/Dockerfile`,
+        `.openshift/${svc}/${svc}.yml`,
+        `.openshift/${svc}/sandbox-build.yml`
+      );
+      const dockerfile = readFileSync(
+        join(tmpProjPath(), `.openshift/${svc}/Dockerfile`),
+        'utf-8'
+      );
+      expect(dockerfile).toContain('node');
+    }, 180000);
+
+    it('writes a Dockerfile and manifests for a frontend app', async () => {
+      const app = uniq('sbx-app');
+      await runNxCommandAsync(
+        `generate @abgov/nx-adsp:vue-app ${app} dev --tenant=test --accessToken=mock-token --skipAgent`
+      );
+      await runNxCommandAsync(
+        `generate @abgov/nx-oc:sandbox ${app} --sandboxProject=test-build --tenant=test --accessToken=mock-token`
+      );
+      checkFilesExist(
+        `.openshift/${app}/Dockerfile`,
+        `.openshift/${app}/${app}.yml`
+      );
+      const dockerfile = readFileSync(
+        join(tmpProjPath(), `.openshift/${app}/Dockerfile`),
+        'utf-8'
+      );
+      expect(dockerfile).toContain('nginx');
+    }, 180000);
   });
 
   describe('react app', () => {


### PR DESCRIPTION
## Why

The Dockerfile packaging regression (PR #278) shipped despite existing tests because of a **test-layer gap**, not missing assertions:

- **Unit tests** (`deployment.spec.ts`, `sandbox.spec.ts`) *do* assert `.openshift/<app>/Dockerfile` exists — but generators resolve templates via `path.join(__dirname, ...)`, which under jest points at the **source tree**, where `Dockerfile__tmpl__` is always present. They validate generator *logic*, not *packaging*.
- **e2e** installs the **built package** (the layer where the asset was dropped) — but no e2e ever ran a generator that emits a Dockerfile (`deployment` self-skips without pipeline setup; `sandbox` was never invoked).

So the one file whose presence depends on packaging was checked only where packaging isn't exercised.

## What

Behavioural e2e (checks generator *output*, not dist layout) that runs `@abgov/nx-oc:sandbox` against the **installed** plugin for:
- a **node** service → asserts `Dockerfile` + `<app>.yml` + `sandbox-build.yml`, Dockerfile contains `node`
- a **frontend** app → asserts `Dockerfile` + `<app>.yml`, Dockerfile contains `nginx`

This crosses the source→package boundary and would have caught the regression regardless of *how* templates are packaged. `:sandbox` is self-contained (emits the manifests itself, no pipeline/`oc`/cluster needed for these app types), and runs against the mock ADSP server already used by the suite.

## Note

Validated locally by running the exact `nx-oc:sandbox` invocation by hand (produced the Dockerfile + manifests). The full `nx e2e` couldn't run in my local env due to a pre-existing `@nx/angular` 22-vs-23 version skew that breaks `nx build nx-adsp` locally (CI builds cleanly via `npm ci`), so CI is the source of truth for this run.

## Known remaining e2e gaps (same class)

- **dotnet Dockerfile** (`dotnet-files/Dockerfile__tmpl__`) — dropped by the same bug, still no e2e (`dotnet-service`/`react-dotnet` need .NET in CI).
- **`nx-oc:deployment` (non-sandbox)** manifests — only unit-tested at source.
- e2e **builds but never runs** apps, so boot-time regressions (e.g. the `CLIENT_SECRET` 401) escape CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)