### PR TITLE
fix(nx-oc): honor --no-interactive for the sandbox registry prompt

### DIFF
--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
 import { getAccessToken, getStatus } from '@abgov/adsp-cli';
 import { AdspConfiguration, AdspOptions } from './adsp';
 import { EnvironmentName, environments } from './environments';
+import { isNonInteractive } from '../utils/interactive';
 
 interface Package {
   dependencies: Record<string, string>;
@@ -30,17 +31,6 @@ export function hasDependency(host: Tree, dependency: string): boolean {
 // everyone else, so requesting it is always safe.
 export const ADSP_ADMIN_SCOPE = 'adsp-cli-admin';
 
-// Mirrors nx-adsp's isNonInteractive (utils/agent.ts) — duplicated because nx-oc
-// is the lower-level package and can't import from nx-adsp. Keep them in sync.
-function isNonInteractive(): boolean {
-  const argv = process.argv;
-  const interactiveIdx = argv.indexOf('--interactive');
-  const flagged =
-    argv.includes('--no-interactive') ||
-    argv.includes('--interactive=false') ||
-    (interactiveIdx !== -1 && argv[interactiveIdx + 1] === 'false');
-  return flagged || !process.stdout.isTTY || process.env.CI === 'true';
-}
 
 /** Resolve the `adsp` binary shipped by the @abgov/adsp-cli dependency. */
 function adspCliBinPath(): string {

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -6,6 +6,7 @@ import {
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import * as utils from '../../adsp';
 import { environments } from '../../adsp';
+import * as gitUtils from '../../utils/git-utils';
 import generator from './sandbox';
 import { Schema } from './schema';
 
@@ -69,6 +70,21 @@ describe('Sandbox Generator', () => {
     expect(manifest).not.toContain('ImageStream');
     expect(manifest).not.toContain('DEPLOY_TAG');
     expect(manifest).toContain('sandbox');
+  });
+
+  it('errors (does not prompt) when the registry cannot be resolved non-interactively', async () => {
+    // Jest has no TTY, so isNonInteractive() is true. With no --registry, nothing
+    // persisted in nx.json, and no git remote to derive from, the generator must
+    // throw an actionable error rather than hang on the enquirer prompt.
+    const spy = jest.spyOn(gitUtils, 'getGitRemoteUrl').mockReturnValue(undefined);
+    try {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addNodeProject(host);
+      const noRegistry: Schema = { project: 'test', sandboxProject: 'test-sandbox' };
+      await expect(generator(host, noRegistry)).rejects.toThrow(/--registry/);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('generates sandbox manifest for frontend app', async () => {

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -18,6 +18,7 @@ import {
 } from '../../utils/git-utils';
 import { getClusterIngressDomain } from '../../utils/oc-utils';
 import { detectApplicationType, getBuildOutputPath } from '../../utils/app-type';
+import { isNonInteractive } from '../../utils/interactive';
 import { DatabaseType } from '../deployment/schema';
 import { NormalizedSchema, Schema } from './schema';
 
@@ -56,6 +57,17 @@ async function resolveRegistry(
   if (derived) {
     console.log(`\n✓ Sandbox registry: ${derived.toLowerCase()} (derived from git remote)\n`);
     return persistRegistry(host, derived);
+  }
+
+  // Nx's --no-interactive doesn't suppress this manual enquirer prompt, so guard
+  // it ourselves — otherwise a non-interactive/CI run hangs here when the registry
+  // can't be derived (no --registry, nothing in nx.json, no git remote).
+  if (isNonInteractive()) {
+    throw new Error(
+      'Could not determine the sandbox container registry: no --registry flag, ' +
+        'nothing persisted in nx.json, and none derivable from a git remote. ' +
+        'Re-run with --registry=<host>/<org> (e.g. --registry=ghcr.io/my-org).'
+    );
   }
 
   const { prompt } = await import('enquirer');

--- a/packages/nx-oc/src/utils/interactive.ts
+++ b/packages/nx-oc/src/utils/interactive.ts
@@ -1,0 +1,15 @@
+/**
+ * True when a generator is running non-interactively and must NOT open an
+ * enquirer prompt. Nx's `--no-interactive` only suppresses its own schema
+ * `x-prompt`s — manual enquirer prompts in generator code keep blocking unless
+ * they check this. Mirrors nx-adsp's utils/agent.ts isNonInteractive; keep in sync.
+ */
+export function isNonInteractive(): boolean {
+  const argv = process.argv;
+  const interactiveIdx = argv.indexOf('--interactive');
+  const flagged =
+    argv.includes('--no-interactive') ||
+    argv.includes('--interactive=false') ||
+    (interactiveIdx !== -1 && argv[interactiveIdx + 1] === 'false');
+  return flagged || !process.stdout.isTTY || process.env.CI === 'true';
+}


### PR DESCRIPTION
## Bug

`nx g @abgov/nx-oc:sandbox … --no-interactive` hung on **"What container registry should sandbox images be published to?"**. Nx's `--no-interactive` only suppresses its own schema `x-prompt`s — the sandbox generator's registry fallback is a **manual enquirer prompt**, so it kept blocking. It bit when `--registry` wasn't passed, nothing was persisted in `nx.json`, and no registry could be derived from a git remote (had to kill it and pass `--registry` explicitly).

## Fix

Guard the prompt with `isNonInteractive()` — in a non-interactive/CI run, throw an actionable error (`Re-run with --registry=<host>/<org>`) instead of opening the prompt. Same pattern already used for the ADSP agent consult.

Extracted `isNonInteractive()` into `utils/interactive.ts` and reused it from `adsp-utils` (which had a private copy), so there's one source in nx-oc.

## Test

New regression test: no `--registry`, no git remote, non-interactive (jest has no TTY) → rejects with a `/--registry/` error instead of hanging. `nx-oc` build / test (101) / lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)