### PR TITLE
docs(nx-adsp): improve express-service AGENTS.md (DB/migration flow, module factoring, end-to-end recipe)

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -69,45 +69,163 @@ To call another service with an access token:
 const token = await tokenProvider.getAccessToken();
 ```
 
+## Project structure & code factoring
+
+`main.ts` is the **composition root** — it initializes the SDK, wires middleware,
+mounts routers, starts the server, and mounts the error handler last. Keep feature
+code out of it. Conventional layout:
+
+```
+src/
+  main.ts                  # composition root — no business logic
+  routes/<resource>.ts     # one express.Router() per resource; thin HTTP handlers
+  services/<resource>.ts   # business logic — no req/res, unit-testable
+<% if (database === 'postgres') { %>  db/schema.ts             # Drizzle tables
+  database.ts              # shared `db` instance
+<% } else if (database === 'mongo') { %>  models/<resource>.ts     # Mongoose models
+  database.ts              # connection helpers
+<% } %>  events.ts                # domain event definitions
+```
+
+Rules of thumb:
+
+- **Do not inline route handlers in `main.ts`.** Add an `express.Router()` per
+  resource under `routes/` and mount it. The example routes in `main.ts` are
+  starters — replace them with mounted routers as you build real features.
+- **Keep handlers thin** — validate input, call a service, shape the response.
+  Put non-trivial logic in `services/` so it can be tested without HTTP.
+- **One responsibility per module** — routers do HTTP, services do logic, the db
+  layer does persistence.
+- **Pass runtime capabilities in; don't import them.** `logger` and `eventService`
+  come from `initializeService()` in `main.ts`, so pass them into a router/service
+  as arguments (e.g. `itemsRouter(eventService)`). Only module-level singletons —
+  the `db` instance, Mongoose models — are imported directly.
+
 ## Adding routes
 
-Add route handlers in `main.ts` under the `/<%= projectName %>/v1` path prefix.
-`passport.authenticate(['tenant', 'anonymous'])` is applied to the entire prefix —
-`req.user` is null for anonymous requests and populated for authenticated ones.
+Factor each resource into its own router module and mount it in `main.ts`.
 
-**Public route:**
 ```typescript
-app.get('/<%= projectName %>/v1/my-resource', (req, res) => {
-  res.json({ ... });
-});
-```
-
-**Protected route** (requires a role, validates input, publishes an event):
-```typescript
+// src/routes/items.ts
+import { Router } from 'express';
 import { authorize, createValidationHandler } from '@abgov/adsp-service-sdk';
 import { z } from 'zod';
+import * as items from '../services/items';
 
-const MySchema = z.object({ name: z.string().min(1) });
+const CreateItem = z.object({ name: z.string().min(1) });
 
-app.post(
-  '/<%= projectName %>/v1/my-resource',
-  authorize('my-role'),                   // 403 if authenticated user lacks role
-  createValidationHandler(MySchema),      // 400 if body fails schema
-  async (req, res, next) => {
+export function itemsRouter(): Router {
+  const router = Router();
+
+  // Anonymous is allowed on the /v1 prefix, so req.user may be null here.
+  router.get('/', async (_req, res, next) => {
     try {
-      const { name } = req.body as z.infer<typeof MySchema>;
-      eventService.send(createMyEvent(name));
-      res.json({ name });
+      res.json(await items.list());
     } catch (err) {
-      next(err);                          // createErrorHandler maps to 500
+      next(err);
     }
-  }
-);
+  });
+
+  // Protected: require a role, validate the body, then delegate to the service.
+  router.post(
+    '/',
+    authorize('item-writer'),
+    createValidationHandler(CreateItem),
+    async (req, res, next) => {
+      try {
+        const { name } = req.body as z.infer<typeof CreateItem>;
+        res.status(201).json(await items.create(name));
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}
 ```
 
-Both `authorize` and `createValidationHandler` pass errors to `next()` —
-`createErrorHandler(logger)` at the bottom of `main.ts` translates them to
-structured HTTP responses (401/403 and 400 respectively).
+Mount it in `main.ts` — after the passport/configuration middleware, before
+`createErrorHandler`:
+
+```typescript
+import { itemsRouter } from './routes/items';
+// ...
+app.use('/<%= projectName %>/v1/items', itemsRouter());
+```
+
+`authorize(role)` → 403 if the user lacks the role; `createValidationHandler(schema)`
+→ 400 on a bad body. Both forward errors to `next()`, which `createErrorHandler`
+(mounted last in `main.ts`) turns into structured HTTP responses.
+
+## Recipe: add a resource end to end
+
+Build a feature the conventional way — persistence, a service, a router, wiring,
+and a test. (Replace the inline example routes in `main.ts` with resources built
+like this.)
+
+<% if (database === 'postgres') { %>1. **Table** — add it to `src/db/schema.ts`, then `nx db:generate <%= projectName %>` and `nx db:migrate <%= projectName %>` (see "Adding a table").
+<% } else if (database === 'mongo') { %>1. **Model** — add a Mongoose model (see "Adding a Mongoose model").
+<% } else { %>1. **Data source** — back the resource with your store (this service has no database configured).
+<% } %>
+2. **Service** — put the logic in `src/services/items.ts`, with no `req`/`res` so
+   it is unit-testable in isolation:
+
+```typescript
+// src/services/items.ts
+<% if (database === 'postgres') { %>import { db } from '../database';
+import { items } from '../db/schema';
+
+export const list = () => db.select().from(items);
+export const create = async (name: string) => {
+  const [row] = await db.insert(items).values({ name }).returning();
+  return row;
+};<% } else if (database === 'mongo') { %>import { ItemModel } from '../models/item';
+
+export const list = () => ItemModel.find().lean();
+export const create = (name: string) => ItemModel.create({ name });<% } else { %>const store: { id: number; name: string }[] = [];
+
+export const list = async () => store;
+export const create = async (name: string) => {
+  const row = { id: store.length + 1, name };
+  store.push(row);
+  return row;
+};<% } %>
+```
+
+3. **Event** (optional) — define it in `src/events.ts` and register it in
+   `initializeService({ events })`. To emit it, have the router factory accept
+   `eventService` — `itemsRouter(eventService)` — and call `eventService.send(...)`
+   in the handler after a successful write (see "Domain events").
+
+4. **Router** — create `src/routes/items.ts` as in "Adding routes" above: thin
+   handlers that validate, call the service, and shape the response.
+
+5. **Mount** — in `main.ts`: `app.use('/<%= projectName %>/v1/items', itemsRouter());`
+
+6. **Test** — mount the router with supertest and mock the service (no DB, no
+   server needed):
+
+```typescript
+import request from 'supertest';
+import express from 'express';
+import { itemsRouter } from './items';
+
+jest.mock('../services/items', () => ({
+  list: async () => [{ id: 1, name: 'first' }],
+  create: jest.fn(),
+}));
+
+describe('items router', () => {
+  it('GET / returns items', async () => {
+    const app = express().use(express.json());
+    app.use('/items', itemsRouter());
+    const res = await request(app).get('/items');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 1, name: 'first' }]);
+  });
+});
+```
 
 ## Adding an environment variable
 

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -186,17 +186,34 @@ app.get('/<%= projectName %>/v1/items', async (_req, res) => {
 by `migrate.js` (bundled from `src/migrate.ts`), which uses only `drizzle-orm` +
 `pg` — no CLI and no native engine — so it runs under OpenShift's arbitrary UID.
 
-## OpenShift deployment — database
+## Database in OpenShift — migrations run automatically
 
-The deployment manifest references a Secret named `{appName}-database` for the
-`DATABASE_URL` value, and runs `node migrate.js` as an init container before the
-application starts. The generated SQL migrations in `drizzle/` are shipped into
-the build output as assets so the init container can apply them.
+Migrations are applied at deploy time by an **init container** named
+`<%= projectName %>-migrate`, which runs `node migrate.js` (everything in
+`drizzle/`) against the database **before the app container starts** — so a
+deploy always brings the schema up to date, and the app never starts against a
+stale DB. `migrate.js` is bundled from `src/migrate.ts` using only `drizzle-orm`
++ `pg` (no `drizzle-kit` CLI, no native engine), so it runs under OpenShift's
+arbitrary UID; it logs `No migrations to apply.` and exits 0 when `drizzle/` is
+empty. The `drizzle/` folder is shipped into the build output as a build asset.
 
-Create the Secret in each OpenShift namespace before first deploy:
+**Sandbox** (`nx run <%= projectName %>:sandbox`) — nothing to set up. The
+sandbox target provisions a shared `sandbox-postgres` instance, creates this
+service's `<%= projectName %>_sandbox` database, and injects `DATABASE_URL`
+(sourced from the `sandbox-postgres-creds` secret) into both the init container
+and the app. If a deploy fails on migrations, read the init container's logs:
 
 ```bash
-oc create secret generic <app-name>-database \
+oc logs -n <namespace> <pod> -c <%= projectName %>-migrate
+```
+
+See `.openshift/<%= projectName %>/SANDBOX.md` for the full sandbox runbook.
+
+**dev / test / prod** — the deployment reads `DATABASE_URL` from a Secret named
+`<%= projectName %>-database`. Create it once per namespace before the first deploy:
+
+```bash
+oc create secret generic <%= projectName %>-database \
   --from-literal=DATABASE_URL=postgresql://user:password@host:5432/dbname \
   -n <namespace>
 ```
@@ -265,15 +282,18 @@ app.get('/<%= projectName %>/v1/items', async (_req, res) => {
 });
 ```
 
-## OpenShift deployment — database
+## Database in OpenShift
 
-The deployment manifest references a Secret named `{appName}-database` for the
-`MONGODB_URI` value.
+**Sandbox** (`nx run <%= projectName %>:sandbox`) — nothing to set up. The
+sandbox target provisions a shared `sandbox-mongodb` instance and injects
+`MONGODB_URI` (sourced from the `sandbox-mongodb-creds` secret) into the app.
+See `.openshift/<%= projectName %>/SANDBOX.md` for the full sandbox runbook.
 
-Create the Secret in each OpenShift namespace before first deploy:
+**dev / test / prod** — the deployment reads `MONGODB_URI` from a Secret named
+`<%= projectName %>-database`. Create it once per namespace before the first deploy:
 
 ```bash
-oc create secret generic <app-name>-database \
+oc create secret generic <%= projectName %>-database \
   --from-literal=MONGODB_URI=mongodb://user:password@host:27017/dbname \
   -n <namespace>
 ```


### PR DESCRIPTION
Improving the express-service `AGENTS.md` so coding agents implement features the right way. Three related changes:

## 1. Module factoring (agents were inlining handlers in `main.ts`)
The old "Adding routes" section literally said *"Add route handlers in `main.ts`"* — so agents did. Replaced with conventional Node/Express structure:
- **"Project structure & code factoring"**: `main.ts` is the composition root (no business logic); one `express.Router()` per resource under `routes/`; logic in `services/` (no `req`/`res`, unit-testable); **pass runtime capabilities (`logger`, `eventService`) in** rather than importing them (only module-level singletons like the `db` instance are imported).
- **"Adding routes"** rewritten to show a router module mounted via `app.use()`.

## 2. End-to-end recipe
New **"Recipe: add a resource end to end"** — table/model → service → domain event → router → mount → supertest test — tying the layers together. The service snippet is database-aware (drizzle / mongoose / in-memory for `none`).

## 3. Database/migration deploy flow (the earlier commit)
The DB section only covered the dev/prod path; rewrote it to lead with the **automatic migrate init container** and cover **sandbox** (auto-provisioned) vs dev/prod (manual secret), with the `oc logs … -c <app>-migrate` debug command.

Docs-only; express-service unit tests pass; rendered output verified for a postgres app. Targets `main`.