### PR TITLE
docs: sandbox flow + PEVN quickstart for agents (beta)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,19 @@ schema.d.ts       # TypeScript interface: Schema
 [name].spec.ts    # Jest unit tests
 ```
 
-New executors must be registered in `packages/nx-oc/executors.json`.
+New executors must be registered in `packages/nx-oc/executors.json`. `nx-oc` ships two:
+`apply` (wraps `oc apply`) and `sandbox` (local-podman-build deploy — see **Sandbox
+deployment** below).
+
+### Migrations
+
+`nx-oc` has an `nx migrate` migrations registry at `packages/nx-oc/migrations.json`
+(wired via the `nx-migrations` field in its `package.json`, and packaged by an asset glob
+in `project.json`). Migrations live under `packages/nx-oc/src/migrations/[name]/`. A
+migration's `version` must be on the branch's release line (e.g. `13.0.0-beta.3` on
+`beta`) so `nx migrate` runs it for the right upgrade range. Migrations retrofit generated
+config in consuming workspaces — e.g. `convert-sandbox-target-to-executor` rewrites older
+`nx:run-commands` sandbox targets to the `@abgov/nx-oc:sandbox` executor.
 
 ---
 
@@ -166,12 +178,20 @@ unless explicitly directed.
 
 ## Branching and Release
 
-- **`main`** — stable releases (e.g. `12.0.0`)
-- **`beta`** — pre-releases (e.g. `12.1.0-beta.1`); use this channel only when a
-  change needs to be validated by importing the published package from a consuming
-  project before it reaches stable. Changes that can be fully verified within this
-  repo (docs, dependency updates, refactors, generator logic covered by unit/e2e
-  tests) should target `main` directly.
+- **`main`** — the current stable line (Nx 22 / `@abgov/*@12`).
+- **`beta`** — the **next major line**, currently Nx 23 / `@abgov/*@13`, published on
+  the `@beta` dist-tag (e.g. `13.0.0-beta.4`). This is a standing major-version track,
+  not just an occasional validation channel: features that require Nx 23 (the sandbox
+  executor, DB auto-detection, `--deployBackend`, etc.) live here and graduate to `main`
+  when the major line does. A change targets `beta` when it depends on the Nx 23 line or
+  needs validation by importing the published package from a consuming project; changes
+  fully verifiable within this repo against the stable line (docs, refactors, generator
+  logic covered by tests) target `main`.
+
+Version-pinned specs written for the `beta` prerelease (peer ranges like `^13.0.0-0`,
+migration `version`s like `13.0.0-beta.3`) are deliberately valid for both the prerelease
+and the eventual stable release, so they carry to `main` on promotion without edits — and
+promotion merges must stay pure (never fold a content edit into a merge commit).
 
 ### Version convention
 
@@ -182,7 +202,13 @@ unless explicitly directed.
 | @nrwl/cli@11 | @abgov/nx-oc@1 |
 | @nrwl/cli@12 | @abgov/nx-oc@2 |
 | @nrwl/cli@15 | @abgov/nx-oc@5 |
-| @nx/devkit@22 | @abgov/nx-oc@12 |
+| @nx/devkit@22 | @abgov/nx-oc@12 (`main`) |
+| @nx/devkit@23 | @abgov/nx-oc@13 (`beta`) |
+
+So the `beta` branch's package peers are `@nx/* ^23`, and its sibling peer is
+`@abgov/nx-oc@^13.0.0-0` (the `-0` accepts the `13.0.0-beta.x` prereleases). When
+bumping a version-pinned spec on `beta` (peer range, migration `version`), keep it on
+the 13 line, not 12.
 
 The `package.json` `version` field in this repo is a placeholder `0.0.0`.
 Semantic-release sets the real published version at CI publish time.
@@ -219,8 +245,16 @@ Publishing uses OIDC (no stored NPM token); `NUGET_API_KEY` is used by `semantic
 
 ## ADSP Platform Notes
 
-Generators that call `getAdspConfiguration()` — `angular-app`, `react-app`, `dotnet-service`,
-`react-dotnet`, `deployment` — perform a live OAuth browser login at generation time to
+App/service generators: `express-service` (Node/Express; `--database postgres` uses Drizzle
+with a migrate init container, `mongo` uses Mongoose), `vue-app`, `react-app`, `angular-app`,
+`dotnet-service`, `react-dotnet`, plus the composite full-stack generators `pevn` / `mevn` /
+`pern` / `pean` (which compose a service + a frontend). Framework peers (`@nx/react`,
+`@nx/angular`, `@nx/vue`, `@nx/express`, `@nx-dotnet/core`) are declared **optional** in
+`nx-adsp`'s `package.json` (`peerDependenciesMeta`), so a consuming workspace installs only
+the peers for the generators it uses and gets a clean, no-`--legacy-peer-deps` install.
+
+Generators that call `getAdspConfiguration()` — the above app/service generators and
+`deployment` — perform a live OAuth browser login at generation time to
 retrieve tenant configuration from ADSP APIs. In unit tests these generators must be mocked:
 
 ```typescript
@@ -239,6 +273,41 @@ ADSP environments (dev, test, prod) are defined in
 - `nx-oc` generators produce `.openshift/` YAML manifests from EJS templates named `*.yml__tmpl__`.
 - The `apply` executor wraps the `oc` CLI; it expects `oc` to be on `PATH`.
 - `pipeline.ts` supports two `pipelineType` values: `'jenkins'` and `'actions'` (GitHub Actions).
+
+---
+
+## Sandbox deployment (nx-oc)
+
+The `sandbox` generator (`packages/nx-oc/src/generators/sandbox/`) sets up a rapid local
+deploy for a single app. It emits, into `.openshift/<app>/`, a `Dockerfile`, the deploy
+manifest, and a `SANDBOX.md` runbook (`files/SANDBOX.md__tmpl__`), and adds two targets to
+the project:
+
+- `sandbox` → the **`@abgov/nx-oc:sandbox` executor** (thin `{ options }`; orchestration is
+  versioned in the plugin, not baked into `project.json`).
+- `sandbox-teardown` → `nx:run-commands` (kept as commands intentionally — simple/idempotent).
+
+The executor (`packages/nx-oc/src/executors/sandbox/`) runs: preflight (`oc` login, `gh auth`,
+`podman info` — fail fast before the build) → optional secret/DB/paired-service provisioning →
+`nx build` → `podman build --platform=linux/amd64` → `podman push` to `ghcr.io/<org>/<ns>-<app>` →
+per-deploy pull secret → `oc tag … --reference-policy=local` → **`oc import-image` with retry**
+(absorbs the tag-reconcile 409) → `oc process | oc apply` → `oc rollout`. Pods pull in-cluster
+via the local reference policy. Options include `--database`, `--imageTag`, `--importRetries`,
+`--deployBackend`, and `--skipBuild`/`--skipPush` (resume a partial deploy).
+
+Key wiring to preserve when editing:
+
+- **DB auto-detection**: `express-service` records an `adsp:database:<type>` project tag; the
+  sandbox generator reads it (falling back to a drizzle `db:migrate` target ⇒ `postgres`), so
+  no `--database` flag is needed. Mirrors the `adsp:proxy-service:<name>:<port>` tag that
+  `vue-app`/frontends record for the executor's paired-Service handling.
+- **Registry** resolves as `--registry` → `nx.json` (persisted) → derived from the git remote →
+  prompt; it's lowercased and stored under `generators['@abgov/nx-oc:sandbox']` in `nx.json`.
+- **Auth**: the deploy reads `gh auth token` for both the image push and the pull secret (no PAT
+  stored), so the **active** `gh` account must have `write:packages` on the registry org — the
+  preflight checks `gh auth status` but not the scope/identity.
+- The generator unit tests assert the target/manifest shape; the executor tests mock `child_process`
+  `execSync` and assert the command sequence/preflight/retry.
 
 ---
 

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -6,13 +6,20 @@ The plugin provides generators for Node/Express services, React and Angular fron
 
 ## Prerequisites
 
+Install only the framework peers for the generators you use — they are declared
+as **optional** peer dependencies, so a workspace that only builds Vue apps
+doesn't need `@nx/react`, `@nx/angular`, etc.
+
 | Generator | Required peer dependency |
 |-----------|--------------------------|
 | `react-app` | `@nx/react` |
 | `angular-app` | `@nx/angular` |
+| `vue-app` | `@nx/vue` |
 | `dotnet-service` | `@nx-dotnet/core` |
 | `react-dotnet` | `@nx/react`, `@nx-dotnet/core` |
-| `express-service` | `@nx/node` |
+| `express-service` | `@nx/express` |
+| `pevn`, `mevn` (full-stack) | `@nx/express`, `@nx/vue` |
+| `pern`, `pean` (full-stack) | `@nx/express`, `@nx/react`/`@nx/angular` |
 | `react-form`, `react-task-list` | existing React project in the workspace |
 
 ## Installation
@@ -28,11 +35,49 @@ npm i -D @abgov/nx-adsp
 npx create-nx-workspace my-workspace
 
 # 2. Install the plugin and any required peer dependencies
-npm i -D @abgov/nx-adsp @nx/node
+npm i -D @abgov/nx-adsp @nx/express
 
 # 3. Generate a quickstart (interactive prompts fill missing options)
 npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 ```
+
+## Full-stack quickstart (PEVN → sandbox)
+
+This is the end-to-end path a coding agent can follow from an empty folder to a
+running full-stack app in an OpenShift sandbox. **The Nx 23 line is published on
+the `@beta` dist-tag** — append `@beta` to installs until it is promoted to
+`latest`.
+
+Prerequisites for the sandbox deploy (steps 4–5): `podman` (machine started on
+macOS), `oc` logged in to the sandbox cluster, and the GitHub CLI (`gh`)
+authenticated as an account with **`write:packages`** on your registry org.
+
+```bash
+# 1. Empty folder → Nx workspace (the plugins require Nx 23)
+npx create-nx-workspace@latest my-solution --preset=apps --workspaceType=integrated --nxCloud=skip --no-interactive
+cd my-solution
+
+# 2. Install the plugins + stack peers (match @nx/* to the workspace nx version)
+NXV=$(node -p "require('./node_modules/nx/package.json').version")
+npm i -D @abgov/nx-oc@beta @abgov/nx-adsp@beta "@nx/express@$NXV" "@nx/vue@$NXV" "@nx/node@$NXV" "@nx/js@$NXV" "@nx/eslint@$NXV"
+
+# 3. Scaffold a Postgres + Express + Vue + Node solution (opens a browser for the ADSP tenant login)
+npx nx g @abgov/nx-adsp:pevn acme --env=dev --tenant=my-tenant
+
+# 4. Add sandbox targets (registry derives from the git remote, or pass --registry=ghcr.io/<org>;
+#    the database is auto-detected from the service — no --database needed)
+npx nx g @abgov/nx-oc:sandbox acme-service --sandboxProject=<namespace> --registry=ghcr.io/<org> --tenant=my-tenant --env=dev
+npx nx g @abgov/nx-oc:sandbox acme-app --sandboxProject=<namespace> --tenant=my-tenant --env=dev
+
+# 5. Deploy — backend first so the frontend's /api proxy resolves
+npx nx run acme-service:sandbox
+npx nx run acme-app:sandbox            # or: --deployBackend to bring the backend up in the same run
+```
+
+Each generated app has an `AGENTS.md` (framework + ADSP context) and, once
+step 4 runs, a `.openshift/<app>/SANDBOX.md` deploy/troubleshooting runbook.
+See [`@abgov/nx-oc`](https://www.npmjs.com/package/@abgov/nx-oc) for the sandbox
+deploy details.
 
 ## Generators
 

--- a/packages/nx-oc/README.md
+++ b/packages/nx-oc/README.md
@@ -139,6 +139,49 @@ npx nx run my-app:deploy
 
 ---
 
+## Sandbox deployment (local build)
+
+For rapid iteration, the `sandbox` generator wires a per-app deploy that builds
+the image **locally with podman**, pushes it to a container registry (GHCR), and
+imports it into your OpenShift namespace — no git push or CI wait. The Nx 23 line
+that ships this is on the `@beta` dist-tag.
+
+```bash
+# Add the sandbox targets to a project (run once per app)
+npx nx g @abgov/nx-oc:sandbox my-app --sandboxProject=<namespace> --registry=ghcr.io/<org>
+
+# Build → podman → push → import → roll out
+npx nx run my-app:sandbox
+
+# Tear down the sandbox resources + delete the pushed image
+npx nx run my-app:sandbox-teardown
+```
+
+Prerequisites: `podman` (machine started on macOS), `oc` logged in to the
+cluster, and `gh` authenticated as an account with **`write:packages`** on the
+registry org (the deploy reads `gh auth token` for the push and pull secret — no
+PAT is stored, so that account must be the **active** `gh` account).
+
+The deploy is the `@abgov/nx-oc:sandbox` **executor**, so its logic is versioned
+in the plugin (fixes reach every project on `npm update`). It:
+
+- **preflights** `oc`/`gh`/`podman` and fails fast with actionable messages
+  before the build;
+- **retries `oc import-image`** to absorb the `oc tag` reconcile race;
+- **auto-detects the database** (from an `adsp:database:*` project tag, or a
+  drizzle `db:migrate` target) and provisions a shared Postgres/Mongo instance +
+  the per-app database + migrate init container — no `--database` flag needed;
+- for a **frontend**, ensures each paired backend's Service exists and **warns**
+  if the backend has no running pods (proxied `/api` calls would 502); pass
+  `--deployBackend` to deploy the backend in the same run;
+- supports `--skipBuild` / `--skipPush` to **resume** a partial deploy.
+
+Running the generator also writes `.openshift/<app>/SANDBOX.md` — a
+deploy/troubleshooting runbook (preflight fixes, resume flags, a manual-completion
+sequence, quota/auth/CrashLoopBackOff guidance).
+
+---
+
 ## Typical workflow
 
 1. Run `pipeline` once per workspace to generate shared build infrastructure manifests.


### PR DESCRIPTION
The root `AGENTS.md` (contributor breadcrumb) and the package READMEs (consumer breadcrumb, shipped to npm) had drifted from the Nx 23 / v13 `beta` line — none of the sandbox executor, DB auto-detection, `--deployBackend`, Vue, or the composite PEVN-family work was documented. This updates all three so a coding agent has an accurate breadcrumb whether it's contributing to the repo or building an app from an empty folder.

## Root `AGENTS.md` (contributor)
- `beta` reframed as the standing Nx 23 / v13 major line (not an occasional validation channel); version table gains `Nx23 → v13`; notes on prerelease-valid version specs and keeping promotion merges pure.
- New **Sandbox deployment (nx-oc)** section: the `sandbox` generator + `@abgov/nx-oc:sandbox` executor, the build→podman→push→import(retry)→rollout flow, DB auto-detection via the `adsp:database` tag, registry resolution, `gh` `write:packages` auth, and resume flags.
- Executor list (`apply` + `sandbox`) and the **migrations** registry (`migrations.json` / `nx-migrations`).
- ADSP notes now include `express-service`/`vue-app` + `pevn`/`mevn`/`pern`/`pean` and the optional framework peers.

## Consumer READMEs (→ npm)
- **nx-adsp**: Vue + full-stack generators added to Prerequisites (with the optional-peer note); a **Full-stack quickstart (PEVN → sandbox)** that runs from an empty folder on `@beta` — the exact flow verified end-to-end this cycle.
- **nx-oc**: a **Sandbox deployment (local build)** section for the `sandbox`/`sandbox-teardown` targets, prerequisites, and executor behaviour.

Docs-only. Targets **beta** because it describes beta-only features; promotes to `main` with the v13 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)