### PR TITLE
fix(nx-adsp): vue Sign in button hidden (ready-gated) + clean up nx demo

### DIFF
--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.spec.ts__tmpl__
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@dsb-norge/vue-keycloak-js', () => ({
+  useKeycloak: () => ({
+    authenticated: ref(false),
+    fullName: ref(''),
+    // ready stays false — Keycloak's check-sso hasn't resolved (or failed).
+    ready: ref(false),
+    keycloak: { login: vi.fn(), logout: vi.fn() },
+  }),
+}));
+
+import App from './App.vue';
+
+describe('App shell header', () => {
+  it('shows Sign in when unauthenticated even before Keycloak is ready', () => {
+    const wrapper = mount(App, { global: { stubs: { RouterView: true } } });
+
+    // The sign-in affordance must not be gated on `ready`: if check-sso never
+    // resolves, the button would be hidden and the user could never log in.
+    const group = wrapper.find('goa-button-group');
+    expect(group.exists()).toBe(true);
+    expect(group.html()).toContain('Sign in');
+  });
+});

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -2,7 +2,7 @@
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 import { RouterView } from 'vue-router';
 
-const { authenticated, fullName, ready, keycloak } = useKeycloak();
+const { authenticated, fullName, keycloak } = useKeycloak();
 
 function login() { keycloak?.login(); }
 function logout() { keycloak?.logout({ redirectUri: window.location.origin }); }
@@ -11,13 +11,18 @@ function logout() { keycloak?.logout({ redirectUri: window.location.origin }); }
 <template>
   <goa-microsite-header type="alpha" />
   <goa-app-header url="/" heading="<%= projectName %>">
-    <span v-if="ready && fullName">{{ fullName }}</span>
-    <goa-button v-if="!authenticated && ready" type="tertiary" @_click="login">
-      Sign in
-    </goa-button>
-    <goa-button v-if="authenticated" type="tertiary" @_click="logout">
-      Sign out
-    </goa-button>
+    <goa-button-group alignment="end">
+      <span v-if="authenticated && fullName">{{ fullName }}</span>
+      <!-- Gate on !authenticated only, not `ready`: if Keycloak's check-sso
+           doesn't resolve (e.g. the silent-SSO iframe is blocked), we still
+           want the sign-in affordance — login() does a full redirect anyway. -->
+      <goa-button v-if="!authenticated" type="tertiary" @_click="login">
+        Sign in
+      </goa-button>
+      <goa-button v-if="authenticated" type="tertiary" @_click="logout">
+        Sign out
+      </goa-button>
+    </goa-button-group>
   </goa-app-header>
   <goa-hero-banner heading="<%= projectName %>" backgroundurl="/assets/banner.jpg" />
   <main>

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -83,6 +83,27 @@ describe('Vue App Generator', () => {
     expect(viteConfig).toContain("isCustomElement: (tag) => tag.startsWith('goa-')");
   }, 30000);
 
+  it('shows the Sign in button without gating on Keycloak readiness', async () => {
+    await generator(host, options);
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).toContain('Sign in');
+    // The reported bug: gating Sign in on `ready` hides it when check-sso never
+    // resolves. It must gate on !authenticated only (like the react/angular apps).
+    expect(app).not.toContain('!authenticated && ready');
+    // Header actions grouped for layout, matching react/angular.
+    expect(app).toContain('goa-button-group');
+  }, 30000);
+
+  it('removes the @nx/vue demo scaffold and ships a passing App test', async () => {
+    await generator(host, options);
+    // The stale nx demo + its failing test must be gone (they fail against our shell).
+    expect(host.exists('apps/test/src/app/App.vue')).toBeFalsy();
+    expect(host.exists('apps/test/src/app/App.spec.ts')).toBeFalsy();
+    expect(host.exists('apps/test/src/app/NxWelcome.vue')).toBeFalsy();
+    // Replaced by our own App test.
+    expect(host.exists('apps/test/src/App.spec.ts')).toBeTruthy();
+  }, 30000);
+
   it('environment.ts is pre-populated with tenant config', async () => {
     await generator(host, options);
     const env = host.read('apps/test/src/environments/environment.ts').toString();

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -97,11 +97,17 @@ export default async function (host: Tree, options: Schema) {
     }
   );
 
-  // Remove Nx scaffold files replaced by our templates. The @nx/vue generator
-  // emits vite.config.mts; we provide a GoA-aware vite.config.ts, so drop the
-  // duplicate to avoid two competing configs.
+  // Remove Nx scaffold files replaced by our templates. @nx/vue (Nx 23) scaffolds
+  // its demo under src/app/ (App.vue, App.spec.ts, NxWelcome.vue) and emits
+  // vite.config.mts; we provide our own App.vue (at src root), views, and a
+  // GoA-aware vite.config.ts. Drop the demo + its now-stale test (which fails
+  // against our shell) and the duplicate config. Paths from older @nx/vue
+  // layouts are kept for safety — host.delete is a no-op when they're absent.
   for (const f of [
     'src/App.vue',
+    'src/app/App.vue',
+    'src/app/App.spec.ts',
+    'src/app/NxWelcome.vue',
     'src/components/HelloWorld.vue',
     'src/views/AboutView.vue',
     'vite.config.mts',


### PR DESCRIPTION
Reported: the sign-in button on a generated Vue app is hidden. **Verified locally with the Vite dev server** (headless-Chrome screenshots) — which corrected my initial guess.

## 1. Sign in button hidden (the real cause)
The header gated the button on `v-if="!authenticated && ready"`. When Keycloak's `check-sso` doesn't resolve — a dev server on a port the client hasn't registered, or a blocked silent-SSO iframe — **`ready` stays false and the button never renders**, so the user can't sign in at all.

Screenshots proved it: as-generated, `ready=false` and no button; force-rendering the button (bare *or* in a group) showed it fine — so the button-group was **not** the cause. Removing the `&& ready` gate (→ `v-if="!authenticated"`) makes the button appear. `login()` does a full redirect, so it works regardless of `check-sso`. This matches the **react-app/angular-app** templates, which gate on `!authenticated` only.

Also wrapped the actions in `<goa-button-group alignment="end">` for react/angular consistency (a cosmetic alignment, not the fix).

## 2. Stale `@nx/vue` demo left behind (found while verifying)
`nx test <app>` **fails out of the box**: the generator's cleanup list targeted old paths (`src/App.vue`, `src/components/HelloWorld.vue`), but `@nx/vue` on Nx 23 scaffolds its demo under **`src/app/`** (`App.vue`, `App.spec.ts`, `NxWelcome.vue`). The demo + its test survived as dead code, and that test fails against our shell. Delete the `src/app/` demo and ship our own `App.spec.ts` (asserts Sign in renders even when `ready=false` — guarding fix #1).

## Verification
- **Live dev server**: `ready=false authed=false` → no button (repro) → after removing the `&& ready` gate, Sign in appears in the header (screenshot).
- **`nx test <app>`**: green (stale failing test gone; new App test passes).
- nx-adsp vue-app spec: **10 pass** (asserts no `!authenticated && ready` gate, the button-group wrapper, and the demo cleanup); build + lint clean.

Targets `main` (v13; verifiable in-repo).