### PR TITLE
fix(nx-adsp): make Keycloak client provisioning uniformly best-effort

### DIFF
--- a/packages/nx-adsp/src/utils/keycloak-admin.ts
+++ b/packages/nx-adsp/src/utils/keycloak-admin.ts
@@ -64,12 +64,18 @@ async function ensureClientRole(
       headers: { Authorization: `Bearer ${accessToken}` },
     });
   } catch (err) {
+    // Best-effort, like the other ensure* helpers: a role we can't read/create
+    // must not abort provisioning or cause the client secret to be dropped.
     if ((err as { response?: { status?: number } })?.response?.status === 404) {
-      await axios.post(baseUrl, { name: roleName, description }, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-      });
+      try {
+        await axios.post(baseUrl, { name: roleName, description }, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+      } catch (createErr) {
+        logAdminError(clientUuid, createErr);
+      }
     } else {
-      throw err;
+      logAdminError(clientUuid, err);
     }
   }
 }
@@ -130,20 +136,25 @@ async function ensureServiceAccountRoles(
   accessToken: string
 ): Promise<void> {
   const { default: axios } = await import('axios');
+  // Best-effort, like the other ensure* helpers: don't abort provisioning or
+  // drop the client secret if a platform service-account role can't be assigned.
+  try {
+    const userUrl = new URL(
+      `/auth/admin/realms/${realm}/clients/${serviceClientUuid}/service-account-user`,
+      accessServiceUrl
+    ).href;
+    const { data: user } = await axios.get<{ id: string }>(userUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
 
-  const userUrl = new URL(
-    `/auth/admin/realms/${realm}/clients/${serviceClientUuid}/service-account-user`,
-    accessServiceUrl
-  ).href;
-  const { data: user } = await axios.get<{ id: string }>(userUrl, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-  });
-
-  await Promise.all(
-    roles.map(({ platformClientId, roleName }) =>
-      assignRoleToServiceAccount(accessServiceUrl, realm, user.id, platformClientId, roleName, accessToken)
-    )
-  );
+    await Promise.all(
+      roles.map(({ platformClientId, roleName }) =>
+        assignRoleToServiceAccount(accessServiceUrl, realm, user.id, platformClientId, roleName, accessToken)
+      )
+    );
+  } catch (err) {
+    logAdminError(serviceClientUuid, err);
+  }
 }
 
 async function getClientSecret(


### PR DESCRIPTION
The service-client provisioning helpers handled failure inconsistently:

| Helper | On failure (before) |
|---|---|
| `ensurePublicClient` | swallow + log |
| `ensureAudienceMapper` | swallow + log |
| `ensureClientRoleScope` | swallow + log |
| **`ensureClientRole`** | **re-throws** (non-404) |
| **`ensureServiceAccountRoles`** | **no catch → propagates** |

Because the two outliers are `await`ed inside `ensureServiceClient`, a role-mapping failure propagated to its `catch` and returned `null` — so the **`CLIENT_SECRET` was dropped even when the client (and its secret) had just been created**. That left an orphaned Keycloak client and a scaffolded service with no secret (runtime `401 invalid_client`). Meanwhile an audience-mapper failure was swallowed silently — the asymmetry flagged in review.

## Change
Make `ensureClientRole` and `ensureServiceAccountRoles` best-effort too (catch + `logAdminError`, no re-throw), matching the other three. Now:
- Every provisioning step is **non-fatal and logged** — consistent behavior.
- `ensureServiceClient` **always returns the secret once the client is obtained**; incomplete role/mapper provisioning is logged and **converges on a re-run** (all `ensure*` calls are idempotent).
- A genuine inability to create the client or read its secret still returns `null` (unchanged, correct).

nx-adsp build + lint clean; all tests pass. (No behavior change for the frontend/composite generators — they already relied on the best-effort helpers.)