### PR TITLE
docs: drop @beta install guidance now that v13 is stable

### DIFF
--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -44,9 +44,8 @@ npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 ## Full-stack quickstart (PEVN → sandbox)
 
 This is the end-to-end path a coding agent can follow from an empty folder to a
-running full-stack app in an OpenShift sandbox. **The Nx 23 line is published on
-the `@beta` dist-tag** — append `@beta` to installs until it is promoted to
-`latest`.
+running full-stack app in an OpenShift sandbox. The plugins require **Nx 23**,
+which `create-nx-workspace@latest` produces by default.
 
 Prerequisites for the sandbox deploy (steps 4–5): `podman` (machine started on
 macOS), `oc` logged in to the sandbox cluster, and the GitHub CLI (`gh`)
@@ -66,7 +65,7 @@ cd my-solution
 
 # 2. Install the plugins + stack peers (match @nx/* to the workspace nx version)
 NXV=$(node -p "require('./node_modules/nx/package.json').version")
-npm i -D @abgov/nx-oc@beta @abgov/nx-adsp@beta "@nx/express@$NXV" "@nx/vue@$NXV" "@nx/node@$NXV" "@nx/js@$NXV" "@nx/eslint@$NXV"
+npm i -D @abgov/nx-oc @abgov/nx-adsp "@nx/express@$NXV" "@nx/vue@$NXV" "@nx/node@$NXV" "@nx/js@$NXV" "@nx/eslint@$NXV"
 
 # 3. Scaffold a Postgres + Express + Vue + Node solution (opens a browser for the ADSP tenant login)
 npx nx g @abgov/nx-adsp:pevn acme --env=dev --tenant=my-tenant --no-interactive

--- a/packages/nx-oc/README.md
+++ b/packages/nx-oc/README.md
@@ -143,8 +143,8 @@ npx nx run my-app:deploy
 
 For rapid iteration, the `sandbox` generator wires a per-app deploy that builds
 the image **locally with podman**, pushes it to a container registry (GHCR), and
-imports it into your OpenShift namespace — no git push or CI wait. The Nx 23 line
-that ships this is on the `@beta` dist-tag.
+imports it into your OpenShift namespace — no git push or CI wait. (Requires the
+Nx 23 line, `@abgov/nx-oc` 13.x.)
 
 ```bash
 # Add the sandbox targets to a project (run once per app)


### PR DESCRIPTION
v13 (Nx 23) graduated to the `latest` dist-tag in #292, so the READMEs should no longer tell consumers to install `@beta`.

- **nx-adsp**: the full-stack quickstart no longer says "the Nx 23 line is on `@beta` — append `@beta`"; installs are plain `npm i -D @abgov/nx-oc @abgov/nx-adsp …`, with a note that the plugins require Nx 23 (what `create-nx-workspace@latest` produces).
- **nx-oc**: the sandbox section's "ships on the `@beta` dist-tag" note becomes "requires the Nx 23 line (`@abgov/nx-oc` 13.x)".

No remaining consumer-facing `@beta` install guidance; fences balanced. (Contributor references to the `beta` *branch* as the prerelease channel are left intact — that's still accurate.) Docs-only, targets `main`.