### PR TITLE
chore(nx-adsp): bump GoA component libraries to the v2 design system

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -114,10 +114,14 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/angular-components': '5.2.1',
-      '@abgov/design-tokens': '1.8.0',
-      '@abgov/ui-components-common': '^2.0.0',
-      '@abgov/web-components': '1.39.3',
+      '@abgov/angular-components': '5.3.0',
+      '@abgov/design-tokens': '2.9.0',
+      // Pin exact (not ^2.0.0): angular-components 5.3.0 imports symbols added in
+      // ui-components-common 2.3.0 (e.g. GoabWorkspaceLayoutScrollState), so a
+      // lower 2.x resolves and fails the build. Keep this in lockstep with the
+      // angular-components version above.
+      '@abgov/ui-components-common': '2.3.0',
+      '@abgov/web-components': '2.3.0',
       'keycloak-angular': '^19.0.2',
       'keycloak-js': '^23.0.7',
       'zone.js': '~0.15.0',

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -128,9 +128,9 @@ export default async function (host: Tree, options: Schema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/design-tokens': '1.8.0',
-      '@abgov/react-components': '6.10.0',
-      '@abgov/web-components': '1.39.3',
+      '@abgov/design-tokens': '2.9.0',
+      '@abgov/react-components': '7.3.0',
+      '@abgov/web-components': '2.3.0',
       '@reduxjs/toolkit': '^2.5.1',
       'keycloak-js': '^23.0.7',
       'react-redux': '^9.2.0',

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -84,8 +84,8 @@ export default async function (host: Tree, options: Schema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/design-tokens': '1.8.0',
-      '@abgov/web-components': '1.39.3',
+      '@abgov/design-tokens': '2.9.0',
+      '@abgov/web-components': '2.3.0',
       // keycloak-js is a transitive dependency of @dsb-norge/vue-keycloak-js;
       // don't pin it directly or the versions diverge into two copies.
       '@dsb-norge/vue-keycloak-js': '^3.0.0',


### PR DESCRIPTION
## What

The frontend generators pinned a Nov-2025 snapshot of the GoA component libraries — several a full **major** behind. Bump all three generators to the current **v2** design system:

| Package | Was | Now |
|---|---|---|
| `@abgov/web-components` *(shared, all 3)* | 1.39.3 | **2.3.0** |
| `@abgov/design-tokens` *(shared, all 3)* | 1.8.0 | **2.9.0** |
| `@abgov/react-components` | 6.10.0 | **7.3.0** |
| `@abgov/angular-components` | 5.2.1 | **5.3.0** |
| `@abgov/ui-components-common` (angular) | `^2.0.0` | **2.3.0** |

## Breaking-change assessment

`web-components` v2.0.0 / `react-components` v7.0.0 declare exactly one breaking change — **"removes experimental wrappers" (#3690)** — which the templates don't use (they import the standard `goa-*`/`Goab*` components). The imported CSS paths (`web-components/index.css`, `design-tokens/dist/tokens.css`) still exist in v2. The rest of the major is a **visual redesign**, so generated apps now render in the current GoA v2 look.

## Angular version-skew fix

`ui-components-common` was pinned `^2.0.0`, which npm resolved to **2.2.0** — too old for `angular-components@5.3.0`, which imports symbols added in **2.3.0** (e.g. `GoabWorkspaceLayoutScrollState`) and **fails the build**. Pinned exact and kept in lockstep with `angular-components`. (This is the shared-lib version-skew risk — flagged and fixed.)

## Verification

Bumped each preview workspace to the v2 set and served the generated app headless:

- **react** (`my-service`) — builds with no TS errors + renders ✓
- **angular** (`adsp-angular-preview`) — builds + renders ✓ (after the `common@2.3.0` fix)
- **vue** (`acme-app`) — renders ✓; Sign in button intact (the #302 reactivity fix holds under web-components 2)

All GoA components (microsite header, app header, hero banner, buttons, layout) render in v2 styling with no missing/broken elements. `nx test nx-adsp` (53) + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)