### PR TITLE
fix(nx-adsp): skip the agent consultation in non-interactive runs

### DIFF
--- a/packages/nx-adsp/src/utils/agent.spec.ts
+++ b/packages/nx-adsp/src/utils/agent.spec.ts
@@ -1,4 +1,4 @@
-import { consultAgent } from './agent';
+import { consultAgent, isNonInteractive } from './agent';
 
 jest.mock('readline', () => ({
   createInterface: jest.fn(() => ({
@@ -61,9 +61,23 @@ function makeMockSocket() {
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
 describe('consultAgent', () => {
+  const ORIGINAL_ARGV = process.argv;
+  const ORIGINAL_TTY = process.stdout.isTTY;
+  const ORIGINAL_CI = process.env.CI;
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    // consultAgent short-circuits when non-interactive; force an interactive
+    // TTY (no flag, no CI) so these tests exercise the interactive flow.
+    process.argv = ['node', 'nx'];
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    delete process.env.CI;
+  });
+  afterAll(() => {
+    process.argv = ORIGINAL_ARGV;
+    Object.defineProperty(process.stdout, 'isTTY', { value: ORIGINAL_TTY, configurable: true });
+    if (ORIGINAL_CI === undefined) delete process.env.CI;
+    else process.env.CI = ORIGINAL_CI;
   });
 
   it('returns null when agent-service is not in directory', async () => {
@@ -146,5 +160,53 @@ describe('consultAgent', () => {
         content: expect.stringContaining('src/main.ts'),
       })
     );
+  });
+});
+
+describe('isNonInteractive', () => {
+  const ORIGINAL_ARGV = process.argv;
+  const ORIGINAL_TTY = process.stdout.isTTY;
+  const ORIGINAL_CI = process.env.CI;
+  const setTTY = (v: boolean | undefined) =>
+    Object.defineProperty(process.stdout, 'isTTY', { value: v, configurable: true });
+
+  afterEach(() => {
+    process.argv = ORIGINAL_ARGV;
+    setTTY(ORIGINAL_TTY);
+    if (ORIGINAL_CI === undefined) delete process.env.CI;
+    else process.env.CI = ORIGINAL_CI;
+  });
+
+  it('is true when --no-interactive is passed, even in an interactive TTY', () => {
+    setTTY(true);
+    delete process.env.CI;
+    process.argv = ['node', 'nx', 'g', 'x', '--no-interactive'];
+    expect(isNonInteractive()).toBe(true);
+  });
+
+  it('honors --interactive=false and --interactive false', () => {
+    setTTY(true);
+    delete process.env.CI;
+    process.argv = ['node', 'nx', 'g', 'x', '--interactive=false'];
+    expect(isNonInteractive()).toBe(true);
+    process.argv = ['node', 'nx', 'g', 'x', '--interactive', 'false'];
+    expect(isNonInteractive()).toBe(true);
+  });
+
+  it('is true without a TTY or on CI', () => {
+    setTTY(false);
+    delete process.env.CI;
+    process.argv = ['node', 'nx'];
+    expect(isNonInteractive()).toBe(true);
+    setTTY(true);
+    process.env.CI = 'true';
+    expect(isNonInteractive()).toBe(true);
+  });
+
+  it('is false in an interactive TTY with no flag and no CI', () => {
+    setTTY(true);
+    delete process.env.CI;
+    process.argv = ['node', 'nx', 'g', 'x'];
+    expect(isNonInteractive()).toBe(false);
   });
 });

--- a/packages/nx-adsp/src/utils/agent.ts
+++ b/packages/nx-adsp/src/utils/agent.ts
@@ -6,6 +6,32 @@ import { getServiceUrls } from '@abgov/nx-oc';
 const AGENT_SERVICE_URN = 'urn:ads:platform:agent-service:v1';
 const AGENT_ID = 'nxAdspAgent';
 
+// The agent consultation is an interactive, stdin-driven conversation, so it must
+// not run unattended (a coding agent, CI, or a piped shell) — it would hang or
+// corrupt stdin.
+//
+// NOTE: this relies on Nx *internal* behavior (not a public API), so re-verify it
+// on Nx upgrades — the two `argv` clauses below are the fragile part:
+//   1. Nx deletes `--interactive` from the generator's options before invoking it
+//      (`delete generatorOptions.interactive` in nx's command-line/generate/generate.js),
+//      so we can't read it from `options`.
+//   2. Nx runs generators in-process, so the CLI args are still on `process.argv`.
+// If Nx ever runs generators out-of-process, or stops stripping the option, the
+// argv detection may go stale. The TTY/CI fallback is the resilient part — it
+// mirrors Nx's own prompt gate (`isTTY()` in command-line utils/params.js:
+// `process.stdout.isTTY && CI !== 'true'`) and still catches unattended runs even
+// if the flag detection breaks. Worst case if all detection fails: the generator
+// prompts and the caller can still pass `--skipAgent`.
+export function isNonInteractive(): boolean {
+  const argv = process.argv;
+  const interactiveIdx = argv.indexOf('--interactive');
+  const flagged =
+    argv.includes('--no-interactive') ||
+    argv.includes('--interactive=false') ||
+    (interactiveIdx !== -1 && argv[interactiveIdx + 1] === 'false');
+  return flagged || !process.stdout.isTTY || process.env.CI === 'true';
+}
+
 // Keep CapabilitySpec exported for backward compatibility and tests,
 // but the primary flow now uses the workspace approach.
 export interface AgentCapability {
@@ -97,6 +123,12 @@ export async function consultAgent(
     additionalRoots?: Record<string, string>;
   }
 ): Promise<AgentResult | null> {
+  if (isNonInteractive()) {
+    process.stdout.write(
+      '\n[nx-adsp] Non-interactive run (--no-interactive / no TTY / CI) — skipping the agent consultation; base scaffolding only.\n'
+    );
+    return null;
+  }
   if (!accessToken) {
     process.stdout.write('\n[nx-adsp] No access token — skipping agent interaction.\n');
     return null;


### PR DESCRIPTION
A coding agent ran a generator **without `--skipAgent`**, which triggered the ADSP agent consultation — an interactive, stdin-driven conversation — and hung (no human to converse with). Honor non-interactive execution so this can't happen.

## Change
`consultAgent()` now no-ops (returns `null`, same as `--skipAgent`) when the run is non-interactive. Detection:
- **The flag** — Nx strips `--interactive` from generator options before invoking the generator (`delete generatorOptions.interactive` in `generate.js`), but the generator runs *in the nx process*, so we read `process.argv` directly: `--no-interactive`, `--interactive=false`, `--interactive false`.
- **Fallback** — Nx's own prompt gate: no TTY, or `CI=true`.

It's a **single-point fix** in `consultAgent()`: every generator and composite that consults the agent already handles a `null` result (base scaffolding only), so no per-generator gate changes were needed. This also makes the e2e and CI runs robust without relying on `--skipAgent`.

## Tests
nx-adsp **41** pass. New `isNonInteractive` coverage (flag variants, TTY/CI fallback, and the interactive case). The existing `consultAgent` tests now force an interactive TTY in `beforeEach` so they still exercise the interactive flow.

Complements #294 (which tells agents to pass `--no-interactive`): now the generators actually honor it for the agent step. Targets `main`.