### PR TITLE
feat(nx-oc,nx-adsp): default ADSP env to test (UAT); detect deployment appType

### DIFF
--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -92,7 +92,7 @@ npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 | Option | Alias | Required | Description |
 |--------|-------|----------|-------------|
 | `name` | — | Yes | Name of the service |
-| `env` | `-e` | Yes | ADSP environment: `dev`, `test`, or `prod` |
+| `env` | `-e` | No | ADSP environment / access service. Defaults to `test` = access-uat.alberta.ca (UAT — use for dev and pre-prod); `prod` = access.alberta.ca; `dev` = ADSP platform dev (restricted) |
 | `tenant` | `-t` | No | ADSP tenant name; looks up the Keycloak realm automatically via a single browser login |
 | `tenantRealm` | `-tr` | No | Keycloak realm UUID; overrides the realm resolved from `--tenant` |
 | `accessToken` | `-at` | No | Access token for non-interactive retrieval of ADSP configuration |
@@ -110,7 +110,7 @@ npx nx g @abgov/nx-adsp:react-app my-app --env dev --tenant my-tenant
 | Option | Alias | Required | Description |
 |--------|-------|----------|-------------|
 | `name` | — | Yes | Name of the application |
-| `env` | `-e` | Yes | ADSP environment: `dev`, `test`, or `prod` |
+| `env` | `-e` | No | ADSP environment / access service. Defaults to `test` = access-uat.alberta.ca (UAT — use for dev and pre-prod); `prod` = access.alberta.ca; `dev` = ADSP platform dev (restricted) |
 | `tenant` | `-t` | No | ADSP tenant name; looks up the Keycloak realm automatically via a single browser login |
 | `tenantRealm` | `-tr` | No | Keycloak realm UUID; overrides the realm resolved from `--tenant` |
 | `accessToken` | `-at` | No | Access token for non-interactive retrieval of ADSP configuration |
@@ -141,7 +141,7 @@ npx nx g @abgov/nx-adsp:dotnet-service my-service --env dev --accessToken $TOKEN
 | Option | Alias | Required | Description |
 |--------|-------|----------|-------------|
 | `name` | — | Yes | Name of the service |
-| `env` | `-e` | Yes | ADSP environment: `dev`, `test`, or `prod` |
+| `env` | `-e` | No | ADSP environment / access service. Defaults to `test` = access-uat.alberta.ca (UAT — use for dev and pre-prod); `prod` = access.alberta.ca; `dev` = ADSP platform dev (restricted) |
 | `accessToken` | `-at` | No | Access token for non-interactive retrieval of ADSP configuration |
 
 ---
@@ -169,7 +169,7 @@ npx nx g @abgov/nx-adsp:react-form my-app --env test
 | Option | Alias | Required | Description |
 |--------|-------|----------|-------------|
 | `project` | — | Yes | Name of the existing Nx project to add the form component to |
-| `env` | `-e` | Yes | ADSP environment to fetch form definitions from (typically `test`) |
+| `env` | `-e` | No | ADSP environment to fetch form definitions from. Defaults to `test` (UAT / access-uat.alberta.ca) |
 | `accessToken` | `-at` | No | Access token for non-interactive retrieval of ADSP configuration |
 
 ---

--- a/packages/nx-adsp/src/generators/angular-app/schema.json
+++ b/packages/nx-adsp/src/generators/angular-app/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -65,10 +58,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "location",
-              "proxyPass"
-            ]
+            "required": ["location", "proxyPass"]
           }
         },
         {
@@ -81,10 +71,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "location",
-            "proxyPass"
-          ]
+          "required": ["location", "proxyPass"]
         }
       ]
     },
@@ -94,9 +81,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/dotnet-service/schema.json
+++ b/packages/nx-adsp/src/generators/dotnet-service/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "accessToken": {
       "type": "string",
@@ -37,9 +30,6 @@
       "alias": "at"
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/express-service/schema.json
+++ b/packages/nx-adsp/src/generators/express-service/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "accessToken": {
       "type": "string",
@@ -38,7 +31,7 @@
     },
     "tenantRealm": {
       "type": "string",
-      "description": "Keycloak realm UUID. Optional when --tenant is provided \u2014 overrides the realm looked up from the tenant service.",
+      "description": "Keycloak realm UUID. Optional when --tenant is provided — overrides the realm looked up from the tenant service.",
       "alias": "tr"
     },
     "tenant": {
@@ -55,9 +48,18 @@
         "message": "Which database would you like to include?",
         "type": "list",
         "items": [
-          { "value": "none", "label": "None — add a database later" },
-          { "value": "postgres", "label": "PostgreSQL (Drizzle)" },
-          { "value": "mongo", "label": "MongoDB (Mongoose)" }
+          {
+            "value": "none",
+            "label": "None — add a database later"
+          },
+          {
+            "value": "postgres",
+            "label": "PostgreSQL (Drizzle)"
+          },
+          {
+            "value": "mongo",
+            "label": "MongoDB (Mongoose)"
+          }
         ]
       }
     },
@@ -67,9 +69,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/mean/schema.json
+++ b/packages/nx-adsp/src/generators/mean/schema.json
@@ -8,14 +8,17 @@
     "name": {
       "type": "string",
       "description": "Name of the project.",
-      "$default": { "$source": "argv", "index": 0 },
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
       "x-prompt": "What name would you like to use for the project?"
     },
     "env": {
       "type": "string",
-      "description": "ADSP environment to initialize the project for.",
-      "enum": ["dev", "test", "prod"],
-      "default": "prod"
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",

--- a/packages/nx-adsp/src/generators/mern/schema.json
+++ b/packages/nx-adsp/src/generators/mern/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -52,9 +45,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/mevn/schema.json
+++ b/packages/nx-adsp/src/generators/mevn/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -52,9 +45,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/pean/schema.json
+++ b/packages/nx-adsp/src/generators/pean/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -52,9 +45,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/pern/schema.json
+++ b/packages/nx-adsp/src/generators/pern/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -52,9 +45,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/pevn/schema.json
+++ b/packages/nx-adsp/src/generators/pevn/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -52,9 +45,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-app/schema.json
+++ b/packages/nx-adsp/src/generators/react-app/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -65,10 +58,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "location",
-              "proxyPass"
-            ]
+            "required": ["location", "proxyPass"]
           }
         },
         {
@@ -81,10 +71,7 @@
               "type": "string"
             }
           },
-          "required": [
-            "location",
-            "proxyPass"
-          ]
+          "required": ["location", "proxyPass"]
         }
       ]
     },
@@ -94,9 +81,6 @@
       "default": false
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-dotnet/schema.json
+++ b/packages/nx-adsp/src/generators/react-dotnet/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "accessToken": {
       "type": "string",
@@ -37,9 +30,6 @@
       "alias": "at"
     }
   },
-  "required": [
-    "name",
-    "env"
-  ],
+  "required": ["name", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-form/schema.json
+++ b/packages/nx-adsp/src/generators/react-form/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target? (Typically test for ADSP tenants.)",
-        "type": "list",
-        "items": [
-          "test",
-          "prod",
-          "dev"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "accessToken": {
       "type": "string",
@@ -37,9 +30,6 @@
       "alias": "at"
     }
   },
-  "required": [
-    "project",
-    "env"
-  ],
+  "required": ["project", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/react-task-list/schema.json
+++ b/packages/nx-adsp/src/generators/react-task-list/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target? (Typically test for ADSP tenants.)",
-        "type": "list",
-        "items": [
-          "test",
-          "prod",
-          "dev"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "accessToken": {
       "type": "string",
@@ -37,9 +30,6 @@
       "alias": "at"
     }
   },
-  "required": [
-    "project",
-    "env"
-  ],
+  "required": ["project", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/vue-app/schema.json
+++ b/packages/nx-adsp/src/generators/vue-app/schema.json
@@ -15,21 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "tenant": {
       "type": "string",
@@ -58,8 +51,12 @@
           "items": {
             "type": "object",
             "properties": {
-              "location": { "type": "string" },
-              "proxyPass": { "type": "string" }
+              "location": {
+                "type": "string"
+              },
+              "proxyPass": {
+                "type": "string"
+              }
             },
             "required": ["location", "proxyPass"]
           }
@@ -67,8 +64,12 @@
         {
           "type": "object",
           "properties": {
-            "location": { "type": "string" },
-            "proxyPass": { "type": "string" }
+            "location": {
+              "type": "string"
+            },
+            "proxyPass": {
+              "type": "string"
+            }
           },
           "required": ["location", "proxyPass"]
         }

--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -253,7 +253,7 @@ describe('Deployment Generator', () => {
     expect(manifest).not.toContain('initContainers');
   });
 
-  it('can skip unknown project type', async () => {
+  it('throws an actionable error when the app type cannot be detected', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await pipeline(host, {
       pipeline: 'test',
@@ -273,10 +273,11 @@ describe('Deployment Generator', () => {
       },
     });
 
-    await generator(host, { ...options, appType: null });
+    // Unrecognized build executor + no --appType → detection fails → actionable throw.
+    await expect(
+      generator(host, { ...options, appType: null })
+    ).rejects.toThrow(/--appType/);
     expect(host.exists('.openshift/test/test.yml')).toBeFalsy();
-    expect(host.exists('.openshift/test/Dockerfile')).toBeFalsy();
-
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['apply-envs']).toBeFalsy();
   });

--- a/packages/nx-oc/src/generators/deployment/deployment.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.ts
@@ -85,8 +85,10 @@ export default async function (host: Tree, options: Schema) {
 
   const normalizedOptions = await normalizeOptions(host, options);
   if (!normalizedOptions.appType) {
-    console.log('Cannot generate deployment for unknown project type.');
-    return;
+    throw new Error(
+      `Could not detect the application type for "${normalizedOptions.projectName}" from its build target. ` +
+        `Pass --appType=node|frontend|dotnet to set it explicitly.`
+    );
   }
 
   config.targets = {

--- a/packages/nx-oc/src/generators/deployment/schema.json
+++ b/packages/nx-oc/src/generators/deployment/schema.json
@@ -15,39 +15,23 @@
     },
     "appType": {
       "type": "string",
-      "description": "Type of application.",
+      "description": "Application type. Auto-detected from the project build target; only pass this to override detection.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
-      "alias": "t",
-      "x-prompt": {
-        "message": "What type of application is the project?",
-        "type": "list",
-        "items": [
-          "frontend",
-          "dotnet",
-          "node"
-        ]
-      }
+      "enum": ["frontend", "node", "dotnet"]
     },
     "env": {
       "type": "string",
-      "description": "Environment to target.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 2
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which ADSP environment do you want to target?",
-        "type": "list",
-        "items": [
-          "dev",
-          "test",
-          "prod"
-        ]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     },
     "accessToken": {
       "type": "string",
@@ -64,10 +48,6 @@
       "description": "Generate a sandbox deployment manifest (local image push, no ImageStream trigger)."
     }
   },
-  "required": [
-    "project",
-    "appType",
-    "env"
-  ],
+  "required": ["project", "appType", "env"],
   "additionalProperties": false
 }

--- a/packages/nx-oc/src/generators/sandbox/schema.json
+++ b/packages/nx-oc/src/generators/sandbox/schema.json
@@ -31,8 +31,9 @@
     },
     "env": {
       "type": "string",
-      "description": "ADSP environment to target.",
-      "default": "dev"
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
+      "default": "test",
+      "enum": ["test", "prod", "dev"]
     },
     "accessToken": {
       "type": "string",

--- a/packages/nx-oc/src/generators/teardown/schema.json
+++ b/packages/nx-oc/src/generators/teardown/schema.json
@@ -15,17 +15,14 @@
     },
     "env": {
       "type": "string",
-      "description": "Environment to target for teardown.",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
       "$default": {
         "$source": "argv",
         "index": 1
       },
       "alias": "e",
-      "x-prompt": {
-        "message": "Which environment to target?",
-        "type": "list",
-        "items": ["dev", "test", "prod"]
-      }
+      "enum": ["test", "prod", "dev"],
+      "default": "test"
     }
   },
   "required": ["project", "env"],


### PR DESCRIPTION
Reduces avoidable interactive prompts in the generators (follow-up to the `appType` prompt work).

## `env` → default `test` (UAT)
App teams get `access-uat` (UAT) for their dev **and** pre-prod work, and `access` for prod; the ADSP platform `dev` environment generally isn't granted to them. So:
- default `--env` to **`test`** (= `access-uat.alberta.ca`) across every generator that targets an ADSP environment (apps, composites, `deployment`, `sandbox`, `teardown`),
- drop the interactive `env` prompt, add an `enum`, and clarify the description with the access-service mapping.

`--env` still overrides. This matches the *"typically test"* hint the `react-form`/`react-task-list` prompts already carried, and aligns the odd cases (`mean` defaulted to `prod`, `sandbox` to `dev`).

## `deployment` `appType` → detect, don't prompt
The `deployment` generator already detects the type (`options.appType ?? detectApplicationType(config)`), but the schema `x-prompt` fired first and asked interactively — the same redundant prompt the sandbox generator had (fixed in #293). Removed the `x-prompt` (and the `-t` alias that collided with `--tenant`), added an `enum`, and replaced the silent unknown-type `console.log`+return with an actionable throw naming `--appType`.

## Tests
nx-oc **110** + nx-adsp **37** pass, build + lint clean. Updated the deployment spec's unknown-type case to assert the actionable throw. README `env` option rows updated to reflect the default + mapping.

Targets `main` (v13; verifiable in-repo).