### PR TITLE
fix(nx-adsp): make @nx/react and @nx/express optional peer deps

### DIFF
--- a/packages/nx-adsp/package.json
+++ b/packages/nx-adsp/package.json
@@ -27,6 +27,12 @@
     "@nx/angular": {
       "optional": true
     },
+    "@nx/express": {
+      "optional": true
+    },
+    "@nx/react": {
+      "optional": true
+    },
     "@nx/vue": {
       "optional": true
     }

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -98,7 +98,13 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
 
-  const { applicationGenerator: initExpress } = await import('@nx/express');
+  const { applicationGenerator: initExpress } = await import('@nx/express').catch(
+    () => {
+      throw new Error(
+        "The 'express-service' generator requires the '@nx/express' plugin. Install it and re-run:\n  npm i -D @nx/express"
+      );
+    }
+  );
   await initExpress(host, {
     ...options,
     skipFormat: true,

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -105,7 +105,13 @@ function removeFiles(host: Tree, options: NormalizedSchema) {
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
 
-  const { applicationGenerator: initReact } = await import('@nx/react');
+  const { applicationGenerator: initReact } = await import('@nx/react').catch(
+    () => {
+      throw new Error(
+        "The 'react-app' generator requires the '@nx/react' plugin. Install it and re-run:\n  npm i -D @nx/react"
+      );
+    }
+  );
 
   // Setting strict to false because of: https://github.com/nrwl/nx/issues/8180
   await initReact(host, {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -65,7 +65,11 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
 
-  const { applicationGenerator: initVue } = await import('@nx/vue');
+  const { applicationGenerator: initVue } = await import('@nx/vue').catch(() => {
+    throw new Error(
+      "The 'vue-app' generator requires the '@nx/vue' plugin. Install it and re-run:\n  npm i -D @nx/vue"
+    );
+  });
   await initVue(host, {
     name: options.name,
     style: 'css',


### PR DESCRIPTION
## Why

`nx-adsp` supports multiple stacks, so the framework plugins are peer deps — but they were marked **inconsistently**: `@nx/angular`, `@nx/vue`, and `@nx-dotnet/core` were `optional`, while **`@nx/react` and `@nx/express` were left required** (an oversight).

Each framework plugin is only used by its matching generator, so requiring react + express forces *every* consumer to satisfy them. A Vue-only PEVN workspace never installs `@nx/react`, and the workspace is often on Nx 23 from `create-nx-workspace`, so npm 7+ hits an unmet/conflicting **required** peer → `ERESOLVE`, install aborts. Users then reach for `--legacy-peer-deps`, which makes npm ignore *all* peers — so it *also* doesn't auto-install the `@nx/express` they genuinely need, producing the `Cannot find module '@nx/express'` crash and a manual install. Both long-standing setup gotchas trace to this one inconsistency.

## What

- Add `@nx/react` and `@nx/express` to `peerDependenciesMeta` as `optional: true` (matching angular/vue/dotnet). Consumers install only their stack's plugins and resolve cleanly **without `--legacy-peer-deps`**.
- Guard the dynamic `import('@nx/react' | '@nx/express' | '@nx/vue')` in the generators so a genuinely missing plugin throws an **actionable** message (`Install it and re-run: npm i -D @nx/…`) instead of a raw `Cannot find module`.

`@nx/devkit`, `@abgov/nx-oc`, `tslib`, and `@nx/eslint` stay required — they're cross-cutting, not stack-specific.

## Tests

`express-service` and `pevn` specs pass (the guards no-op when the plugin resolves). Note: this doesn't address the separate Nx-22-vs-23 version-range pinning — that's a different issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)