### PR TITLE
fix(nx-adsp): point frontend AGENTS.md at the current design system docs (design.alberta.ca)

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -39,6 +39,14 @@ describe('angular app generator', () => {
     expect(appTree.exists('apps/test/nginx.conf')).toBeTruthy();
   }, 120000);
 
+  it('AGENTS.md points at the current design system docs', async () => {
+    await angularApp(appTree, options);
+    const agents = appTree.read('apps/test/AGENTS.md').toString();
+    expect(agents).toContain('design.alberta.ca/components');
+    // guard against the retired ui-components.alberta.ca URL creeping back in
+    expect(agents).not.toContain('ui-components.alberta.ca');
+  }, 120000);
+
   it('can add nginx proxy', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await angularApp(host, {

--- a/packages/nx-adsp/src/generators/angular-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/AGENTS.md__tmpl__
@@ -62,13 +62,25 @@ const authGuard = createAuthGuard(async (_route, _state, { authenticated, keyclo
 
 ## GoA design system
 
-Components are imported from `@abgov/angular-components` with the `Goab` prefix
-and added to each standalone component's `imports` array:
+**Find a component:** browse the gallery at
+[design.alberta.ca/components](https://design.alberta.ca/components/) — press ⌘K to
+search components and examples. Each component's page documents its properties,
+events, and usage; treat it as the source of truth. Angular uses the `Goab*`
+wrappers from `@abgov/angular-components`, imported into each standalone component's
+`imports` array:
 
 ```typescript
 import { GoabButton, GoabAppHeader } from '@abgov/angular-components';
 
 @Component({ imports: [GoabButton, GoabAppHeader], ... })
+```
+
+**Events**: the Angular wrappers expose events as outputs — bind with `(onClick)`,
+`(onChange)`, etc. on the `goab-*` element:
+
+```html
+<goab-button type="tertiary" (onClick)="login()">Sign in</goab-button>
+<goab-dropdown (onChange)="handleSelect($event)"></goab-dropdown>
 ```
 
 **Known limitation:** `GoabHeroBanner.backgroundUrl` does not bind reliably via

--- a/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
@@ -54,13 +54,18 @@ const token = await getAccessToken(); // refreshes token if needed
 
 ## GoA design system
 
-Components are imported from `@abgov/react-components` with the `Goab` prefix:
+**Find a component:** browse the gallery at
+[design.alberta.ca/components](https://design.alberta.ca/components/) — press ⌘K to
+search components and examples. Each component's page documents its properties,
+events, and usage; treat it as the source of truth. React uses the `Goab*` wrappers
+from `@abgov/react-components` over those components:
 
 ```typescript
 import { GoabButton, GoabAppHeader, GoabButtonGroup } from '@abgov/react-components';
 ```
 
-**Event names**: GoA React components use `onGoab*` handlers (not standard React synthetic events):
+**Events**: GoA React components use `onGoab*` handlers (not standard React synthetic
+events); the payload is on `e.detail`:
 
 ```tsx
 <GoabButton onGoabClick={handleSave}>Save</GoabButton>
@@ -69,8 +74,8 @@ import { GoabButton, GoabAppHeader, GoabButtonGroup } from '@abgov/react-compone
 <GoabCheckbox onGoabChange={(e) => setChecked(e.detail.checked)} />
 ```
 
-Event detail shapes vary by component — check the `detail` type in `@abgov/react-components`.
-See [GoA web components docs](https://ui-components.alberta.ca) for the full component reference.
+Event `detail` shapes vary by component — check the component's gallery page or the
+`detail` type in `@abgov/react-components`.
 
 ## Adding a new route
 

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -31,6 +31,15 @@ describe('React App Generator', () => {
     expect(host.exists('apps/test/nginx.conf')).toBeTruthy();
   }, 30000);
 
+  it('AGENTS.md points at the current design system docs', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+    const agents = host.read('apps/test/AGENTS.md').toString();
+    expect(agents).toContain('design.alberta.ca/components');
+    // guard against the retired ui-components.alberta.ca URL creeping back in
+    expect(agents).not.toContain('ui-components.alberta.ca');
+  }, 30000);
+
   it('can add nginx proxy', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, {

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -101,11 +101,15 @@ router.beforeEach((to) => {
 
 ## GoA design system
 
-Use `goa-*` web components directly in Vue templates. The vite.config.ts
-`isCustomElement` option prevents Vue from warning about unknown elements.
+**Find a component:** browse the gallery at
+[design.alberta.ca/components](https://design.alberta.ca/components/) — press ⌘K to
+search components and examples. Each component's page documents its properties,
+events, and usage; treat it as the source of truth. Vue uses the framework-agnostic
+`goa-*` web components (`@abgov/web-components`) directly — the `vite.config.ts`
+`isCustomElement` option stops Vue from warning about them.
 
-**Event names**: GoA web component interactive elements emit custom events with
-a `_` prefix to avoid conflicts with native browser events:
+**Events**: GoA web components emit custom events with a `_` prefix (to avoid
+clashing with native browser events); bind them with Vue's `@` syntax:
 
 ```html
 <goa-button type="primary" @_click="handleSave">Save</goa-button>
@@ -115,8 +119,6 @@ a `_` prefix to avoid conflicts with native browser events:
 ```
 
 Use `@_click` for buttons and `@_change` for inputs, dropdowns, and checkboxes.
-See [GoA web components docs](https://ui-components.alberta.ca) for the full
-component and event reference.
 
 ## Adding a view
 

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -49,6 +49,14 @@ describe('Vue App Generator', () => {
     expect(config.targets.build.options.outputPath).toBe('dist/apps/test');
   }, 30000);
 
+  it('AGENTS.md points at the current design system docs', async () => {
+    await generator(host, options);
+    const agents = host.read('apps/test/AGENTS.md').toString();
+    expect(agents).toContain('design.alberta.ca/components');
+    // guard against the retired ui-components.alberta.ca URL creeping back in
+    expect(agents).not.toContain('ui-components.alberta.ca');
+  }, 30000);
+
   it('inits Keycloak with no hidden iframes so init never hangs', async () => {
     await generator(host, options);
     // Strip // comments — they legitimately reference the disabled iframe options


### PR DESCRIPTION
## Problem

The frontend generators' "GoA design system" breadcrumb was wrong or missing:

- **vue** and **react** linked to `ui-components.alberta.ca` — the **retired** URL. The canonical docs are now **`design.alberta.ca`** (the [ui-components repo](https://github.com/GovAlta/ui-components) README points there).
- **angular** linked to **nothing** — its section covered imports and one known limitation but gave no pointer to the design system or event conventions.

So a coding agent building GoA UI had a dead link (vue/react) or no link (angular).

## Change

Standardize the breadcrumb across all three, pointing at the searchable **component gallery** (`https://design.alberta.ca/components/`, ⌘K search, 50 components each with props/events/examples), plus consistent per-framework specifics:

| | Import pattern | Event convention |
|---|---|---|
| vue | `goa-*` web components directly | `@_click` / `@_change` |
| react | `Goab*` from `@abgov/react-components` | `onGoab*` + `e.detail` |
| angular | `Goab*` from `@abgov/angular-components` | `(onClick)` / `(onChange)` outputs — **newly documented** |

Angular keeps its `GoabHeroBanner.backgroundUrl` binding-limitation note.

## Regression guard

Each frontend spec now asserts its generated `AGENTS.md` references `design.alberta.ca/components` and does **not** contain the retired `ui-components.alberta.ca` URL — so a stale link can't ship again. `nx test nx-adsp` (53) and lint green.

Note: no GoA design-system MCP server exists yet (only `@abgov/adsp-sdk-mcp-server`), so this breadcrumb is docs-links-only. If a components MCP ships later, it'd wire in like the SDK one (#303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)