### PR TITLE
fix(nx-adsp): jest coverage config invalid when coverageDirectory has no trailing comma

### DIFF
--- a/packages/nx-adsp/src/utils/quality.spec.ts
+++ b/packages/nx-adsp/src/utils/quality.spec.ts
@@ -1,0 +1,67 @@
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { addJestCoverageConfig } from './quality';
+
+function makeConfig(coverageDirectoryLine: string): string {
+  return [
+    'module.exports = {',
+    "  displayName: 'svc',",
+    "  preset: '../../jest.preset.js',",
+    `  ${coverageDirectoryLine}`,
+    '};',
+    '',
+  ].join('\n');
+}
+
+// Parse the exported object literal; throws SyntaxError if the config is invalid
+// (e.g. a property with no separating comma).
+function evalConfigObject(src: string): Record<string, unknown> {
+  const body = src.slice(src.indexOf('{'), src.lastIndexOf('}') + 1);
+  return new Function(`return (${body})`)() as Record<string, unknown>;
+}
+
+describe('addJestCoverageConfig', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('inserts a comma when coverageDirectory is the last property (no trailing comma)', () => {
+    // The @nx/jest (Nx 23) template leaves coverageDirectory without a trailing comma.
+    tree.write(
+      'apps/svc/jest.config.cts',
+      makeConfig("coverageDirectory: 'test-output/jest/coverage'")
+    );
+
+    addJestCoverageConfig(tree, 'apps/svc');
+    const out = tree.read('apps/svc/jest.config.cts').toString();
+
+    expect(out).toContain("coverageDirectory: 'test-output/jest/coverage',");
+    expect(out).toContain('collectCoverage: true,');
+    expect(out).toContain('lines: 60,');
+    expect(out).not.toContain(',,');
+    // The result must be a valid object literal.
+    const cfg = evalConfigObject(out);
+    expect(cfg.collectCoverage).toBe(true);
+    expect((cfg.coverageThreshold as { global: { lines: number } }).global.lines).toBe(60);
+  });
+
+  it('does not double the comma when coverageDirectory already has one', () => {
+    tree.write(
+      'apps/svc/jest.config.cts',
+      makeConfig("coverageDirectory: '../../coverage/svc',")
+    );
+
+    addJestCoverageConfig(tree, 'apps/svc');
+    const out = tree.read('apps/svc/jest.config.cts').toString();
+
+    expect(out).toContain("coverageDirectory: '../../coverage/svc',");
+    expect(out).not.toContain(',,');
+    expect(() => evalConfigObject(out)).not.toThrow();
+  });
+
+  it('is a no-op when there is no jest config', () => {
+    expect(() => addJestCoverageConfig(tree, 'apps/none')).not.toThrow();
+    expect(tree.exists('apps/none/jest.config.cts')).toBe(false);
+  });
+});

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -56,9 +56,13 @@ export function addJestCoverageConfig(host: Tree, projectRoot: string): void {
   if (!host.exists(jestPath)) return;
 
   const existing = host.read(jestPath).toString();
+  // Capture the coverageDirectory line WITHOUT its trailing comma, then re-emit
+  // it with one before the inserted properties. @nx/jest may leave
+  // coverageDirectory as the last property (no trailing comma), so appending
+  // properties after it verbatim would produce an invalid object literal.
   const modified = existing.replace(
-    /([ \t]*coverageDirectory:[^\n]+\n)/,
-    `$1  collectCoverage: true,\n  coverageThreshold: {\n    global: {\n      lines: 60,\n    },\n  },\n`
+    /([ \t]*coverageDirectory:[^\n]*?),?\n/,
+    `$1,\n  collectCoverage: true,\n  coverageThreshold: {\n    global: {\n      lines: 60,\n    },\n  },\n`
   );
   if (modified !== existing) {
     host.write(jestPath, modified);


### PR DESCRIPTION
`addJestCoverageConfig` inserted `collectCoverage` / `coverageThreshold` immediately after the `coverageDirectory` line, assuming it ended with a comma. But **@nx/jest on Nx 23 emits `coverageDirectory` as the last property with no trailing comma**, so the insertion produced:

```js
  coverageDirectory: 'test-output/jest/coverage'
  collectCoverage: true,      // ← no comma above → invalid object literal
```

That's a syntax error in `jest.config.cts`, breaking `nx test <project>` for a freshly generated service.

## Fix
Capture the `coverageDirectory` line **without** its (optional) trailing comma, then re-emit it with exactly one comma before the inserted properties:
```
/([ \t]*coverageDirectory:[^\n]*?),?\n/  →  `$1,\n  collectCoverage: true, …`
```
Valid whether or not the template had a comma, and it never doubles an existing one.

## Tests
New `quality.spec.ts` covers both cases (no-comma and with-comma) and **parses the resulting object literal** to assert it's syntactically valid, plus the no-config no-op. 3 pass; nx-adsp build + lint clean.