### PR TITLE
docs(nx-adsp): run generators non-interactively (coding agents)

### DIFF
--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -52,6 +52,13 @@ Prerequisites for the sandbox deploy (steps 4–5): `podman` (machine started on
 macOS), `oc` logged in to the sandbox cluster, and the GitHub CLI (`gh`)
 authenticated as an account with **`write:packages`** on your registry org.
 
+> **Coding agents:** run generators with `--no-interactive` **and** every required
+> option (name, `--env`, `--sandboxProject`, etc.) supplied — otherwise Nx prompts
+> and your session hangs waiting for input. Setting `CI=true` in the env has the
+> same effect and also skips the Nx Cloud prompt. (`nx run <target>` executors
+> don't prompt — this only applies to `nx g` generators.) The commands below
+> already follow this.
+
 ```bash
 # 1. Empty folder → Nx workspace (the plugins require Nx 23)
 npx create-nx-workspace@latest my-solution --preset=apps --workspaceType=integrated --nxCloud=skip --no-interactive
@@ -62,12 +69,12 @@ NXV=$(node -p "require('./node_modules/nx/package.json').version")
 npm i -D @abgov/nx-oc@beta @abgov/nx-adsp@beta "@nx/express@$NXV" "@nx/vue@$NXV" "@nx/node@$NXV" "@nx/js@$NXV" "@nx/eslint@$NXV"
 
 # 3. Scaffold a Postgres + Express + Vue + Node solution (opens a browser for the ADSP tenant login)
-npx nx g @abgov/nx-adsp:pevn acme --env=dev --tenant=my-tenant
+npx nx g @abgov/nx-adsp:pevn acme --env=dev --tenant=my-tenant --no-interactive
 
 # 4. Add sandbox targets (registry derives from the git remote, or pass --registry=ghcr.io/<org>;
 #    the database is auto-detected from the service — no --database needed)
-npx nx g @abgov/nx-oc:sandbox acme-service --sandboxProject=<namespace> --registry=ghcr.io/<org> --tenant=my-tenant --env=dev
-npx nx g @abgov/nx-oc:sandbox acme-app --sandboxProject=<namespace> --tenant=my-tenant --env=dev
+npx nx g @abgov/nx-oc:sandbox acme-service --sandboxProject=<namespace> --registry=ghcr.io/<org> --tenant=my-tenant --env=dev --no-interactive
+npx nx g @abgov/nx-oc:sandbox acme-app --sandboxProject=<namespace> --tenant=my-tenant --env=dev --no-interactive
 
 # 5. Deploy — backend first so the frontend's /api proxy resolves
 npx nx run acme-service:sandbox

--- a/packages/nx-adsp/src/generators/angular-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/AGENTS.md__tmpl__
@@ -9,7 +9,16 @@ This app is paired with **`<%= pairedProject %>`** — the Express backend it ta
 API calls use the `/api/` prefix which the Angular dev proxy rewrites to `/<%= pairedProject %>/` on port 3333.
 When working on a feature that spans both projects, read `apps/<%= pairedProject %>/AGENTS.md` for the service context.
 <% } %>
+## Running Nx commands (coding agents)
+
+Run generators with `--no-interactive` **and** every required option supplied. With
+`--no-interactive`, a missing required option errors instead of prompting, so an
+interactive prompt never blocks your session (`CI=true` in the env does the same and
+also skips the Nx Cloud prompt). This applies to `nx g` generators; `nx run <target>`
+executors read options from `project.json` and do not prompt.
+
 ## Stack
+
 
 - **UI**: Angular 19 standalone + GoA design system (`@abgov/angular-components` — `Goab*` components)
 - **Auth**: `keycloak-angular` with `keycloak-js`

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -9,7 +9,16 @@ This service is paired with **`<%= pairedProject %>`** — the frontend app it s
 The frontend proxies `/api/` to `/<%= projectName %>/` on port 3333 (dev) and via nginx (production).
 When working on a feature that spans both projects, read `apps/<%= pairedProject %>/AGENTS.md` for the frontend context.
 <% } %>
+## Running Nx commands (coding agents)
+
+Run generators with `--no-interactive` **and** every required option supplied. With
+`--no-interactive`, a missing required option errors instead of prompting, so an
+interactive prompt never blocks your session (`CI=true` in the env does the same and
+also skips the Nx Cloud prompt). This applies to `nx g` generators; `nx run <target>`
+executors read options from `project.json` and do not prompt.
+
 ## Stack
+
 
 - **Runtime**: Node.js + Express
 - **Auth**: passport.js with tenant strategy from `@abgov/adsp-service-sdk`

--- a/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
@@ -9,7 +9,16 @@ This app is paired with **`<%= pairedProject %>`** — the Express backend it ta
 API calls use the `/api/` prefix which the webpack dev proxy rewrites to `/<%= pairedProject %>/` on port 3333.
 When working on a feature that spans both projects, read `apps/<%= pairedProject %>/AGENTS.md` for the service context.
 <% } %>
+## Running Nx commands (coding agents)
+
+Run generators with `--no-interactive` **and** every required option supplied. With
+`--no-interactive`, a missing required option errors instead of prompting, so an
+interactive prompt never blocks your session (`CI=true` in the env does the same and
+also skips the Nx Cloud prompt). This applies to `nx g` generators; `nx run <target>`
+executors read options from `project.json` and do not prompt.
+
 ## Stack
+
 
 - **UI**: React 18 + GoA design system (`@abgov/react-components` — `Goab*` components)
 - **Auth**: `keycloak-js` via Redux Toolkit slice (`src/app/user.slice.ts`)

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -9,7 +9,16 @@ This app is paired with **`<%= pairedProject %>`** — the Express backend it ta
 API calls use the `/api/` prefix which the Vite dev proxy rewrites to `/<%= pairedProject %>/` on port 3333.
 When working on a feature that spans both projects, read `apps/<%= pairedProject %>/AGENTS.md` for the service context.
 <% } %>
+## Running Nx commands (coding agents)
+
+Run generators with `--no-interactive` **and** every required option supplied. With
+`--no-interactive`, a missing required option errors instead of prompting, so an
+interactive prompt never blocks your session (`CI=true` in the env does the same and
+also skips the Nx Cloud prompt). This applies to `nx g` generators; `nx run <target>`
+executors read options from `project.json` and do not prompt.
+
 ## Stack
+
 
 - **UI**: Vue 3 (Composition API) + GoA design system (`@abgov/web-components` — `goa-*` custom elements)
 - **Auth**: `@dsb-norge/vue-keycloak-js` (wraps `keycloak-js`)


### PR DESCRIPTION
Follow-up to the `appType` prompt fix (#293). Removing that one prompt wasn't enough on its own: **any `nx g` generator can prompt** (the sandbox generator still prompts for `project`/`sandboxProject`, the ADSP generators for the tenant, and Nx's built-in generators prompt too), and a coding agent in a pseudo-TTY (Copilot's shell often is one) hangs on any of them.

## The rule (documented where agents read it)
- Pass **`--no-interactive`** so Nx never prompts — **and** supply every required option, because with `--no-interactive` a missing required option *errors* instead of prompting.
- `CI=true` in the env does the same and also skips the Nx Cloud connect prompt.
- Applies to **`nx g`** (generators). **`nx run <target>`** executors read options from `project.json` and don't prompt.

## Changes
- **nx-adsp README**: an agent callout in the full-stack quickstart + `--no-interactive` on its `nx g` commands (they already pass explicit options, so it's a clean pairing).
- **All four app `AGENTS.md` templates**: a short "Running Nx commands (coding agents)" note, so an agent running *further* generators inside a scaffolded app sees it too.

Docs/templates only; no EJS tags in the note (rendering unaffected). Targets `main`.