### PR TITLE
fix(nx-oc): don't prompt for sandbox appType; detect it

### DIFF
--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -107,6 +107,18 @@ describe('Sandbox Generator', () => {
     expect(host.exists('.openshift/test/sandbox-build.yml')).toBeFalsy();
   });
 
+  it('throws an actionable error when the app type cannot be detected', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    // An unrecognized build executor → detectApplicationType returns undefined.
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: { build: { executor: '@nx/js:tsc', options: {} } },
+    });
+
+    await expect(generator(host, options)).rejects.toThrow(/--appType/);
+  });
+
   it('writes a SANDBOX.md deploy/troubleshooting runbook next to the manifests', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     addNodeProject(host);

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -250,8 +250,10 @@ async function registerSandboxRedirectUri(options: NormalizedSchema) {
 export default async function (host: Tree, options: Schema) {
   const normalizedOptions = await normalizeOptions(host, options);
   if (!normalizedOptions.appType) {
-    console.log('Cannot generate sandbox deployment for unknown project type.');
-    return;
+    throw new Error(
+      `Could not detect the application type for "${normalizedOptions.projectName}" from its build target. ` +
+        `Pass --appType=node|frontend|dotnet to set it explicitly.`
+    );
   }
 
   addManifestFiles(host, normalizedOptions);

--- a/packages/nx-oc/src/generators/sandbox/schema.json
+++ b/packages/nx-oc/src/generators/sandbox/schema.json
@@ -21,13 +21,8 @@
     },
     "appType": {
       "type": "string",
-      "description": "Type of application.",
-      "alias": "t",
-      "x-prompt": {
-        "message": "What type of application is the project?",
-        "type": "list",
-        "items": ["frontend", "dotnet", "node"]
-      }
+      "description": "Application type. Auto-detected from the project's build target; only pass this to override detection (e.g. for a custom build executor).",
+      "enum": ["frontend", "node", "dotnet"]
     },
     "database": {
       "type": "string",


### PR DESCRIPTION
Running `nx g @abgov/nx-oc:sandbox <project>` interactively prompted **"What type of application is the project?"** — even though the generator already infers it. The `appType` schema property carried an `x-prompt`, and Nx collects prompted options *before* the code's `options.appType ?? detectApplicationType(config)` fallback runs, so detection never got a chance in a terminal. (Scripted/`--no-interactive` runs skip `x-prompt`, which is why the prompt only showed up interactively.)

## Change
- Remove the `x-prompt` from `appType` so interactive runs use the same `detectApplicationType()` detection (build executor → `frontend`/`node`/`dotnet`) as scripted ones.
- Drop the `-t` alias (it collided with `--tenant`'s conventional short flag); keep `appType` as an optional override with an `enum`.
- When detection genuinely can't classify a project (e.g. a custom build executor), **throw an actionable error** naming `--appType` instead of the old silent `console.log` + `return`.

## Tests
nx-oc **110** pass, build + lint clean — includes a new case asserting the unknown-type error mentions `--appType`; existing tests already cover detection producing the right `appType` with no flag.

Targets `main` (v13 is released there; fully verifiable by unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)