### PR TITLE
refactor(nx-adsp): scaffold express service with a dedicated router module

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -69,16 +69,29 @@ describe('Express Service Generator', () => {
     expect(mcp.mcpServers['adsp-sdk']).toEqual({ command: 'node', args: ['/local/build/main.js'] });
   }, 60000);
 
-  it('includes authorize, createValidationHandler, and example route in main.ts', async () => {
+  it('factors routes into a router module mounted in main.ts (not inlined)', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, options);
 
+    // main.ts holds infra + the mount, not route handlers.
     const mainTs = host.read('apps/test/src/main.ts').toString();
-    expect(mainTs).toContain('authorize');
-    expect(mainTs).toContain('createValidationHandler');
     expect(mainTs).toContain('createErrorHandler');
-    expect(mainTs).toContain('/v1/example');
-    expect(mainTs).toContain('eventService.send');
+    expect(mainTs).toContain("import { exampleRouter } from './routes/example'");
+    expect(mainTs).toContain('exampleRouter(eventService)');
+    // The handler internals moved out of main.ts.
+    expect(mainTs).not.toContain('authorize');
+    expect(mainTs).not.toContain('/v1/example');
+
+    // The router module carries the handlers, capabilities passed in as args.
+    expect(host.exists('apps/test/src/routes/example.ts')).toBeTruthy();
+    const routerTs = host.read('apps/test/src/routes/example.ts').toString();
+    expect(routerTs).toContain('export function exampleRouter(eventService: EventService)');
+    expect(routerTs).toContain('authorize');
+    expect(routerTs).toContain('createValidationHandler');
+    expect(routerTs).toContain('eventService.send');
+
+    // Shipped with a supertest test demonstrating the router-testing pattern.
+    expect(host.exists('apps/test/src/routes/example.spec.ts')).toBeTruthy();
   }, 60000);
 
   it('scaffolds postgres database files and targets', async () => {

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -135,6 +135,8 @@ export default async function (host: Tree, options: Schema) {
       '@types/cors': '^2.8.17',
       '@types/passport': '^1.0.16',
       '@types/passport-anonymous': '^1.0.3',
+      supertest: '^7.0.0',
+      '@types/supertest': '^6.0.0',
       ...(normalizedOptions.database === 'postgres' ? { 'drizzle-kit': '^0.31.0', '@types/pg': '^8.11.0' } : {}),
       'eslint-plugin-security': '^3.0.0',
       'eslint-plugin-no-secrets': '^2.0.0',

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -55,7 +55,8 @@ need project-scoped MCP enabled. The server runs via `npx` and needs no credenti
 
 | File | Purpose |
 |------|---------|
-| `src/main.ts` | App entry — SDK init, middleware, routes, server start |
+| `src/main.ts` | Composition root — SDK init, middleware, mounts routers, server start |
+| `src/routes/example.ts` | Example `express.Router()` — starter resource; copy it per resource |
 | `src/environment.ts` | Validated env config with defaults pre-set from ADSP tenant |
 | `src/events.ts` | Domain event definitions — register in `initializeService({ events })` |
 <% if (database === 'postgres') { %>
@@ -109,8 +110,9 @@ src/
 Rules of thumb:
 
 - **Do not inline route handlers in `main.ts`.** Add an `express.Router()` per
-  resource under `routes/` and mount it. The example routes in `main.ts` are
-  starters — replace them with mounted routers as you build real features.
+  resource under `routes/` and mount it. `src/routes/example.ts` is the shipped
+  starter (with a `example.spec.ts` supertest test) — copy its shape per resource
+  and replace it as you build real features.
 - **Keep handlers thin** — validate input, call a service, shape the response.
   Put non-trivial logic in `services/` so it can be tested without HTTP.
 - **One responsibility per module** — routers do HTTP, services do logic, the db

--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -1,22 +1,18 @@
-import { AdspId, authorize, createErrorHandler, createValidationHandler, initializeService } from '@abgov/adsp-service-sdk';
+import { AdspId, createErrorHandler, initializeService } from '@abgov/adsp-service-sdk';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
 import passport from 'passport';
 import { Strategy as AnonymousStrategy } from 'passport-anonymous';
-import { z } from 'zod';
 <% if (database === 'postgres') { %>
 import { closeDatabase } from './database';
 <% } else if (database === 'mongo') { %>
 import { connectDatabase, disconnectDatabase } from './database';
 <% } %>
 import { environment } from './environment';
-import { createExampleEvent, exampleEventDefinition } from './events';
-
-const ExampleRequestSchema = z.object({
-  id: z.string().min(1),
-});
+import { exampleEventDefinition } from './events';
+import { exampleRouter } from './routes/example';
 
 async function initializeApp() {
   const serviceId = AdspId.parse(environment.CLIENT_ID);
@@ -56,12 +52,6 @@ async function initializeApp() {
   passport.use('tenant', tenantStrategy);
   app.use(passport.initialize());
 
-  app.use(
-    '/<%= projectName %>/v1',
-    passport.authenticate(['tenant', 'anonymous'], { session: false }),
-    configurationHandler
-  );
-
   app.get('/health', async (_req, res) => {
     const platform = await healthCheck();
     res.json({ ...platform });
@@ -78,46 +68,14 @@ async function initializeApp() {
     });
   });
 
-  app.get('/<%= projectName %>/v1', (_req, res) => {
-    res.json({
-      _links: {
-        self: { href: '/<%= projectName %>/v1' },
-        public: { href: '/<%= projectName %>/v1/public' },
-        private: { href: '/<%= projectName %>/v1/private' },
-      },
-    });
-  });
-
-  // Public endpoint — no authentication required.
-  app.get('/<%= projectName %>/v1/public', (_req, res) => {
-    res.json({ message: 'Hello from the public <%= projectName %> API.' });
-  });
-
-  // Private endpoint — requires an authenticated tenant user.
-  app.get(
-    '/<%= projectName %>/v1/private',
-    passport.authenticate(['tenant'], { session: false }),
-    (req, res) => {
-      res.json({ message: `Hello, ${req.user!.name}.` });
-    }
-  );
-
-  // Example: protected route demonstrating authorize, input validation, and a domain event.
-  // Require 'example-role' — replace with a role relevant to your service.
-  // Remove or replace this route once you have real business logic.
-  app.post(
-    '/<%= projectName %>/v1/example',
-    authorize('example-role'),
-    createValidationHandler(ExampleRequestSchema),
-    async (req, res, next) => {
-      try {
-        const { id } = req.body as z.infer<typeof ExampleRequestSchema>;
-        eventService.send(createExampleEvent(id));
-        res.json({ id });
-      } catch (err) {
-        next(err);
-      }
-    }
+  // v1 API: authenticate (tenant or anonymous) and resolve tenant configuration
+  // for the whole subtree, then mount the resource routers. Add one router per
+  // resource under routes/ and mount it here — keep handlers out of main.ts.
+  app.use(
+    '/<%= projectName %>/v1',
+    passport.authenticate(['tenant', 'anonymous'], { session: false }),
+    configurationHandler,
+    exampleRouter(eventService)
   );
 
   // Mount error handler last — after all routes and middleware.

--- a/packages/nx-adsp/src/generators/express-service/files/src/routes/example.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/routes/example.spec.ts__tmpl__
@@ -1,0 +1,26 @@
+import type { EventService } from '@abgov/adsp-service-sdk';
+import express from 'express';
+import request from 'supertest';
+import { exampleRouter } from './example';
+
+describe('exampleRouter', () => {
+  // The router only needs eventService.send — mock it, so the test needs no DB
+  // and no real auth. This is the pattern for testing any resource router.
+  const eventService = { send: jest.fn() } as unknown as EventService;
+
+  const app = express();
+  app.use(express.json());
+  app.use('/<%= projectName %>/v1', exampleRouter(eventService));
+
+  it('serves the public endpoint without authentication', async () => {
+    const res = await request(app).get('/<%= projectName %>/v1/public');
+    expect(res.status).toBe(200);
+    expect(res.body.message).toContain('public');
+  });
+
+  it('exposes resource links at the index', async () => {
+    const res = await request(app).get('/<%= projectName %>/v1');
+    expect(res.status).toBe(200);
+    expect(res.body._links.public.href).toBe('/<%= projectName %>/v1/public');
+  });
+});

--- a/packages/nx-adsp/src/generators/express-service/files/src/routes/example.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/routes/example.ts__tmpl__
@@ -1,0 +1,59 @@
+import { authorize, createValidationHandler, type EventService } from '@abgov/adsp-service-sdk';
+import { Router } from 'express';
+import passport from 'passport';
+import { z } from 'zod';
+import { createExampleEvent } from '../events';
+
+const ExampleRequestSchema = z.object({
+  id: z.string().min(1),
+});
+
+// Thin HTTP handlers for the example resource, grouped in an express.Router().
+// Capabilities from initializeService() are passed in (not imported) so the router
+// stays testable — mount it with supertest and pass a mock eventService (see the
+// spec). This is a starter: add one router per resource under routes/ and replace
+// this once you have real business logic.
+export function exampleRouter(eventService: EventService): Router {
+  const router = Router();
+
+  // Resource index — hypermedia links to this resource's routes. req.baseUrl is
+  // the mount path, so the router doesn't hard-code where it's mounted.
+  router.get('/', (req, res) => {
+    res.json({
+      _links: {
+        self: { href: req.baseUrl },
+        public: { href: `${req.baseUrl}/public` },
+        private: { href: `${req.baseUrl}/private` },
+      },
+    });
+  });
+
+  // Public endpoint — no authentication required.
+  router.get('/public', (_req, res) => {
+    res.json({ message: 'Hello from the public <%= projectName %> API.' });
+  });
+
+  // Private endpoint — requires an authenticated tenant user.
+  router.get('/private', passport.authenticate(['tenant'], { session: false }), (req, res) => {
+    res.json({ message: `Hello, ${req.user!.name}.` });
+  });
+
+  // Protected route demonstrating authorize, input validation, and a domain event.
+  // Require 'example-role' — replace with a role relevant to your service.
+  router.post(
+    '/example',
+    authorize('example-role'),
+    createValidationHandler(ExampleRequestSchema),
+    async (req, res, next) => {
+      try {
+        const { id } = req.body as z.infer<typeof ExampleRequestSchema>;
+        eventService.send(createExampleEvent(id));
+        res.json({ id });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+}


### PR DESCRIPTION
## Problem

The express scaffold **documented** "do not inline route handlers in `main.ts`" (added in #297) but **shipped every route inlined in `main.ts`**. The entry point — the first file an agent reads — modeled the exact anti-pattern the AGENTS.md warns against, so coding agents copied it. (Same inlined-routes issue that prompted #297, one level up: the scaffold itself was the bad example.)

## Change

Factor the example routes into **`src/routes/example.ts`** — an `express.Router()` factory that takes `eventService` as an argument (matching the AGENTS.md "pass runtime capabilities in, don't import them" rule), mounted in `main.ts`. `main.ts` is now purely a **composition root**: SDK init, middleware, the operational `/` and `/health` endpoints, the `v1` auth+config mount + router, and the error handler last.

Also ships **`src/routes/example.spec.ts`** — a supertest test that mounts the router with a mocked `eventService`, demonstrating the router-testing pattern the AGENTS.md describes.

- Adds `supertest` + `@types/supertest` dev deps (the generated router test needs them).
- `AGENTS.md`: `main.ts` described as the composition root; `routes/example.ts` listed as the starter to copy; the factoring rule points at the shipped router + spec.
- Generator spec asserts route internals live in the router module and **not** in `main.ts`.

## Verification

In a generated service: `nx build` (router + `main.ts` typecheck clean) and the `example.spec` supertest suite (2 tests) pass. `nx test nx-adsp` (50) and `nx lint nx-adsp` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)