### PR TITLE
fix(nx-oc): stop e2e corrupting published environments; retry sandbox import

### DIFF
--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -36,29 +36,6 @@ function setupE2eWorkspace(mockUrl: string) {
     cwd: tmpProjPath(),
     stdio: ['ignore', 'ignore', 'ignore'],
   });
-  // npm caches file: deps by tarball hash and may install a stale compiled version.
-  // Directly overwrite environments.js so the generator always uses the mock URLs.
-  writeMockEnvironments(mockUrl);
-}
-
-// Overwrite @abgov/nx-oc's compiled environments.js so ADSP calls hit the mock
-// server. Generators that finish with installPackagesTask reinstall the file:
-// dep and restore the real URLs, so this must be re-applied before any later
-// generate that resolves ADSP config (e.g. the sandbox generator run after an
-// app generate).
-function writeMockEnvironments(mockUrl: string) {
-  writeFileSync(
-    join(tmpProjPath(), 'node_modules/@abgov/nx-oc/src/adsp/environments.js'),
-    `"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.environments = void 0;
-exports.environments = {
-  dev:  { accessServiceUrl: "${mockUrl}", directoryServiceUrl: "${mockUrl}" },
-  test: { accessServiceUrl: "${mockUrl}", directoryServiceUrl: "${mockUrl}" },
-  prod: { accessServiceUrl: "${mockUrl}", directoryServiceUrl: "${mockUrl}" },
-};
-`
-  );
 }
 
 const MOCK_CLIENT_UUID = 'aaaa1111-bbbb-cccc-dddd-eeee22223333';
@@ -139,6 +116,13 @@ describe('nx-adsp e2e', () => {
     await new Promise<void>((resolve) => mockServer.listen(0, '127.0.0.1', resolve));
     port = (mockServer.address() as AddressInfo).port;
     mockUrl = `http://localhost:${port}`;
+    // Point the generators' ADSP calls at the mock via the ADSP_E2E_* overrides
+    // that environments.ts honours. Do NOT overwrite the compiled
+    // environments.js — that mutation can leak into the published package (it
+    // once shipped a localhost URL). Env vars are inherited by the generator
+    // subprocesses that runNxCommandAsync spawns.
+    process.env.ADSP_E2E_ACCESS_URL = mockUrl;
+    process.env.ADSP_E2E_DIRECTORY_URL = mockUrl;
   }, 30000);
 
   afterAll(async () => {
@@ -184,9 +168,6 @@ describe('nx-adsp e2e', () => {
       await runNxCommandAsync(
         `generate @abgov/nx-adsp:express-service ${svc} dev --tenant=test --accessToken=mock-token --skipAgent --database=none`
       );
-      // The app generate reinstalls @abgov/nx-oc (installPackagesTask), restoring
-      // the real ADSP URLs — re-point them at the mock before the sandbox generate.
-      writeMockEnvironments(mockUrl);
       await runNxCommandAsync(
         `generate @abgov/nx-oc:sandbox ${svc} --sandboxProject=test-build --registry=ghcr.io/test-org --tenant=test --accessToken=mock-token`
       );
@@ -217,7 +198,6 @@ describe('nx-adsp e2e', () => {
       await runNxCommandAsync(
         `generate @abgov/nx-adsp:vue-app ${app} dev --tenant=test --accessToken=mock-token --skipAgent`
       );
-      writeMockEnvironments(mockUrl);
       await runNxCommandAsync(
         `generate @abgov/nx-oc:sandbox ${app} --sandboxProject=test-build --registry=ghcr.io/test-org --tenant=test --accessToken=mock-token`
       );

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -115,8 +115,13 @@ describe('Sandbox Generator', () => {
         c.includes(`oc tag ${imageRef} test:sandbox --reference-policy=local`)
       )
     ).toBeTruthy();
+    // import-image is retried to absorb the 409 from oc tag's async reconcile.
     expect(
-      cmds.some((c) => c.includes('oc import-image test:sandbox --confirm'))
+      cmds.some(
+        (c) =>
+          c.includes('oc import-image test:sandbox --confirm') &&
+          c.includes('until')
+      )
     ).toBeTruthy();
     // Per-deploy pull secret from the gh session (no stored PAT).
     expect(

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -249,8 +249,11 @@ function addSandboxTarget(host: Tree, options: NormalizedSchema) {
   commands.push(
     `oc tag ${imageRef} ${projectName}:sandbox --reference-policy=local -n ${sandboxProject}`
   );
+  // oc tag triggers an async imagestream reconcile, so a back-to-back
+  // import-image can 409 ("object has been modified"). Retry until it settles.
   commands.push(
-    `oc import-image ${projectName}:sandbox --confirm -n ${sandboxProject}`
+    `n=0; until oc import-image ${projectName}:sandbox --confirm -n ${sandboxProject}; do ` +
+      `n=$((n+1)); [ $n -ge 5 ] && exit 1; sleep 3; done`
   );
 
   commands.push(


### PR DESCRIPTION
## Why

An end-to-end release test (fresh Nx workspace → install released plugins → generate a PEVN full-stack solution → deploy to sandbox) surfaced two real bugs.

### 1. Published `environments.js` shipped a mock localhost URL

`@abgov/nx-oc@12.15.0` shipped `src/adsp/environments.js` pointing at `http://localhost:<port>`, so consumers' generators hit `ECONNREFUSED` instead of ADSP. Root cause: the nx-adsp e2e's `writeMockEnvironments()` **overwrote the compiled** `environments.js` in `node_modules/@abgov/nx-oc`, and because the Release CI runs e2e in the same workspace it builds+publishes from (via `--install-links`), the mock leaked into the published tarball.

Fix: switch the e2e to the `ADSP_E2E_ACCESS_URL` / `ADSP_E2E_DIRECTORY_URL` env-var overrides that `environments.ts` already honours (inherited by the generator subprocesses), and delete the file-overwrite entirely. The e2e no longer mutates the package, so a release can't ship a mock URL.

### 2. Sandbox `oc import-image` raced `oc tag`

`oc tag` kicks off an async imagestream reconcile, so the immediately-following `oc import-image --confirm` intermittently 409'd (`the object has been modified`). Wrap the import in a bounded retry loop.

## Effect

The nx-oc change re-publishes the package (12.15.1) with the correct `environments.js` compiled from source — fixing the corruption in the same release that lands the import-race fix.

## Test

- `nx test nx-oc` — sandbox spec asserts the import is retried (`until` + `import-image`); 11/11 pass.
- e2e spec compiles; no remaining `writeMockEnvironments` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)