### PR TITLE
fix(nx-adsp): vue Sign in no-op — restore useKeycloak() reactivity + drop all hanging init iframes

### DIFF
--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -43,21 +43,33 @@ executors read options from `project.json` and do not prompt.
 ```typescript
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 
-// useKeycloak() returns a DeepReadonly<VueKeycloakInstance>
-const { authenticated, fullName, ready, token, tokenParsed, keycloak } = useKeycloak();
+// useKeycloak() returns a readonly(reactive(...)) instance. Keep the object and
+// read fields off it — do NOT destructure. Destructuring snapshots each field at
+// setup time, so `kc.keycloak` would freeze at `undefined` (login() a no-op) and
+// `kc.authenticated` would never flip to true. All fields populate asynchronously
+// once Keycloak's init settles.
+const kc = useKeycloak();
 
-authenticated       // Ref<boolean> — true after sign-in
-fullName            // Ref<string | undefined> — display name from token
-ready               // Ref<boolean> — true once Keycloak init has settled
-token               // Ref<string | undefined> — current access token
+kc.authenticated    // boolean — true after sign-in
+kc.fullName         // string | undefined — display name from token
+kc.ready            // boolean — true once Keycloak init has settled
+kc.token            // string | undefined — current access token
 
 // Call Keycloak actions via the underlying keycloak-js instance:
-keycloak?.login()
-keycloak?.logout({ redirectUri: window.location.origin })
+kc.keycloak?.login()
+kc.keycloak?.logout({ redirectUri: window.location.origin })
 
 // Refresh token before an authenticated API call:
-await keycloak?.updateToken(30);
-const bearer = keycloak?.token;
+await kc.keycloak?.updateToken(30);
+const bearer = kc.keycloak?.token;
+```
+
+To run work when auth settles (it flips after mount, e.g. on return from the
+login redirect), `watch` it rather than reading once:
+
+```typescript
+import { watch } from 'vue';
+watch(() => kc.authenticated, (authed) => { if (authed) loadPrivateData(); }, { immediate: true });
 ```
 
 Route guard (in `router/index.ts`):
@@ -65,10 +77,10 @@ Route guard (in `router/index.ts`):
 ```typescript
 router.beforeEach((to) => {
   if (to.meta.requiresAuth) {
-    const { authenticated, ready, keycloak } = useKeycloak();
-    if (!ready) return true;    // let Keycloak init settle first
-    if (!authenticated) {
-      keycloak?.login({ redirectUri: window.location.origin + to.fullPath });
+    const kc = useKeycloak();
+    if (!kc.ready) return true;    // let Keycloak init settle first
+    if (!kc.authenticated) {
+      kc.keycloak?.login({ redirectUri: window.location.origin + to.fullPath });
       return false;
     }
   }

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -40,6 +40,17 @@ executors read options from `project.json` and do not prompt.
 
 ## Auth pattern
 
+> ⚠️ **Never destructure `useKeycloak()`.** Unlike most Vue composables (which
+> return `ref`s that survive destructuring), this wrapper returns a
+> `readonly(reactive({...}))` whose fields are **plain values** — `authenticated`
+> is a `boolean`, `keycloak` is the instance-or-`undefined`, etc. Every field is
+> `false`/`undefined` at setup time and only populates **asynchronously** once
+> Keycloak's init settles. `const { keycloak } = useKeycloak()` therefore captures
+> a permanent `undefined`, so `keycloak?.login()` becomes a silent no-op and
+> `authenticated` never flips — and it *looks* fine because the initial render is
+> correct. Always keep the object (`const kc = useKeycloak()`) and read `kc.field`
+> at call/render time. This is the single most common way to break auth here.
+
 ```typescript
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -155,7 +155,6 @@ nx run <%= projectName %>:teardown-dev      # remove from dev environment
 
 - `src/main.ts` — Keycloak plugin is registered once here; do not call `new Keycloak()` elsewhere
 - `environments/environment.ts` — access URL and realm are pre-configured for the ADSP tenant
-- `silent-check-sso.html` — required for keycloak-js silent SSO; must be served from the app root
 - `vite.config.ts` — the `isCustomElement` predicate must stay to suppress Vue warnings for `goa-*` elements
 
 ## Sandbox deployment (local build)

--- a/packages/nx-adsp/src/generators/vue-app/files/public/nginx.conf__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/public/nginx.conf__tmpl__
@@ -26,10 +26,6 @@ http {
       add_header Cache-Control "public, no-transform";
     }
 
-    location = /silent-check-sso.html {
-      add_header Cache-Control "no-store";
-    }
-
     location / {
       try_files $uri /index.html;
     }

--- a/packages/nx-adsp/src/generators/vue-app/files/public/silent-check-sso.html__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/public/silent-check-sso.html__tmpl__
@@ -1,5 +1,0 @@
-<html>
-<body>
-<script>parent.postMessage(location.href, location.origin);</script>
-</body>
-</html>

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.spec.ts__tmpl__
@@ -1,27 +1,38 @@
 import { mount } from '@vue/test-utils';
-import { ref } from 'vue';
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('@dsb-norge/vue-keycloak-js', () => ({
-  useKeycloak: () => ({
-    authenticated: ref(false),
-    fullName: ref(''),
-    // ready stays false — Keycloak's check-sso hasn't resolved (or failed).
-    ready: ref(false),
+// Mirror the real wrapper: useKeycloak() returns a reactive() whose fields are
+// plain values (NOT refs), with login/logout on the nested `keycloak` instance.
+// Build the state inside the (hoisted) factory to dodge vi.mock hoisting issues.
+vi.mock('@dsb-norge/vue-keycloak-js', async () => {
+  const { reactive } = await import('vue');
+  const kc = reactive({
+    authenticated: false,
+    fullName: '',
+    ready: true,
     keycloak: { login: vi.fn(), logout: vi.fn() },
-  }),
-}));
+  });
+  return { useKeycloak: () => kc };
+});
 
+import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 import App from './App.vue';
 
 describe('App shell header', () => {
-  it('shows Sign in when unauthenticated even before Keycloak is ready', () => {
+  it('shows Sign in when unauthenticated', () => {
     const wrapper = mount(App, { global: { stubs: { RouterView: true } } });
-
-    // The sign-in affordance must not be gated on `ready`: if check-sso never
-    // resolves, the button would be hidden and the user could never log in.
     const group = wrapper.find('goa-button-group');
     expect(group.exists()).toBe(true);
     expect(group.html()).toContain('Sign in');
+  });
+
+  it('Sign in click calls keycloak.login (guards against lost reactivity)', async () => {
+    // The bug: destructuring useKeycloak() froze `keycloak` at undefined, so
+    // login() was a permanent no-op. Reactive access must reach the instance.
+    const kc = useKeycloak();
+    const wrapper = mount(App, { global: { stubs: { RouterView: true } } });
+    const btn = wrapper.findAll('goa-button').find((b) => b.text().includes('Sign in'));
+    await btn?.trigger('_click');
+    expect(kc.keycloak?.login).toHaveBeenCalled();
   });
 });

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -2,24 +2,28 @@
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 import { RouterView } from 'vue-router';
 
-const { authenticated, fullName, keycloak } = useKeycloak();
+// Keep the reactive instance — do NOT destructure. useKeycloak() returns a
+// readonly(reactive()); destructuring snapshots each field at setup time, so
+// `keycloak` would be frozen at its initial `undefined` (login() a no-op) and
+// `authenticated` would never flip. Access fields on `kc` to stay reactive.
+const kc = useKeycloak();
 
-function login() { keycloak?.login(); }
-function logout() { keycloak?.logout({ redirectUri: window.location.origin }); }
+function login() { kc.keycloak?.login(); }
+function logout() { kc.keycloak?.logout({ redirectUri: window.location.origin }); }
 </script>
 
 <template>
   <goa-microsite-header type="alpha" />
   <goa-app-header url="/" heading="<%= projectName %>">
     <goa-button-group alignment="end">
-      <span v-if="authenticated && fullName">{{ fullName }}</span>
-      <!-- Gate on !authenticated only, not `ready`: if Keycloak's check-sso
-           doesn't resolve (e.g. the silent-SSO iframe is blocked), we still
-           want the sign-in affordance — login() does a full redirect anyway. -->
-      <goa-button v-if="!authenticated" type="tertiary" @_click="login">
+      <span v-if="kc.authenticated && kc.fullName">{{ kc.fullName }}</span>
+      <!-- Gate on !authenticated only, never on `ready`: with no load-time SSO
+           check, `ready` flips true immediately but stays informational — the
+           sign-in affordance must always show until the user is authenticated. -->
+      <goa-button v-if="!kc.authenticated" type="tertiary" @_click="login">
         Sign in
       </goa-button>
-      <goa-button v-if="authenticated" type="tertiary" @_click="logout">
+      <goa-button v-if="kc.authenticated" type="tertiary" @_click="logout">
         Sign out
       </goa-button>
     </goa-button-group>

--- a/packages/nx-adsp/src/generators/vue-app/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/main.ts__tmpl__
@@ -18,10 +18,18 @@ app.use(keycloakPlugin, {
     realm: environment.access.realm,
     clientId: environment.access.client_id,
   },
+  // check-sso WITHOUT silentCheckSsoRedirectUri: on load, do a full-page redirect
+  // to Keycloak (prompt=none) and back — detecting an existing SSO session while
+  // still allowing anonymous access. We deliberately DON'T use the silent-SSO
+  // iframe (silentCheckSsoRedirectUri): keycloak-js's silent check waits on an
+  // untimed iframe postMessage that hangs forever when third-party cookies are
+  // blocked (common cross-origin), which would leave keycloak.login() a permanent
+  // no-op (the wrapper only exposes the instance after init() settles). The
+  // wrapper requires an `onLoad`, so 'check-sso' with a redirect is the anonymous-
+  // friendly, hang-free choice ('login-required' would force login on every load).
   init: {
     onLoad: 'check-sso',
     pkceMethod: 'S256',
-    silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
   },
 });
 

--- a/packages/nx-adsp/src/generators/vue-app/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/main.ts__tmpl__
@@ -18,18 +18,23 @@ app.use(keycloakPlugin, {
     realm: environment.access.realm,
     clientId: environment.access.client_id,
   },
-  // check-sso WITHOUT silentCheckSsoRedirectUri: on load, do a full-page redirect
-  // to Keycloak (prompt=none) and back — detecting an existing SSO session while
-  // still allowing anonymous access. We deliberately DON'T use the silent-SSO
-  // iframe (silentCheckSsoRedirectUri): keycloak-js's silent check waits on an
-  // untimed iframe postMessage that hangs forever when third-party cookies are
-  // blocked (common cross-origin), which would leave keycloak.login() a permanent
-  // no-op (the wrapper only exposes the instance after init() settles). The
-  // wrapper requires an `onLoad`, so 'check-sso' with a redirect is the anonymous-
-  // friendly, hang-free choice ('login-required' would force login on every load).
+  // No load-time SSO check and no hidden iframes. keycloak-js's silent-SSO
+  // (silentCheckSsoRedirectUri) and login-status (checkLoginIframe) iframes both
+  // wait on an untimed postMessage that never arrives when third-party cookies are
+  // blocked (common cross-origin, e.g. behind the ADSP gateway) — init() then
+  // hangs forever, the wrapper never populates its `keycloak` ref, and login()
+  // stays a permanent no-op. So we disable every iframe: checkLoginIframe:false
+  // drops the login-status iframe, omitting silentCheckSsoRedirectUri drops the
+  // silent iframe (that combination also skips the 3p-cookie probe iframe), and an
+  // empty onLoad skips the load-time check entirely — the wrapper requires onLoad
+  // to be a string, and keycloak-js treats a falsy onLoad as "no check". Result:
+  // init settles immediately as anonymous and Sign in redirects on demand. To
+  // auto-detect an existing session where the environment allows it, set
+  // onLoad: 'check-sso' (adds a prompt=none redirect round-trip on every load).
   init: {
-    onLoad: 'check-sso',
+    onLoad: '',
     pkceMethod: 'S256',
+    checkLoginIframe: false,
   },
 });
 

--- a/packages/nx-adsp/src/generators/vue-app/files/src/router/index.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/router/index.ts__tmpl__
@@ -16,10 +16,12 @@ const router = createRouter({
 
 router.beforeEach((to) => {
   if (to.meta.requiresAuth) {
-    const { authenticated, ready, keycloak } = useKeycloak();
-    if (!ready) return true;
-    if (!authenticated) {
-      keycloak?.login({ redirectUri: window.location.origin + to.fullPath });
+    // Read fields off the reactive instance (don't destructure) — consistent with
+    // the views and safe if this ever moves out of the per-navigation callback.
+    const kc = useKeycloak();
+    if (!kc.ready) return true;
+    if (!kc.authenticated) {
+      kc.keycloak?.login({ redirectUri: window.location.origin + to.fullPath });
       return false;
     }
   }

--- a/packages/nx-adsp/src/generators/vue-app/files/src/views/HomeView.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/views/HomeView.vue__tmpl__
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 
-const { authenticated, keycloak } = useKeycloak();
+// Keep the reactive instance — do NOT destructure (see App.vue): a destructured
+// `authenticated`/`keycloak` freezes at its setup-time value, so the private
+// fetch below would never see the user sign in and the bearer token stays undefined.
+const kc = useKeycloak();
 const publicResource = ref('Not retrieved — is the backend service running?');
 const privateResource = ref('Not retrieved — sign in first.');
 
@@ -14,20 +17,27 @@ onMounted(async () => {
   } catch {
     publicResource.value = 'Error loading public resource.';
   }
+});
 
-  if (authenticated) {
+// React to authentication (which settles asynchronously and may flip after mount,
+// e.g. on return from the login redirect) rather than reading it once on mount.
+watch(
+  () => kc.authenticated,
+  async (authenticated) => {
+    if (!authenticated) return;
     try {
-      await keycloak?.updateToken(30);
+      await kc.keycloak?.updateToken(30);
       const res = await fetch('/api/v1/private', {
-        headers: { Authorization: `Bearer ${keycloak?.token}` },
+        headers: { Authorization: `Bearer ${kc.keycloak?.token}` },
       });
       const data = await res.json();
       privateResource.value = data.message;
     } catch {
       privateResource.value = 'Error loading private resource.';
     }
-  }
-});
+  },
+  { immediate: true }
+);
 </script>
 
 <template>

--- a/packages/nx-adsp/src/generators/vue-app/files/src/views/ProtectedView.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/views/ProtectedView.vue__tmpl__
@@ -1,14 +1,18 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 
-const { fullName, tokenParsed } = useKeycloak();
-const userEmail = tokenParsed?.email ?? '';
+// Keep the reactive instance — do NOT destructure (see App.vue): fullName and
+// tokenParsed populate asynchronously once Keycloak settles, so a destructured
+// snapshot would freeze them at undefined and the page would render blank.
+const kc = useKeycloak();
+const userEmail = computed(() => kc.tokenParsed?.email ?? '');
 </script>
 
 <template>
   <section>
     <h2>Protected page</h2>
-    <p>You are signed in as <strong>{{ fullName }}</strong> ({{ userEmail }}).</p>
+    <p>You are signed in as <strong>{{ kc.fullName }}</strong> ({{ userEmail }}).</p>
     <router-link to="/">← Back to home</router-link>
   </section>
 </template>

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -36,9 +36,8 @@ describe('Vue App Generator', () => {
     await generator(host, options);
     const config = readProjectConfiguration(host, 'test');
     expect(config.root).toBe('apps/test');
-    // nginx.conf + silent-check-sso live in the Vite publicDir so they end up in the build output.
+    // nginx.conf lives in the Vite publicDir so it ends up in the build output.
     expect(host.exists('apps/test/public/nginx.conf')).toBeTruthy();
-    expect(host.exists('apps/test/public/silent-check-sso.html')).toBeTruthy();
     expect(host.exists('apps/test/src/main.ts')).toBeTruthy();
     expect(host.exists('apps/test/src/App.vue')).toBeTruthy();
     expect(host.exists('apps/test/src/router/index.ts')).toBeTruthy();
@@ -48,6 +47,26 @@ describe('Vue App Generator', () => {
     expect(host.exists('apps/test/vite.config.mts')).toBeFalsy();
     // build output mirrors the workspace layout under the root dist/.
     expect(config.targets.build.options.outputPath).toBe('dist/apps/test');
+  }, 30000);
+
+  it('inits Keycloak without the hanging silent-SSO iframe check', async () => {
+    await generator(host, options);
+    // Strip // comments — they legitimately reference silentCheckSsoRedirectUri to
+    // explain its absence; assert against the actual init code.
+    const code = host
+      .read('apps/test/src/main.ts')
+      .toString()
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n');
+    // keycloak-js's silent check-sso (silentCheckSsoRedirectUri) waits on an
+    // untimed iframe postMessage that hangs when third-party cookies are blocked,
+    // leaving keycloak.login() a no-op. Use check-sso via full redirect instead.
+    expect(code).not.toContain('silentCheckSsoRedirectUri');
+    expect(code).toContain("onLoad: 'check-sso'");
+    expect(code).toContain("pkceMethod: 'S256'");
+    // the now-unused silent-check-sso.html is no longer generated
+    expect(host.exists('apps/test/public/silent-check-sso.html')).toBeFalsy();
   }, 30000);
 
   it('index.html is at the Vite entry root and its mount target matches main.ts', async () => {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -49,24 +49,46 @@ describe('Vue App Generator', () => {
     expect(config.targets.build.options.outputPath).toBe('dist/apps/test');
   }, 30000);
 
-  it('inits Keycloak without the hanging silent-SSO iframe check', async () => {
+  it('inits Keycloak with no hidden iframes so init never hangs', async () => {
     await generator(host, options);
-    // Strip // comments — they legitimately reference silentCheckSsoRedirectUri to
-    // explain its absence; assert against the actual init code.
+    // Strip // comments — they legitimately reference the disabled iframe options
+    // to explain their absence; assert against the actual init code.
     const code = host
       .read('apps/test/src/main.ts')
       .toString()
       .split('\n')
       .filter((l) => !l.trim().startsWith('//'))
       .join('\n');
-    // keycloak-js's silent check-sso (silentCheckSsoRedirectUri) waits on an
-    // untimed iframe postMessage that hangs when third-party cookies are blocked,
-    // leaving keycloak.login() a no-op. Use check-sso via full redirect instead.
+    // keycloak-js's silent-SSO (silentCheckSsoRedirectUri) and login-status
+    // (checkLoginIframe) iframes both wait on an untimed postMessage that hangs
+    // when third-party cookies are blocked, leaving keycloak.login() a no-op. We
+    // disable both and skip the load-time check (empty onLoad) so init settles.
     expect(code).not.toContain('silentCheckSsoRedirectUri');
-    expect(code).toContain("onLoad: 'check-sso'");
+    expect(code).toContain('checkLoginIframe: false');
+    expect(code).toContain("onLoad: ''");
     expect(code).toContain("pkceMethod: 'S256'");
     // the now-unused silent-check-sso.html is no longer generated
     expect(host.exists('apps/test/public/silent-check-sso.html')).toBeFalsy();
+  }, 30000);
+
+  it('reads Keycloak fields off the reactive instance without destructuring', async () => {
+    await generator(host, options);
+    // The Sign in no-op bug: destructuring useKeycloak() (a readonly(reactive()))
+    // froze `keycloak` at undefined so login() never fired. Every consumer must
+    // keep the instance and read fields off it.
+    for (const file of [
+      'apps/test/src/App.vue',
+      'apps/test/src/views/HomeView.vue',
+      'apps/test/src/views/ProtectedView.vue',
+      'apps/test/src/router/index.ts',
+    ]) {
+      const code = host.read(file).toString();
+      expect(code).toContain('= useKeycloak()');
+      // no destructuring assignment off useKeycloak()
+      expect(code).not.toMatch(/const\s*\{[^}]*\}\s*=\s*useKeycloak\(\)/);
+    }
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).toContain('kc.keycloak?.login()');
   }, 30000);
 
   it('index.html is at the Vite entry root and its mount target matches main.ts', async () => {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -86,8 +86,9 @@ export default async function (host: Tree, options: Schema) {
     {
       '@abgov/design-tokens': '1.8.0',
       '@abgov/web-components': '1.39.3',
+      // keycloak-js is a transitive dependency of @dsb-norge/vue-keycloak-js;
+      // don't pin it directly or the versions diverge into two copies.
       '@dsb-norge/vue-keycloak-js': '^3.0.0',
-      'keycloak-js': '^23.0.7',
       'pinia': '^2.0.0',
       'vue-router': '^4.0.0',
     },
@@ -132,8 +133,8 @@ export default async function (host: Tree, options: Schema) {
     };
   }
 
-  // nginx.conf and silent-check-sso.html live in the Vite publicDir
-  // (<projectRoot>/public) so they are emitted to the build output root — the
+  // nginx.conf lives in the Vite publicDir
+  // (<projectRoot>/public) so it's emitted to the build output root — the
   // @nx/vite:build executor ignores webpack-style `assets`. Pin outputPath to
   // the workspace-root dist so it matches the vite config's outDir and the
   // generated Dockerfile's COPY path.


### PR DESCRIPTION
## Root cause (corrected after live investigation)

The dead Sign in button had **two** independent causes. The originally-suspected silent-SSO iframe was only part of it — the **operative** bug was lost Vue reactivity.

### 1. Lost reactivity from destructuring `useKeycloak()` (the button no-op)
`useKeycloak()` returns a `readonly(reactive())`. Every consumer destructured it:
```ts
const { authenticated, keycloak } = useKeycloak();  // frozen snapshots
```
Destructuring snapshots each field at setup time, so `keycloak` stayed frozen at its initial `undefined` and `keycloak?.login()` was a **permanent no-op** — even once init settled and the store populated. The same freeze hit `HomeView` (bearer token `undefined` → private API unauthenticated), `ProtectedView` (blank name/email), and the `AGENTS.md` pattern that documented it.

**Verified via headless Chrome + CDP:** the live store reached `ready=true` / `kcInstance=true` and `$keycloak.keycloak.login()` redirected fine, yet clicking the real button did nothing — until destructuring was removed, after which the button redirects to Keycloak.

**Fix:** keep the reactive instance and read fields off it (`const kc = useKeycloak(); kc.keycloak?.login()`) across `App.vue`, `HomeView`, `ProtectedView`, the router guard, and `AGENTS.md`. `HomeView` now `watch`es `kc.authenticated` so the private fetch runs when auth settles (it flips *after* mount, e.g. on return from the login redirect).

### 2. Init hardening — disable all hidden iframes
keycloak-js's silent-SSO (`silentCheckSsoRedirectUri`) **and** login-status (`checkLoginIframe`, default **on**) iframes both wait on an **untimed** `postMessage` that never arrives when third-party cookies are blocked (the sandbox / cross-origin behind the ADSP gateway) → `init()` hangs → the store's `keycloak` never populates → even the reactivity-fixed button would be a no-op. (Headless can't reproduce the hang since it allows 3p cookies, but the keycloak-js source confirms the untimed waits.)

**Fix (`main.ts`):** `onLoad: ''` (the wrapper requires `onLoad` to be a *string*; keycloak-js treats a falsy `onLoad` as "no load-time check"), `checkLoginIframe: false`, and no `silentCheckSsoRedirectUri` — that combination also skips the 3p-cookie probe iframe. Init settles immediately as anonymous; **Sign in redirects on demand**. Also removes the now-unused `silent-check-sso.html` + its nginx block (from the earlier commit).

## Tests
- Generated `App.spec` now mirrors the real wrapper (`reactive()` with plain-value fields, not refs) and asserts a **Sign in click actually calls `keycloak.login`** — a direct guard against the reactivity regression.
- Generator spec asserts no consumer destructures `useKeycloak()` and that the init disables the iframes.
- `nx test nx-adsp` (45) and generated `acme-app` vitest (2) green; `acme-app` build + live sign-in redirect verified end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)