### PR TITLE
feat(nx-oc): --deployBackend option + warn when a paired backend is absent

### DIFF
--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutorContext } from '@nx/devkit';
+import { ExecutorContext, logger } from '@nx/devkit';
 import runExecutor from './sandbox';
 import { SandboxExecutorSchema } from './schema';
 
@@ -182,5 +182,42 @@ describe('sandbox executor', () => {
   it('adds no paired-service guard without proxy-service tags', async () => {
     await runExecutor(baseOptions, context());
     expect(commands().some((c) => c.includes('oc get service'))).toBe(false);
+  });
+
+  it('warns when a paired backend has no running pods', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    // default mock returns '' for `oc get endpoints` → no endpoints
+    await runExecutor(
+      { ...baseOptions, appType: 'frontend' },
+      context(['adsp:proxy-service:test-service:3333'])
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('test-service'));
+    // warn only — does not deploy the backend
+    expect(commands().some((c) => c.includes('nx run test-service:sandbox'))).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('does not warn when the paired backend has endpoints', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    execSync.mockImplementation((cmd: string) =>
+      Buffer.from(cmd.includes('oc get endpoints test-service') ? '10.1.2.3' : '')
+    );
+    await runExecutor(
+      { ...baseOptions, appType: 'frontend' },
+      context(['adsp:proxy-service:test-service:3333'])
+    );
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('deployBackend deploys each paired backend first (no warning)', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    await runExecutor(
+      { ...baseOptions, appType: 'frontend', deployBackend: true },
+      context(['adsp:proxy-service:test-service:3333'])
+    );
+    expect(commands().some((c) => c.includes('npx nx run test-service:sandbox'))).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -56,6 +56,17 @@ function run(label: string, cmd: string, cwd: string): void {
   execSync(cmd, { stdio: 'inherit', cwd, shell: '/bin/bash' });
 }
 
+// Run a command and capture stdout; returns '' on any failure.
+function capture(cmd: string, cwd: string): string {
+  try {
+    return execSync(cmd, { cwd, shell: '/bin/bash', stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
 // oc tag triggers an async imagestream reconcile, so a back-to-back
 // import-image can 409 ("object has been modified"). Retry until it settles.
 function importWithRetry(
@@ -106,6 +117,7 @@ export default async function runExecutor(
     imageTag = 'sandbox',
     skipBuild = false,
     skipPush = false,
+    deployBackend = false,
     importRetries = 5,
   } = options;
 
@@ -217,6 +229,35 @@ export default async function runExecutor(
           `oc create service clusterip ${name} --tcp=${port}:${port} -n ${sandboxProject}`,
         cwd
       );
+    }
+
+    // The Service stub above only stops nginx crashlooping; the backend needs
+    // its own pods for /api proxying to work. Deploy it (opt-in) or warn that
+    // proxied calls will 502 until it is deployed separately.
+    for (const { name } of proxyServices) {
+      if (deployBackend) {
+        try {
+          run(`Deploy paired backend ${name}`, `npx nx run ${name}:sandbox`, cwd);
+        } catch {
+          throw new Error(
+            `--deployBackend: could not deploy paired backend "${name}". Ensure it has a sandbox target ` +
+              `(nx g @abgov/nx-oc:sandbox ${name} --sandboxProject ${sandboxProject}).`
+          );
+        }
+      } else {
+        const endpoints = capture(
+          `oc get endpoints ${name} -n ${sandboxProject} -o jsonpath='{.subsets[*].addresses[*].ip}'`,
+          cwd
+        );
+        if (!endpoints) {
+          logger.warn(
+            `\n⚠ Paired backend "${name}" has no running pods in ${sandboxProject}. ` +
+              `The frontend will deploy, but requests proxied to ${name} will 502 until it is deployed:\n` +
+              `    nx run ${name}:sandbox\n` +
+              `  (or re-run this target with --deployBackend to deploy it first).`
+          );
+        }
+      }
     }
 
     // ---- build locally + push to the registry ----

--- a/packages/nx-oc/src/executors/sandbox/schema.d.ts
+++ b/packages/nx-oc/src/executors/sandbox/schema.d.ts
@@ -8,5 +8,6 @@ export interface SandboxExecutorSchema {
   imageTag?: string;
   skipBuild?: boolean;
   skipPush?: boolean;
+  deployBackend?: boolean;
   importRetries?: number;
 }

--- a/packages/nx-oc/src/executors/sandbox/schema.json
+++ b/packages/nx-oc/src/executors/sandbox/schema.json
@@ -40,6 +40,11 @@
       "default": false,
       "description": "Skip the registry login + push and reuse the already-pushed image (resume from the import step)."
     },
+    "deployBackend": {
+      "type": "boolean",
+      "default": false,
+      "description": "For a frontend: deploy each paired backend (its own sandbox target) first, so proxied /api calls work. Off by default; without it, a missing backend is warned about, not deployed."
+    },
     "importRetries": {
       "type": "number",
       "default": 5,

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -25,7 +25,15 @@ nx run <%= projectName %>:sandbox --skipBuild            # reuse the built image
 nx run <%= projectName %>:sandbox --skipBuild --skipPush # reuse the pushed image; re-import + roll out only
 nx run <%= projectName %>:sandbox --imageTag=<tag>       # push/import under a different tag
 nx run <%= projectName %>:sandbox --importRetries=8      # more import retries on a slow cluster
-```
+<% if (appType === 'frontend') { %>nx run <%= projectName %>:sandbox --deployBackend         # deploy each paired backend (its own sandbox) first
+<% } %>```
+<% if (appType === 'frontend') { %>
+This frontend proxies `/api` to its paired backend Service. The target always
+ensures that Service exists (so nginx doesn't crashloop), but by default it does
+**not** deploy the backend — if the backend has no running pods it **warns** that
+proxied calls will 502, and names the target to run. Pass `--deployBackend` to
+deploy each paired backend as part of this run instead.
+<% } %>
 
 ## Preflight failures — cause → fix
 


### PR DESCRIPTION
Targets **beta**. Follow-up to the sandbox executor (#287).

A frontend's sandbox proxies `/api` to its paired backend Service. The target already ensures that Service exists (so nginx doesn't crashloop), but the backend needs its own pods for proxying to actually work — otherwise the frontend deploys "successfully" and every API call silently 502s.

## Change
- **Default: warn, don't deploy.** If a paired backend has no endpoints (no running pods), the deploy logs an actionable warning — that proxied calls will 502, and the exact `nx run <backend>:sandbox` to fix it. No silent half-working stack.
- **Opt-in: `--deployBackend`.** Deploys each paired backend (its own sandbox target) first, so one command brings up a working stack.

## Why an option, not a new target or an implicit dependency
Plain frontend iteration stays fast — no implicit backend rebuild on every frontend deploy. The heavier "bring up both" is explicit and opt-in. No extra target to learn.

## Tests
104 nx-oc tests pass, including: warns when the paired backend has no endpoints (and does *not* deploy it), no warning when endpoints exist, and `--deployBackend` runs `nx run <backend>:sandbox` first. SANDBOX.md documents both behaviors (frontend-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)