### PR TITLE
fix(nx-adsp): make platform-role provisioning failures clear and actionable

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -89,6 +89,30 @@ To call another service with an access token:
 const token = await tokenProvider.getAccessToken();
 ```
 
+## Service won't start (401/403)
+
+If `nx serve` exits with `Failed to start: ADSP service registration did not
+complete` (401/403 from `TenantService`/`ServiceRegistration`), the service's
+Keycloak **service-account user** is missing required platform roles:
+
+| Platform client | Role |
+|---|---|
+| `urn:ads:platform:tenant-service` | `platform-service` |
+| `urn:ads:platform:event-service` | `event-sender` |
+| `urn:ads:platform:configuration-service` | `configured-service` |
+
+The generator assigns these when it creates the client, but that needs an admin
+login (`manage-users`). If it printed a `WARNING: could not grant required
+platform role(s)` during generation, fix it by either:
+
+1. signing in with the admin scope and **re-running the generator** (its
+   existing-client path back-fills the roles):
+   ```bash
+   npx @abgov/adsp-cli login --tenant <tenant> --scope adsp-cli-admin
+   ```
+2. or adding those three client roles to the `<%= projectName %>` service-account
+   user in the ADSP admin portal.
+
 ## Project structure & code factoring
 
 `main.ts` is the **composition root** — it initializes the SDK, wires middleware,

--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -107,4 +107,16 @@ initializeApp().then(({ app, logger }) => {
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
 <% } %>
+}).catch((err) => {
+  // Startup failed. The most common cause is the service's Keycloak service-account
+  // missing required ADSP platform roles, so initializeService() 401/403s (see the
+  // "Service won't start (401/403)" section in AGENTS.md). Exit deliberately with a
+  // clear message instead of surfacing a raw unhandled-rejection stack trace.
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(
+    `[<%= projectName %>] Failed to start: ADSP service registration did not complete. ` +
+      `The Keycloak service-account may be missing required platform roles ` +
+      `(platform-service / event-sender / configured-service). See AGENTS.md. Cause: ${message}`
+  );
+  process.exit(1);
 });

--- a/packages/nx-adsp/src/utils/keycloak-admin.ts
+++ b/packages/nx-adsp/src/utils/keycloak-admin.ts
@@ -132,28 +132,43 @@ async function ensureServiceAccountRoles(
   accessServiceUrl: string,
   realm: string,
   serviceClientUuid: string,
+  serviceClientId: string,
   roles: Array<{ platformClientId: string; roleName: string }>,
   accessToken: string
 ): Promise<void> {
   const { default: axios } = await import('axios');
-  // Best-effort, like the other ensure* helpers: don't abort provisioning or
-  // drop the client secret if a platform service-account role can't be assigned.
+  const allRoles = roles.map((r) => `${r.platformClientId}:${r.roleName}`);
+
+  // Best-effort — never abort provisioning or drop the client secret. But unlike
+  // the other ensure* helpers, these roles are LOAD-BEARING: initializeService()
+  // 401/403s at startup without them. So report failures per-role, by service
+  // name, and spell out the impact/fix (assigning a client role to the
+  // service-account user needs manage-users, not just manage-clients).
+  let userId: string;
   try {
     const userUrl = new URL(
       `/auth/admin/realms/${realm}/clients/${serviceClientUuid}/service-account-user`,
       accessServiceUrl
     ).href;
-    const { data: user } = await axios.get<{ id: string }>(userUrl, {
+    const { data } = await axios.get<{ id: string }>(userUrl, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
-
-    await Promise.all(
-      roles.map(({ platformClientId, roleName }) =>
-        assignRoleToServiceAccount(accessServiceUrl, realm, user.id, platformClientId, roleName, accessToken)
-      )
-    );
+    userId = data.id;
   } catch (err) {
-    logAdminError(serviceClientUuid, err);
+    logRoleProvisioningFailure(serviceClientId, realm, allRoles, err);
+    return;
+  }
+
+  const results = await Promise.allSettled(
+    roles.map(({ platformClientId, roleName }) =>
+      assignRoleToServiceAccount(accessServiceUrl, realm, userId, platformClientId, roleName, accessToken)
+    )
+  );
+  const failed = results.flatMap((r, i) =>
+    r.status === 'rejected' ? [{ role: allRoles[i], reason: r.reason }] : []
+  );
+  if (failed.length > 0) {
+    logRoleProvisioningFailure(serviceClientId, realm, failed.map((f) => f.role), failed[0].reason);
   }
 }
 
@@ -189,6 +204,37 @@ function logAdminError(clientId: string, err: unknown): void {
 }
 
 /**
+ * Reports a failure to grant the platform service-account roles. Unlike a generic
+ * admin error, these roles are required for the generated service to boot, so the
+ * message names the service, lists exactly which role(s) failed, states the
+ * runtime impact, and gives the fix — rather than a bare "create it manually".
+ */
+function logRoleProvisioningFailure(
+  serviceClientId: string,
+  realm: string,
+  failedRoles: string[],
+  err: unknown
+): void {
+  const status = (err as { response?: { status?: number } })?.response?.status;
+  const serviceName = serviceClientId.split(':').pop() ?? serviceClientId;
+  const cause =
+    status === 401 || status === 403
+      ? 'your ADSP login lacks the manage-users permission on this realm'
+      : `${(err as Error)?.message ?? err}`;
+  process.stdout.write(
+    `\n[nx-adsp] WARNING: could not grant required platform role(s) to service '${serviceName}':\n` +
+      failedRoles.map((r) => `             - ${r}\n`).join('') +
+      `          Cause: ${cause}.\n` +
+      `          These roles are REQUIRED — '${serviceName}' will fail to start (401/403 in\n` +
+      `          initializeService()) until they are granted. To fix, either:\n` +
+      `            1) sign in with the admin scope and re-run this generator:\n` +
+      `                 npx @abgov/adsp-cli login --scope adsp-cli-admin\n` +
+      `            2) or add these client roles to the '${serviceName}' service-account user\n` +
+      `               in the ADSP admin portal (realm ${realm}).\n\n`
+  );
+}
+
+/**
  * Ensures a confidential service-account client exists in the tenant realm.
  * Returns the client secret when a new client is created; returns null when
  * the client already existed or the operation could not be completed.
@@ -221,7 +267,7 @@ export async function ensureServiceClient(
         accessToken
       );
       await Promise.all([
-        ensureServiceAccountRoles(accessServiceUrl, realm, existingClient.id, platformRoles, accessToken),
+        ensureServiceAccountRoles(accessServiceUrl, realm, existingClient.id, clientId, platformRoles, accessToken),
         ensureAudienceMapper(accessServiceUrl, realm, clientId, 'urn:ads:platform:push-service', accessToken),
       ]);
       return getClientSecret(accessServiceUrl, realm, existingClient.id, accessToken);
@@ -252,7 +298,7 @@ export async function ensureServiceClient(
       accessToken
     );
     await Promise.all([
-      ensureServiceAccountRoles(accessServiceUrl, realm, uuid, platformRoles, accessToken),
+      ensureServiceAccountRoles(accessServiceUrl, realm, uuid, clientId, platformRoles, accessToken),
       ensureAudienceMapper(accessServiceUrl, realm, clientId, 'urn:ads:platform:push-service', accessToken),
     ]);
     process.stdout.write(`[nx-adsp] Created service client '${clientId}'.\n`);


### PR DESCRIPTION
Follow-up to the `ADSP_CLI_ADMIN_SCOPE_GAP` finding. Now that `manage-users` is on the `adsp-cli-admin` scope, the common path works — this makes the *failure* path (non-admin login, transient 403, or a realm where the scope isn't fully configured) diagnosable instead of a silently-broken service.

## Before
- One opaque line: `Cannot manage client 'c86848be-…' — create it manually` — a Keycloak-internal UUID, no role names, no hint it's load-bearing (`Promise.all` collapsed all three role assignments into one first-failure message).
- Generated `main.ts` had no `.catch()`, so the resulting startup 401/403 surfaced as a raw unhandled-rejection crash.

## After
- **`ensureServiceAccountRoles`**: `Promise.allSettled` → reports **which** of the three platform roles failed, names the **service** (`hello-world-nx-service`, not a UUID), and prints a dedicated warning stating the roles are **required** (the service won't start until granted) plus the two fixes: re-login `--scope adsp-cli-admin` and re-run (existing-client path back-fills), or grant in the portal. Still **best-effort** — scaffolding succeeds; a non-admin can generate then have an admin grant the roles.
- **Generated `main.ts`**: `.catch()` around `initializeApp()` → exits with a clear message pointing at AGENTS.md instead of a raw stack.
- **express AGENTS.md**: new "Service won't start (401/403)" section listing the three roles + the fixes (matches the `.catch` message's reference).

Kept best-effort rather than a hard generation error (per the earlier discussion): the scaffold is still useful and the failure is now loud + recoverable.

nx-adsp build / test (53) / lint green. `--tenant` provisioning path already verified live against dev/autotest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)