### PR TITLE
feat(nx-oc,nx-adsp): auto-detect the sandbox database

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -84,6 +84,9 @@ describe('Express Service Generator', () => {
           typeof a === 'object' && (a as { output?: string }).output === 'drizzle'
       )
     ).toBe(true);
+
+    // Tagged so the sandbox generator wires the DB without a --database flag.
+    expect(config.tags).toContain('adsp:database:postgres');
   }, 60000);
 
   it('scaffolds mongo database files and targets', async () => {
@@ -101,6 +104,7 @@ describe('Express Service Generator', () => {
     expect(config.targets['dev-db']).toBeTruthy();
     expect(config.targets['serve'].dependsOn).toContain('dev-db');
     expect(config.targets['db:generate']).toBeFalsy();
+    expect(config.tags).toContain('adsp:database:mongo');
   }, 60000);
 
   it('does not scaffold database files when database is none', async () => {
@@ -113,5 +117,8 @@ describe('Express Service Generator', () => {
 
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['dev-db']).toBeFalsy();
+    expect((config.tags ?? []).some((t) => t.startsWith('adsp:database:'))).toBe(
+      false
+    );
   }, 60000);
 });

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -209,9 +209,19 @@ export default async function (host: Tree, options: Schema) {
 
   }
 
+  // Record the database as a project tag so the nx-oc sandbox generator can
+  // wire DATABASE_URL + the migrate init container without a --database flag.
+  const dbTag = `adsp:database:${normalizedOptions.database}`;
+  const tags =
+    normalizedOptions.database !== 'none' &&
+    !(projectConfig.tags ?? []).includes(dbTag)
+      ? [...(projectConfig.tags ?? []), dbTag]
+      : projectConfig.tags;
+
   updateProjectConfiguration(host, normalizedOptions.projectName, {
     ...projectConfig,
     targets,
+    tags,
   });
 
   addSemgrepTarget(host, normalizedOptions.projectName);

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -216,6 +216,75 @@ describe('Sandbox Generator', () => {
     expect(config.targets['sandbox'].options.database).toBe('mongo');
   });
 
+  describe('database auto-detection (no --database flag)', () => {
+    function addServiceProject(host, extra: Record<string, unknown> = {}) {
+      addProjectConfiguration(host, 'test', {
+        root: 'apps/test',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@nx/webpack:webpack',
+            options: { compiler: 'tsc', target: 'node' },
+          },
+        },
+        ...extra,
+      });
+    }
+
+    it('detects postgres from the adsp:database tag', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host, { tags: ['adsp:database:postgres'] });
+      await generator(host, options); // options has no database
+      expect(
+        readProjectConfiguration(host, 'test').targets['sandbox'].options.database
+      ).toBe('postgres');
+    });
+
+    it('detects mongo from the adsp:database tag', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host, { tags: ['adsp:database:mongo'] });
+      await generator(host, options);
+      expect(
+        readProjectConfiguration(host, 'test').targets['sandbox'].options.database
+      ).toBe('mongo');
+    });
+
+    it('falls back to postgres from a drizzle db:migrate target (pre-tag projects)', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host, {
+        targets: {
+          build: {
+            executor: '@nx/webpack:webpack',
+            options: { compiler: 'tsc', target: 'node' },
+          },
+          'db:migrate': { executor: 'nx:run-commands', options: {} },
+        },
+      });
+      await generator(host, options);
+      expect(
+        readProjectConfiguration(host, 'test').targets['sandbox'].options.database
+      ).toBe('postgres');
+    });
+
+    it('the --database flag overrides detection', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host, { tags: ['adsp:database:postgres'] });
+      await generator(host, { ...options, database: 'none' });
+      expect(
+        readProjectConfiguration(host, 'test').targets['sandbox'].options.database
+      ).toBeUndefined(); // explicit none → no database key
+    });
+
+    it('leaves database unset when there is no signal', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host);
+      await generator(host, options);
+      expect(
+        readProjectConfiguration(host, 'test').targets['sandbox'].options.database
+      ).toBeUndefined();
+    });
+  });
+
   it('registers the deployment Route redirect URI for a frontend client', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     addFrontendProject(host);

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -2,6 +2,7 @@ import {
   formatFiles,
   generateFiles,
   names,
+  ProjectConfiguration,
   readNxJson,
   readProjectConfiguration,
   Tree,
@@ -17,9 +18,22 @@ import {
 } from '../../utils/git-utils';
 import { getClusterIngressDomain } from '../../utils/oc-utils';
 import { detectApplicationType, getBuildOutputPath } from '../../utils/app-type';
+import { DatabaseType } from '../deployment/schema';
 import { NormalizedSchema, Schema } from './schema';
 
 const SANDBOX_GENERATOR = '@abgov/nx-oc:sandbox';
+const DATABASE_TAG_PREFIX = 'adsp:database:';
+
+// Infer the database when --database wasn't passed, so a DB-backed service isn't
+// silently deployed without its DATABASE_URL/migrate wiring. Prefer the explicit
+// tag the express-service generator records; fall back to a drizzle db:migrate
+// target (postgres) for projects generated before the tag existed.
+function detectDatabase(config: ProjectConfiguration): DatabaseType | undefined {
+  const tag = (config.tags ?? []).find((t) => t.startsWith(DATABASE_TAG_PREFIX));
+  if (tag) return tag.slice(DATABASE_TAG_PREFIX.length) as DatabaseType;
+  if (config.targets?.['db:migrate']) return 'postgres';
+  return undefined;
+}
 
 // Resolves the sandbox container registry once per workspace and persists it to
 // nx.json so subsequent sandbox generations reuse it without re-prompting:
@@ -95,6 +109,7 @@ async function normalizeOptions(
   return {
     ...options,
     appType,
+    database: options.database ?? detectDatabase(config) ?? 'none',
     adsp,
     projectName,
     buildOutputPath: getBuildOutputPath(config),


### PR DESCRIPTION
Targets **beta**. Closes the sharpest footgun found in the live PEVN full-flow test.

## Problem
The sandbox generator defaulted `database` to `none` with no detection or prompt. Scaffolding a Postgres service's sandbox without `--database=postgres` produced a manifest with **no `DATABASE_URL` and no migrate init container**, so the service deployed and immediately crashlooped:

```
Missing environment variables:
   DATABASE_URL: undefined
```

— even though the project had unmistakable DB markers (`db:migrate` target, `drizzle.config.ts`). For the PEVN flow this is easy to hit and gives no hint.

## Fix (mirrors the paired-service tag pattern)
- **express-service** records an `adsp:database:<type>` project tag (exactly how vue-app records `adsp:proxy-service:*`).
- **sandbox generator** reads that tag; falls back to a drizzle `db:migrate` target ⇒ `postgres` for projects generated before the tag existed.
- An explicit `--database` flag still overrides.

Result: `nx g @abgov/nx-oc:sandbox <service>` wires the DB for a PEVN backend with no flag, and already-generated Postgres services are covered by the fallback.

## Tests
- nx-oc **109** pass — new: detect postgres/mongo from the tag, postgres from the `db:migrate` fallback, `--database` overrides, and no-signal ⇒ unset.
- nx-adsp **37** pass — express-service now asserts the `adsp:database:*` tag for postgres/mongo and its absence for none.

Found during the live beta full-flow deploy (alongside the peer-dep fix #289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)