### PR TITLE
feat(nx-adsp): equip generated express services with the ADSP SDK MCP server

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -1,4 +1,4 @@
-import { readProjectConfiguration } from '@nx/devkit';
+import { readJson, readProjectConfiguration, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import * as utils from '@abgov/nx-oc';
@@ -33,6 +33,40 @@ describe('Express Service Generator', () => {
     expect(host.exists('apps/test/src/main.ts')).toBeTruthy();
     expect(host.exists('apps/test/src/environment.ts')).toBeTruthy();
     expect(host.exists('apps/test/src/environments/environment.ts')).toBeFalsy();
+  }, 60000);
+
+  it('wires the ADSP SDK MCP server into the workspace .mcp.json', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    expect(host.exists('.mcp.json')).toBeTruthy();
+    const mcp = readJson(host, '.mcp.json');
+    expect(mcp.mcpServers['adsp-sdk']).toEqual({
+      command: 'npx',
+      args: ['-y', '@abgov/adsp-sdk-mcp-server'],
+    });
+    // Agents are pointed at the tools, not left to guess the SDK.
+    const agents = host.read('apps/test/AGENTS.md').toString();
+    expect(agents).toContain('@abgov/adsp-sdk-mcp-server');
+    expect(agents).toContain('get_platform_quickstart');
+    expect(agents).toContain('search_sdk_reference');
+  }, 60000);
+
+  it('merges .mcp.json without clobbering other servers or a customized entry', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    writeJson(host, '.mcp.json', {
+      mcpServers: {
+        other: { command: 'other-cmd', args: [] },
+        'adsp-sdk': { command: 'node', args: ['/local/build/main.js'] },
+      },
+    });
+    await generator(host, options);
+
+    const mcp = readJson(host, '.mcp.json');
+    // Unrelated server preserved.
+    expect(mcp.mcpServers.other).toEqual({ command: 'other-cmd', args: [] });
+    // A team's customized adsp-sdk entry is not overwritten.
+    expect(mcp.mcpServers['adsp-sdk']).toEqual({ command: 'node', args: ['/local/build/main.js'] });
   }, 60000);
 
   it('includes authorize, createValidationHandler, and example route in main.ts', async () => {

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -15,7 +15,7 @@ import * as path from 'path';
 import { consultAgent } from '../../utils/agent';
 import { ensureServiceClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
-import { addEslintQualityRules, addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings } from '../../utils/quality';
+import { addAdspMcpServer, addEslintQualityRules, addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings } from '../../utils/quality';
 import { Schema, NormalizedSchema } from './schema';
 
 async function normalizeOptions(
@@ -147,6 +147,8 @@ export default async function (host: Tree, options: Schema) {
   addEslintQualityRules(host, normalizedOptions.projectRoot, ['**/*.spec.ts', '**/*.test.ts']);
   addJestCoverageConfig(host, normalizedOptions.projectRoot);
   addVsCodeSettings(host);
+  // Equip coding agents with grounded ADSP docs + Node SDK reference lookup.
+  addAdspMcpServer(host);
 
   const projectConfig = readProjectConfiguration(host, normalizedOptions.projectName);
   const targets = { ...projectConfig.targets };

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -17,6 +17,25 @@ interactive prompt never blocks your session (`CI=true` in the env does the same
 also skips the Nx Cloud prompt). This applies to `nx g` generators; `nx run <target>`
 executors read options from `project.json` and do not prompt.
 
+## ADSP knowledge (MCP)
+
+This workspace is wired with the **`@abgov/adsp-sdk-mcp-server`** MCP server (see
+`.mcp.json` at the workspace root). It gives grounded, sourced answers about ADSP
+and the Node SDK. **Prefer these tools over recalling `@abgov/adsp-service-sdk`
+APIs from memory** when integrating ADSP capabilities:
+
+- `get_platform_quickstart` — the canonical `initializePlatform` usage pattern and
+  a capabilities summary. Start here for "how do I use ADSP from this service?".
+- `search_sdk_reference` — look up `@abgov/adsp-service-sdk` by symbol, module, or
+  keyword; returns kind, description, option/return shape, example, deprecation.
+- `search_adsp_docs` — keyword search across ADSP platform docs (getting started,
+  architecture, service concepts, tutorials).
+- `read_adsp_doc` — read the full content of a doc page found via search.
+
+If these tools aren't available, your MCP client hasn't loaded `.mcp.json` yet —
+Claude Code prompts to approve project MCP servers on first use; other clients may
+need project-scoped MCP enabled. The server runs via `npx` and needs no credentials.
+
 ## Stack
 
 

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -107,3 +107,29 @@ export function addVsCodeSettings(host: Tree): void {
     writeJson(host, settingsPath, settings);
   }
 }
+
+/**
+ * Registers the @abgov/adsp-sdk-mcp-server MCP server in the workspace-root
+ * `.mcp.json` so a coding agent (Claude Code and other MCP clients) can look up
+ * grounded ADSP docs and `@abgov/adsp-service-sdk` reference instead of guessing.
+ *
+ * It's a stdio knowledge server (no credentials, run via npx), so wiring is just
+ * config. Merges into an existing `.mcp.json` and never clobbers a user-customized
+ * `adsp-sdk` entry, so it's safe to re-run and to run for every generated service.
+ */
+export function addAdspMcpServer(host: Tree): void {
+  const mcpPath = '.mcp.json';
+  const server = { command: 'npx', args: ['-y', '@abgov/adsp-sdk-mcp-server'] };
+
+  if (host.exists(mcpPath)) {
+    updateJson(host, mcpPath, (existing) => {
+      const mcpServers = { ...(existing?.mcpServers ?? {}) };
+      // Preserve an existing entry (a team may have pinned a version or repointed
+      // it at a local build) — only add ours when it isn't already configured.
+      mcpServers['adsp-sdk'] = mcpServers['adsp-sdk'] ?? server;
+      return { ...existing, mcpServers };
+    });
+  } else {
+    writeJson(host, mcpPath, { mcpServers: { 'adsp-sdk': server } });
+  }
+}


### PR DESCRIPTION
## What

Generated express services now ship a workspace-root **`.mcp.json`** registering the newly-published **`@abgov/adsp-sdk-mcp-server`**, so a coding agent working in a bootstrapped project gets grounded, sourced answers about ADSP and the Node SDK instead of guessing at `@abgov/adsp-service-sdk` APIs.

## Why here

The MCP server is a **stdio knowledge server** — bundled ADSP docs + a curated reference of every `@abgov/adsp-service-sdk` export, run via `npx`, **no credentials**. It's **Node-SDK-specific**, so it's wired by the **express-service** generator only (the frontend generators don't use the SDK). It exposes four tools:

- `get_platform_quickstart` — canonical `initializePlatform` pattern + capabilities summary
- `search_sdk_reference` — look up SDK symbols/modules (kind, options, return shape, example, deprecation)
- `search_adsp_docs` / `read_adsp_doc` — search + read the ADSP platform docs

## Changes

- **`addAdspMcpServer(host)`** (`utils/quality.ts`) mirrors the existing `addVsCodeSettings` workspace-root-config pattern: **merges** into an existing `.mcp.json` and **never clobbers** a user-customized `adsp-sdk` entry (a team may pin a version or point it at a local build), so it's safe to re-run and to run once per generated service in a monorepo.
- Generated **`AGENTS.md`** documents the four tools and tells agents to **prefer them over recalling SDK APIs from memory**, with a one-line note on MCP-client approval.
- Tests: `.mcp.json` is created with the expected server config; a pre-existing `.mcp.json` merges without dropping other servers or overwriting a customized entry; `AGENTS.md` references the server + tools.

`nx test nx-adsp` (47) and `nx lint nx-adsp` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)