### PR TITLE
fix(nx-oc): default ADSP env to test (UAT), not prod

### DIFF
--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -88,7 +88,9 @@ export async function ensureAdspToken(options: {
   // Force the CLI to talk to the generator's target environment. Note: we set
   // ADSP_ENV, never ADSP_TENANT_REALM — the latter would make getStatus() drop
   // the persisted tenantName (it can't trust a name against an overridden realm).
-  process.env.ADSP_ENV = env || process.env.ADSP_ENV || 'prod';
+  // Default to 'test' (UAT), never 'prod' — matches every generator's schema
+  // default and avoids an accidental production hit if env is ever unset.
+  process.env.ADSP_ENV = env || process.env.ADSP_ENV || 'test';
 
   const fetchToken = async (): Promise<string | undefined> => {
     const result = await getAccessToken(scopes.length ? { scopes } : undefined);
@@ -144,7 +146,7 @@ export async function getAdspConfiguration(
   options: { env: EnvironmentName; accessToken?: string; tenant?: string; tenantRealm?: string }
 ): Promise<AdspConfiguration> {
   const { env, accessToken } = options;
-  const environment = environments[env || 'prod'];
+  const environment = environments[env || 'test'];
 
   if (isAdspOptions(options)) {
     // Adsp configuration already resolved — return it directly.


### PR DESCRIPTION
Follow-up to #307 — this one-commit fix was pushed just after #307 was squash-merged, so it missed the merge.

The shared `adsp-utils` fallback used `env || 'prod'` in two spots (`ensureAdspToken` and `getAdspConfiguration`). Every generator schema defaults `env` to `test` (`access-uat.alberta.ca`), so an unset env at the code level would silently target **production** — the opposite of the plugin's UAT-safe default. Aligns both fallbacks to `test`.

Only triggers when `env` is unset at the code level (programmatic call / schema regression); when it does, UAT is the safe landing, not prod. nx-oc build/test/lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)