### PR TITLE
test(nx-oc,nx-adsp): guard that every src asset is packaged

### DIFF
--- a/packages/nx-adsp/project.json
+++ b/packages/nx-adsp/project.json
@@ -39,6 +39,11 @@
             "output": "./src"
           },
           {
+            "input": "./packages/nx-adsp/src",
+            "glob": "**/*__tmpl__",
+            "output": "./src"
+          },
+          {
             "input": "./packages/nx-adsp",
             "glob": "generators.json",
             "output": "."

--- a/packages/nx-adsp/src/build-assets.spec.ts
+++ b/packages/nx-adsp/src/build-assets.spec.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as path from 'path';
+// minimatch is always present (nx depends on it); used only in this test.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import minimatch = require('minimatch');
+
+/**
+ * Guards the source -> published-package boundary.
+ *
+ * The build copies non-source files (generator templates, schemas, static
+ * assets) into the package via the build target's `assets` globs. Any such file
+ * NOT matched by a glob is silently dropped from the published package, so a
+ * consumer's generate produces output referencing a file that was never
+ * shipped. This is exactly how `Dockerfile__tmpl__` was lost: the rename from
+ * `Dockerfile.template` (dotted) to `Dockerfile__tmpl__` (dotless) stopped it
+ * matching `**\/*.!(ts)`.
+ *
+ * Unit tests of the generators can't catch this — they resolve templates from
+ * the source tree, never the packaged output. This asserts the invariant
+ * directly: every non-TypeScript file under src is covered by an asset glob.
+ */
+describe('build assets packaging', () => {
+  const srcRoot = __dirname;
+  const projectRoot = path.join(srcRoot, '..');
+  const repoRoot = path.join(projectRoot, '..', '..');
+
+  function listFiles(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(full) : [full];
+    });
+  }
+
+  it('matches every non-TypeScript src file with an asset glob', () => {
+    const project = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'project.json'), 'utf-8')
+    );
+    const assets: unknown[] = project.targets.build.options.assets ?? [];
+
+    // Globs whose input is this package's src directory.
+    const srcGlobs = assets
+      .filter(
+        (a): a is { input: string; glob: string } =>
+          typeof a === 'object' &&
+          a !== null &&
+          'input' in a &&
+          path.resolve(repoRoot, (a as { input: string }).input) === srcRoot
+      )
+      .map((a) => a.glob);
+
+    // Every non-source file under src must ship (tsc only emits .ts -> .js).
+    const mustShip = listFiles(srcRoot)
+      .filter((f) => !/\.tsx?$/.test(f))
+      .map((f) => path.relative(srcRoot, f));
+
+    const unmatched = mustShip.filter(
+      (rel) => !srcGlobs.some((glob) => minimatch(rel, glob, { dot: true }))
+    );
+
+    expect(unmatched).toEqual([]);
+  });
+});

--- a/packages/nx-oc/src/build-assets.spec.ts
+++ b/packages/nx-oc/src/build-assets.spec.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as path from 'path';
+// minimatch is always present (nx depends on it); used only in this test.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import minimatch = require('minimatch');
+
+/**
+ * Guards the source -> published-package boundary.
+ *
+ * The build copies non-source files (generator templates, schemas, static
+ * assets) into the package via the build target's `assets` globs. Any such file
+ * NOT matched by a glob is silently dropped from the published package, so a
+ * consumer's generate produces output referencing a file that was never
+ * shipped. This is exactly how `Dockerfile__tmpl__` was lost: the rename from
+ * `Dockerfile.template` (dotted) to `Dockerfile__tmpl__` (dotless) stopped it
+ * matching `**\/*.!(ts)`.
+ *
+ * Unit tests of the generators can't catch this — they resolve templates from
+ * the source tree, never the packaged output. This asserts the invariant
+ * directly: every non-TypeScript file under src is covered by an asset glob.
+ */
+describe('build assets packaging', () => {
+  const srcRoot = __dirname;
+  const projectRoot = path.join(srcRoot, '..');
+  const repoRoot = path.join(projectRoot, '..', '..');
+
+  function listFiles(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      return entry.isDirectory() ? listFiles(full) : [full];
+    });
+  }
+
+  it('matches every non-TypeScript src file with an asset glob', () => {
+    const project = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, 'project.json'), 'utf-8')
+    );
+    const assets: unknown[] = project.targets.build.options.assets ?? [];
+
+    // Globs whose input is this package's src directory.
+    const srcGlobs = assets
+      .filter(
+        (a): a is { input: string; glob: string } =>
+          typeof a === 'object' &&
+          a !== null &&
+          'input' in a &&
+          path.resolve(repoRoot, (a as { input: string }).input) === srcRoot
+      )
+      .map((a) => a.glob);
+
+    // Every non-source file under src must ship (tsc only emits .ts -> .js).
+    const mustShip = listFiles(srcRoot)
+      .filter((f) => !/\.tsx?$/.test(f))
+      .map((f) => path.relative(srcRoot, f));
+
+    const unmatched = mustShip.filter(
+      (rel) => !srcGlobs.some((glob) => minimatch(rel, glob, { dot: true }))
+    );
+
+    expect(unmatched).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

The `Dockerfile__tmpl__` packaging regression shipped because the assertion that the Dockerfile is generated lives only in **unit tests that resolve templates from the source tree** — never from the built/published package where the asset-glob dropped it. Generator unit tests are structurally blind to packaging.

## What

A cheap, deterministic structural invariant in both plugins: **every non-TypeScript file under `src` (templates, schemas, static assets) must be matched by a build `assets` glob**, else it won't be copied into the package.

- No build/install/workspace required — reads `project.json` asset globs and the src tree, checks coverage with `minimatch({dot:true})` (which faithfully models the real copy: it misses dotless `Dockerfile__tmpl__` under `**/*.!(ts)` and matches it under `**/*__tmpl__`).
- Verified it **fails** — listing all three `Dockerfile__tmpl__` (node/frontend/**dotnet**) — when the `**/*__tmpl__` glob is removed, and passes when present.
- Covers the **dotnet Dockerfile**, which the behavioural e2e (#279) can't easily reach (no .NET in CI).

Also adds the `**/*__tmpl__` asset glob to **nx-adsp** for parity with nx-oc, so a future dotless template there is packaged (nx-adsp currently has none, so this is defensive).

## Relationship to #279

Complementary, not redundant: this guards **packaging completeness** (is everything shipped?) cheaply and deterministically; the e2e guards **wiring/behaviour** (does the installed plugin produce correctly-referenced output?). The invariant is the higher-ROI catch for *this* bug class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)