### PR TITLE
fix(nx-adsp): peer @abgov/nx-oc on the v13 line (was ^12.3.0)

### DIFF
--- a/packages/nx-adsp/package.json
+++ b/packages/nx-adsp/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/nx-adsp"
   },
   "peerDependencies": {
-    "@abgov/nx-oc": "^12.3.0",
+    "@abgov/nx-oc": "^13.0.0-0",
     "@nx-dotnet/core": "^3.0.0",
     "@nx/angular": "^23.0.0",
     "@nx/devkit": "^23.0.0",


### PR DESCRIPTION
Found while testing a clean full-flow install of the `@beta` plugins.

`npm i -D @abgov/nx-oc@beta @abgov/nx-adsp@beta` fails:

```
peer @abgov/nx-oc@"^12.3.0" from @abgov/nx-adsp@13.0.0-beta.4
```

When beta moved to Nx 23 / v13, the `@nx/*` peers were bumped to `^23` but the sibling `@abgov/nx-oc` peer was left at `^12.3.0`. Installing `@abgov/nx-oc@beta` (13.x) then ERESOLVEs — defeating the clean, no-`--legacy-peer-deps` install #282 established.

Bump to `^13.0.0-0` so it accepts the `13.0.0-beta.x` prereleases **and** stable `13.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)