### PR TITLE
feat(nx-oc,nx-adsp): run Playwright e2e against deployed environments in the pipeline

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -47,6 +47,11 @@ describe('angular app generator', () => {
         appTree.exists('apps/test-e2e/playwright.config.mts')
     ).toBe(true);
     expect(appTree.exists('apps/test-e2e/cypress.config.ts')).toBeFalsy();
+    // webServer guarded so CI can target a deployed URL (BASE_URL) instead of a local server
+    const cfg = appTree.exists('apps/test-e2e/playwright.config.mts')
+      ? 'apps/test-e2e/playwright.config.mts'
+      : 'apps/test-e2e/playwright.config.ts';
+    expect(appTree.read(cfg).toString()).toContain('process.env.BASE_URL');
   }, 120000);
 
   it('AGENTS.md points at the current design system docs', async () => {

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -2,7 +2,7 @@ import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import { confirmAfterAgentInterrupt, consultAgent } from '../../utils/agent';
 import { ensureAudienceMapper, ensureClientRoleScope, ensurePublicClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
-import { addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings } from '../../utils/quality';
+import { addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings, guardPlaywrightWebServer } from '../../utils/quality';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -111,6 +111,10 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
     directory: normalizedOptions.projectRoot,
     skipFormat: true,
   });
+
+  // Let the Playwright e2e target the deployed URL (BASE_URL) in CI instead of
+  // always starting a local dev server — see the nx-oc pipeline's e2e jobs.
+  guardPlaywrightWebServer(host, `${normalizedOptions.projectRoot}-e2e`);
 
   addDependenciesToPackageJson(
     host,

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -40,6 +40,11 @@ describe('React App Generator', () => {
         host.exists('apps/test-e2e/playwright.config.mts')
     ).toBe(true);
     expect(host.exists('apps/test-e2e/cypress.config.ts')).toBeFalsy();
+    // webServer guarded so CI can target a deployed URL (BASE_URL) instead of a local server
+    const cfg = host.exists('apps/test-e2e/playwright.config.mts')
+      ? 'apps/test-e2e/playwright.config.mts'
+      : 'apps/test-e2e/playwright.config.ts';
+    expect(host.read(cfg).toString()).toContain('process.env.BASE_URL');
   }, 30000);
 
   it('AGENTS.md points at the current design system docs', async () => {

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -2,7 +2,7 @@ import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import { confirmAfterAgentInterrupt, consultAgent } from '../../utils/agent';
 import { ensureAudienceMapper, ensureClientRoleScope, ensurePublicClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
-import { addEslintQualityRules, addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings } from '../../utils/quality';
+import { addEslintQualityRules, addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings, guardPlaywrightWebServer } from '../../utils/quality';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -124,6 +124,10 @@ export default async function (host: Tree, options: Schema) {
     strict: false,
     directory: normalizedOptions.projectRoot,
   });
+
+  // Let the Playwright e2e target the deployed URL (BASE_URL) in CI instead of
+  // always starting a local dev server — see the nx-oc pipeline's e2e jobs.
+  guardPlaywrightWebServer(host, `${normalizedOptions.projectRoot}-e2e`);
 
   addDependenciesToPackageJson(
     host,

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -57,6 +57,11 @@ describe('Vue App Generator', () => {
         host.exists('apps/test-e2e/playwright.config.mts')
     ).toBe(true);
     expect(host.exists('apps/test-e2e/cypress.config.ts')).toBeFalsy();
+    // webServer guarded so CI can target a deployed URL (BASE_URL) instead of a local server
+    const cfg = host.exists('apps/test-e2e/playwright.config.mts')
+      ? 'apps/test-e2e/playwright.config.mts'
+      : 'apps/test-e2e/playwright.config.ts';
+    expect(host.read(cfg).toString()).toContain('process.env.BASE_URL');
   }, 30000);
 
   it('AGENTS.md points at the current design system docs', async () => {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -2,7 +2,7 @@ import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import { confirmAfterAgentInterrupt, consultAgent } from '../../utils/agent';
 import { ensureAudienceMapper, ensureClientRoleScope, ensurePublicClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
-import { addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings } from '../../utils/quality';
+import { addJestCoverageConfig, addSemgrepTarget, addVsCodeSettings, guardPlaywrightWebServer } from '../../utils/quality';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -80,6 +80,10 @@ export default async function (host: Tree, options: Schema) {
     routing: true,
     directory: normalizedOptions.projectRoot,
   });
+
+  // Let the Playwright e2e target the deployed URL (BASE_URL) in CI instead of
+  // always starting a local dev server — see the nx-oc pipeline's e2e jobs.
+  guardPlaywrightWebServer(host, `${normalizedOptions.projectRoot}-e2e`);
 
   addDependenciesToPackageJson(
     host,

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -91,6 +91,38 @@ export function addSemgrepTarget(host: Tree, projectName: string): void {
   updateProjectConfiguration(host, projectName, config);
 }
 
+/**
+ * Makes the generated Playwright e2e config skip its local dev-server when
+ * BASE_URL is set. @nx/playwright's config already reads BASE_URL for `baseURL`
+ * (its own comment says "for CI, set BASE_URL to the deployed application"), but
+ * its `webServer` block would still start a local `nx serve` in CI. Guarding it on
+ * BASE_URL lets the same suite run locally (spins the dev server) or against a
+ * deployed URL in the pipeline (no local server) — see the pipeline's e2e jobs.
+ *
+ * This is @nx/playwright's own documented pattern for testing a hosted target
+ * (point `baseURL` at the deployment, leave `webServer` out); the common idiom is
+ * `webServer: process.env.CI ? undefined : {...}` — we key on BASE_URL instead so
+ * the server is only dropped when we actually have a deployed URL. It also avoids
+ * the serve/webServer double-start race in nx that has no clean built-in fix:
+ * https://github.com/nrwl/nx/issues/34698 (the pipeline additionally passes
+ * --exclude-task-dependencies to skip nx's cached inferred `serve` dependsOn).
+ *
+ * Idempotent and a no-op if the config lacks a webServer or is already guarded.
+ */
+export function guardPlaywrightWebServer(host: Tree, e2eProjectRoot: string): void {
+  for (const ext of ['mts', 'ts', 'cts', 'js', 'mjs']) {
+    const configPath = `${e2eProjectRoot}/playwright.config.${ext}`;
+    if (!host.exists(configPath)) continue;
+    const cfg = host.read(configPath).toString();
+    if (cfg.includes('process.env.BASE_URL') || !cfg.includes('webServer: {')) return;
+    host.write(
+      configPath,
+      cfg.replace('webServer: {', 'webServer: process.env.BASE_URL ? undefined : {')
+    );
+    return;
+  }
+}
+
 export function addVsCodeSettings(host: Tree): void {
   const settingsPath = '.vscode/settings.json';
   const settings = {

--- a/packages/nx-oc/generators.json
+++ b/packages/nx-oc/generators.json
@@ -18,6 +18,11 @@
       "schema": "./src/generators/setup-secrets/schema.json",
       "description": "Sets GitHub Actions secrets and OpenShift GHCR pull secret for the pipeline."
     },
+    "setup-runner": {
+      "factory": "./src/generators/setup-runner/setup-runner",
+      "schema": "./src/generators/setup-runner/schema.json",
+      "description": "Provisions the self-hosted GitHub Actions runner for deployed-env Playwright e2e (secret, Deployment, RUN_E2E)."
+    },
     "deployment": {
       "factory": "./src/generators/deployment/deployment",
       "schema": "./src/generators/deployment/schema.json",

--- a/packages/nx-oc/src/generators/pipeline/actions/openshift/github-runner/README.md__tmpl__
+++ b/packages/nx-oc/src/generators/pipeline/actions/openshift/github-runner/README.md__tmpl__
@@ -1,0 +1,108 @@
+# Playwright e2e runner (`<%= ocInfraProject %>`)
+
+A self-hosted GitHub Actions runner (label **`playwright`**) that the pipeline's
+`e2e<Env>` jobs run on, so they can reach the **network-private** environment
+routes that GitHub-hosted runners can't. It uses the shared **public** image
+[`ghcr.io/govalta/github-runner-playwright`](https://github.com/GovAlta/github-runner-images)
+— no pull secret needed.
+
+## Setup
+
+### Create the PAT (the one manual github.com step)
+
+Registration itself is automatic — the runner self-registers using the PAT, with
+no click-through on github.com to approve it. But **creating** the PAT is a
+browser step that can't be automated (it's credential issuance): generate a
+classic token at <https://github.com/settings/tokens> with **`read:packages` +
+`repo`** scope (`admin:org` instead of `repo` for an org-wide runner), and keep
+it handy for the step below. Everything after (`oc apply` → self-register →
+*Idle*) needs no further GitHub UI.
+
+> If an **org** has restricted self-hosted runners (org setting or runner-group
+> policy), registration returns 403 until an org admin permits this repo — even
+> with a valid PAT. Repos allow self-hosted runners by default, so usually
+> there's nothing to toggle.
+
+### Provision the runner
+
+If you generated the pipeline with `--apply` this is **done for you**. To
+provision (or repair) the runner on its own at any time:
+
+```bash
+nx g @abgov/nx-oc:setup-runner --infra <%= ocInfraProject %>
+```
+
+It prompts for the PAT, creates the `github-runner-pat` secret, applies this
+Deployment, and sets `RUN_E2E=true`.
+
+The only step that can't be automated is the private-CA configmap (we don't have
+your cert), and only if internal routes use one:
+
+```bash
+oc create configmap goa-ca \
+  --from-file=goa-ca.crt=<path-to-ca.crt> -n <%= ocInfraProject %>
+```
+
+Confirm the runner shows up under the repo's **Settings → Actions → Runners**
+(status *Idle*, label `playwright`).
+
+### Manual setup (equivalent of the generator)
+
+```bash
+# 1. PAT for runner registration (repo scope; admin:org for an org-wide runner).
+oc create secret generic github-runner-pat \
+  --from-literal=pat=<YOUR_PAT> -n <%= ocInfraProject %>
+
+# 2. (Only if internal endpoints use a private CA) the CA cert Node/Playwright must trust:
+oc create configmap goa-ca \
+  --from-file=goa-ca.crt=<path-to-ca.crt> -n <%= ocInfraProject %>
+
+# 3. Start the runner:
+oc apply -f .openshift/github-runner/deployment.yml
+
+# 4. Enable e2e in CI (the e2e<Env> jobs are gated on this so they never queue
+#    before a runner exists):
+gh variable set RUN_E2E --body true
+```
+
+## PAT scopes
+
+One classic PAT covers everything the pipeline needs from GitHub. It must carry
+both scopes (they serve different purposes — a token missing one still "works"
+until the corresponding step runs):
+
+| Scope | Used for | Symptom if missing |
+| --- | --- | --- |
+| `read:packages` | `ghcr-pull-secret` — OpenShift pulling/importing app images from GHCR | `oc import-image` / deploy fails with `unauthorized` or `manifest unknown` pulling `ghcr.io/...` |
+| `repo` (`admin:org` for an org-wide runner) | `github-runner-pat` — the runner self-registering with GitHub | Runner never appears under **Settings → Actions → Runners**; `e2e<Env>` jobs sit **Queued** forever (nothing with label `playwright` to pick them up) |
+
+Fine-grained PATs also work if granted the equivalent access (repo
+Administration + Actions for registration, Packages: read for pull); the classic
+scopes above are the simplest.
+
+## How e2e runs
+
+After each `deploy<Env>`, the `e2e<Env>` job (on this runner) resolves every
+affected app's live route (`oc get route`) and runs its Playwright suite against
+`https://<route>` (`BASE_URL`). It's **report-style** — results surface in the run
+but do not gate promotion (promotion is gated by the environment's approval, if
+configured). Apps without a Playwright e2e project or a Route are skipped.
+
+Prod is intentionally covered by unauthenticated smoke only; authenticated
+regression (per app, pre-prod) is set up separately.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `e2e<Env>` jobs stuck **Queued** | No runner registered with label `playwright` (pod not running, or PAT lacks `repo`/`admin:org`) | `oc get pods -n <%= ocInfraProject %> -l app=github-runner-playwright`; check logs for a registration error; recreate `github-runner-pat` with a `repo`-scoped PAT |
+| Runner pod `CrashLoopBackOff`, logs show 401/403 on registration | PAT invalid, expired, or missing `repo`/`admin:org` | Re-run `nx g @abgov/nx-oc:setup-runner --infra <%= ocInfraProject %>` with a fresh PAT (recreates the secret and restarts the runner) |
+| `e2e<Env>` jobs never appear at all | `RUN_E2E` not set | `gh variable set RUN_E2E --body true` |
+| e2e step: `oc get route` empty / app skipped | App has no Route in the env namespace yet, or no Playwright e2e project | Expected for non-web apps; otherwise confirm the deploy created a Route |
+| Playwright: `net::ERR_CERT_AUTHORITY_INVALID` / TLS errors against internal routes | Runner doesn't trust the internal CA | Create the optional `goa-ca` configmap (see Setup) and restart the runner |
+| Image build/deploy: `unauthorized` pulling `ghcr.io/...` | `ghcr-pull-secret` PAT lacks `read:packages` | Re-run `setup-secrets` with a PAT that has `read:packages` |
+
+To register an **org-wide** runner (shared across repos) instead of this
+repo-scoped one, the PAT needs `admin:org` and `GITHUB_REPOSITORY` in the
+Deployment should be dropped in favour of an org URL — see the
+[runner image repo](https://github.com/GovAlta/github-runner-images).

--- a/packages/nx-oc/src/generators/pipeline/actions/openshift/github-runner/deployment.yml__tmpl__
+++ b/packages/nx-oc/src/generators/pipeline/actions/openshift/github-runner/deployment.yml__tmpl__
@@ -1,0 +1,60 @@
+# Self-hosted GitHub Actions runner for Playwright e2e (registers with label
+# "playwright"). Runs in-cluster so the pipeline's e2e<Env> jobs can reach the
+# network-private environment routes that GitHub-hosted runners can't.
+#
+# Image: the shared public runner image (ghcr.io/govalta/github-runner-playwright)
+# — public, so no pull secret is needed. See README.md for the one-time setup
+# (PAT secret + optional CA ConfigMap) before `oc apply`.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-runner-playwright
+  namespace: <%= ocInfraProject %>
+  labels:
+    app: github-runner-playwright
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-runner-playwright
+  template:
+    metadata:
+      labels:
+        app: github-runner-playwright
+    spec:
+      containers:
+        - name: runner
+          image: ghcr.io/govalta/github-runner-playwright:latest
+          env:
+            - name: GITHUB_OWNER
+              value: "<%= githubOwner %>"
+            - name: GITHUB_REPOSITORY
+              value: "<%= githubRepo %>"
+            - name: RUNNER_LABELS
+              value: "playwright"
+            - name: GITHUB_PAT
+              valueFrom:
+                secretKeyRef:
+                  name: github-runner-pat
+                  key: pat
+            # Internal CA so Node/Playwright trust internal TLS — mounted at
+            # runtime, never baked into the public image. Harmless if goa-ca
+            # doesn't exist (the volume is optional).
+            - name: NODE_EXTRA_CA_CERTS
+              value: /etc/ssl/goa/goa-ca.crt
+          volumeMounts:
+            - name: goa-ca
+              mountPath: /etc/ssl/goa
+              readOnly: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+      volumes:
+        - name: goa-ca
+          configMap:
+            name: goa-ca
+            optional: true

--- a/packages/nx-oc/src/generators/pipeline/actions/workflows/pipeline.yml__tmpl__
+++ b/packages/nx-oc/src/generators/pipeline/actions/workflows/pipeline.yml__tmpl__
@@ -226,4 +226,64 @@ jobs:
               oc rollout status dc/$app -n <%= ocEnvProject %>
             fi
           done
+
+  e2e<%= envs[i] %>:
+    # Smoke-test the deployed <%= envs[i] %> apps with Playwright against their live
+    # routes. Runs on the in-cluster self-hosted runner (label "playwright") so it
+    # can reach network-private URLs GitHub-hosted runners can't. Report-style: it
+    # does NOT gate promotion (the next deploy depends on deploy<%= envs[i] %>, not this).
+    # Requires the runner + the RUN_E2E repo variable — see
+    # .openshift/github-runner/README.md.
+    if: needs.build.outputs.affected_apps && vars.RUN_E2E == 'true'
+    needs: [build, deploy<%= envs[i] %>]
+    runs-on: [self-hosted, playwright]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      AFFECTED_APPS: ${{ needs.build.outputs.affected_apps }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      - name: OC login
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          namespace: <%= ocEnvProject %>
+          insecure_skip_tls_verify: true
+      - name: Smoke e2e against <%= envs[i] %>
+        run: |
+          set -eo pipefail
+          npx playwright install chromium
+          for app in $AFFECTED_APPS
+          do
+            e2e="${app}-e2e"
+            root=$(npx nx show project "$e2e" --json 2>/dev/null \
+              | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).root||"")}catch{}}') || true
+            if [ -z "$root" ] || ! ls "$root"/playwright.config.* > /dev/null 2>&1 ; then
+              echo "skip $app — no Playwright e2e project"
+              continue
+            fi
+            host=$(oc get route "$app" -n <%= ocEnvProject %> -o jsonpath='{.spec.host}' 2>/dev/null || true)
+            if [ -z "$host" ] ; then
+              echo "skip $app — no Route in <%= ocEnvProject %>"
+              continue
+            fi
+            echo "e2e $e2e against https://$host"
+            # We test the deployed URL, so no local server should run. Two guards,
+            # because @nx/playwright can start a local server two ways and neither
+            # has a clean built-in "test a hosted target" mode (nrwl/nx#34698):
+            #   1. The Playwright config's own webServer — guarded on BASE_URL in
+            #      the frontend generators (webServer undefined when BASE_URL set).
+            #   2. nx's inferred `serve` dependsOn, derived from that webServer and
+            #      cached by config-file hash (not env), so it can persist even with
+            #      BASE_URL set — --exclude-task-dependencies skips it.
+            # https://github.com/nrwl/nx/issues/34698
+            BASE_URL="https://$host" npx nx e2e "$e2e" --exclude-task-dependencies
+          done
 <% }); -%>

--- a/packages/nx-oc/src/generators/pipeline/pipeline.spec.ts
+++ b/packages/nx-oc/src/generators/pipeline/pipeline.spec.ts
@@ -65,6 +65,31 @@ describe('Pipeline Generator', () => {
       expect(workflow).toContain('oc set triggers');
     });
 
+    it('adds a deployed-env Playwright e2e job + the self-hosted runner manifest', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      await generator(host, options);
+
+      const workflow = host.read('.github/workflows/pipeline.yml').toString();
+      // e2e runs on the in-cluster self-hosted runner, gated so it can't queue
+      // before the runner exists, resolves the deployed URL, and is report-style.
+      expect(workflow).toContain('[self-hosted, playwright]');
+      expect(workflow).toContain("vars.RUN_E2E == 'true'");
+      expect(workflow).toContain('oc get route');
+      expect(workflow).toContain('BASE_URL=');
+      // --exclude-task-dependencies skips nx's inferred serve dependency so no
+      // local server runs when targeting the deployed URL.
+      expect(workflow).toContain('nx e2e "$e2e" --exclude-task-dependencies');
+
+      // Runner provisioning ships as in-repo manifests referencing the shared
+      // public image (no per-repo build, no pull secret).
+      expect(host.exists('.openshift/github-runner/deployment.yml')).toBeTruthy();
+      const dep = host.read('.openshift/github-runner/deployment.yml').toString();
+      expect(dep).toContain('ghcr.io/govalta/github-runner-playwright');
+      expect(dep).toContain('RUNNER_LABELS');
+      expect(dep).toContain('test-infra'); // namespace = the infra project
+      expect(host.exists('.openshift/github-runner/README.md')).toBeTruthy();
+    });
+
     it('can generate multiple envs', async () => {
       const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
       await generator(host, { ...options, envs: 'test-dev test-test' });

--- a/packages/nx-oc/src/generators/pipeline/pipeline.ts
+++ b/packages/nx-oc/src/generators/pipeline/pipeline.ts
@@ -1,9 +1,11 @@
 import { formatFiles, generateFiles, Tree } from '@nx/devkit';
 import * as path from 'path';
 import { pipelineEnvs as envs } from '../../pipeline-envs';
-import { deriveRegistryFromRemote, getGitRemoteUrl } from '../../utils/git-utils';
+import { deriveRegistryFromRemote, getGitHubRepo, getGitRemoteUrl } from '../../utils/git-utils';
+import { promptForGitHubPat } from '../../utils/gh-utils';
 import applyInfraGenerator from '../apply-infra/apply-infra';
 import setupSecretsGenerator from '../setup-secrets/setup-secrets';
+import setupRunnerGenerator from '../setup-runner/setup-runner';
 import { NormalizedSchema, Schema } from './schema';
 
 function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
@@ -50,9 +52,19 @@ async function resolveRegistry(registry?: string): Promise<string> {
 }
 
 function addFiles(host: Tree, options: NormalizedSchema) {
+  const remoteUrl = getGitRemoteUrl()?.trim();
+  // owner/repo drive the self-hosted e2e runner's registration (GITHUB_OWNER /
+  // GITHUB_REPOSITORY). Empty when there's no GitHub remote — the runner manifest
+  // then ships with placeholders the operator fills in (see its README).
+  const repoSlug = getGitHubRepo(remoteUrl) ?? '';
+  const [githubOwner, githubRepo] = repoSlug.includes('/')
+    ? repoSlug.split('/')
+    : ['<your-org>', '<your-repo>'];
   const templateOptions = {
     ...options,
-    sourceRepositoryUrl: getGitRemoteUrl()?.trim(),
+    sourceRepositoryUrl: remoteUrl,
+    githubOwner,
+    githubRepo,
     envs,
     tmpl: '',
   };
@@ -96,12 +108,22 @@ export default async function (host: Tree, options: Schema) {
 
     const remoteUrl = getGitRemoteUrl()?.trim();
     if (remoteUrl) {
-      await setupSecretsGenerator(host, { infra: normalizedOptions.ocInfraProject });
+      // Prompt once and share: the pull secret needs read:packages and the e2e
+      // runner registration needs repo, so one PAT with both scopes covers
+      // setup-secrets and setup-runner without a second prompt. Each generator
+      // falls back to its own prompt when run standalone.
+      const pat = await promptForGitHubPat(
+        'Enter a GitHub PAT with read:packages + repo scope\n' +
+        '  (read:packages → OpenShift image pull; repo → e2e runner registration):'
+      );
+      await setupSecretsGenerator(host, { infra: normalizedOptions.ocInfraProject, pat });
+      await setupRunnerGenerator(host, { infra: normalizedOptions.ocInfraProject, pat });
     } else {
       console.log(
-        '\n⚠  No git remote found — skipping GitHub secrets setup.\n' +
+        '\n⚠  No git remote found — skipping GitHub secrets and e2e runner setup.\n' +
         `   Push to GitHub first then run:\n` +
-        `   npx nx g @abgov/nx-oc:setup-secrets --infra ${normalizedOptions.ocInfraProject}\n`
+        `   npx nx g @abgov/nx-oc:setup-secrets --infra ${normalizedOptions.ocInfraProject}\n` +
+        `   npx nx g @abgov/nx-oc:setup-runner --infra ${normalizedOptions.ocInfraProject}\n`
       );
     }
   }

--- a/packages/nx-oc/src/generators/setup-runner/schema.d.ts
+++ b/packages/nx-oc/src/generators/setup-runner/schema.d.ts
@@ -1,0 +1,9 @@
+export interface Schema {
+  infra: string;
+  // PAT (repo scope) used to register the runner with GitHub. Passed
+  // programmatically by the pipeline generator (prompted once, shared with
+  // setup-secrets); when omitted, a standalone run prompts for it. Deliberately
+  // not a CLI flag — never pass a secret on the command line — so it's absent
+  // from schema.json.
+  pat?: string;
+}

--- a/packages/nx-oc/src/generators/setup-runner/schema.json
+++ b/packages/nx-oc/src/generators/setup-runner/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxOcSetupRunner",
+  "title": "Set up the self-hosted e2e runner",
+  "type": "object",
+  "properties": {
+    "infra": {
+      "type": "string",
+      "description": "Name of the OpenShift infra project the runner Deployment and its secret live in.",
+      "alias": "i",
+      "x-prompt": "What is the OpenShift infra project?"
+    }
+  },
+  "required": ["infra"],
+  "additionalProperties": false
+}

--- a/packages/nx-oc/src/generators/setup-runner/setup-runner.spec.ts
+++ b/packages/nx-oc/src/generators/setup-runner/setup-runner.spec.ts
@@ -1,0 +1,96 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import * as ocUtils from '../../utils/oc-utils';
+import * as ghUtils from '../../utils/gh-utils';
+import * as gitUtils from '../../utils/git-utils';
+import { Schema } from './schema';
+import generator from './setup-runner';
+
+jest.mock('../../utils/oc-utils');
+jest.mock('../../utils/gh-utils');
+jest.mock('../../utils/git-utils');
+
+const ocMock = ocUtils as jest.Mocked<typeof ocUtils>;
+const ghMock = ghUtils as jest.Mocked<typeof ghUtils>;
+const gitMock = gitUtils as jest.Mocked<typeof gitUtils>;
+
+const MANIFEST = '.openshift/github-runner/deployment.yml';
+
+describe('Setup Runner Generator', () => {
+  const options: Schema = { infra: 'my-infra' };
+
+  function withManifest() {
+    const host = createTreeWithEmptyWorkspace();
+    host.write(MANIFEST, 'kind: Deployment\n');
+    return host;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ocMock.ensureOcLogin.mockImplementation(() => undefined);
+    ocMock.createGenericSecret.mockReturnValue(true);
+    ocMock.runOcCommand.mockReturnValue({ success: true });
+    ocMock.rolloutRestartDeployment.mockReturnValue(true);
+    ghMock.checkGhCli.mockImplementation(() => undefined);
+    ghMock.setGhVariable.mockReturnValue(true);
+    ghMock.promptForGitHubPat.mockResolvedValue('test-pat');
+    gitMock.getGitRemoteUrl.mockReturnValue('https://github.com/GovAlta/nx-tools.git');
+    gitMock.getGitHubRepo.mockReturnValue('GovAlta/nx-tools');
+  });
+
+  it('creates the secret, applies the Deployment, and enables RUN_E2E', async () => {
+    const host = withManifest();
+    await generator(host, options);
+
+    expect(ocMock.createGenericSecret).toHaveBeenCalledWith(
+      'github-runner-pat', { pat: 'test-pat' }, 'my-infra'
+    );
+    expect(ocMock.runOcCommand).toHaveBeenCalledWith('apply', [], expect.anything());
+    expect(ocMock.rolloutRestartDeployment).toHaveBeenCalledWith('github-runner-playwright', 'my-infra');
+    expect(ghMock.setGhVariable).toHaveBeenCalledWith('RUN_E2E', 'true', 'GovAlta/nx-tools');
+  });
+
+  it('reuses a PAT passed in by the caller without prompting', async () => {
+    const host = withManifest();
+    await generator(host, { ...options, pat: 'passed-in-pat' });
+
+    expect(ghMock.promptForGitHubPat).not.toHaveBeenCalled();
+    expect(ocMock.createGenericSecret).toHaveBeenCalledWith(
+      'github-runner-pat', { pat: 'passed-in-pat' }, 'my-infra'
+    );
+  });
+
+  it('prompts for a PAT when one is not passed in', async () => {
+    const host = withManifest();
+    await generator(host, options);
+    expect(ghMock.promptForGitHubPat).toHaveBeenCalled();
+  });
+
+  it('does nothing when the runner manifest is absent', async () => {
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, options);
+
+    expect(ocMock.ensureOcLogin).not.toHaveBeenCalled();
+    expect(ocMock.createGenericSecret).not.toHaveBeenCalled();
+    expect(ghMock.setGhVariable).not.toHaveBeenCalled();
+  });
+
+  it('skips when no GitHub remote is found', async () => {
+    gitMock.getGitRemoteUrl.mockReturnValue(undefined);
+    gitMock.getGitHubRepo.mockReturnValue(undefined);
+
+    const host = withManifest();
+    await generator(host, options);
+
+    expect(ocMock.createGenericSecret).not.toHaveBeenCalled();
+    expect(ghMock.setGhVariable).not.toHaveBeenCalled();
+  });
+
+  it('does not enable RUN_E2E when applying the Deployment fails', async () => {
+    ocMock.runOcCommand.mockReturnValue({ success: false });
+
+    const host = withManifest();
+    await generator(host, options);
+
+    expect(ghMock.setGhVariable).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx-oc/src/generators/setup-runner/setup-runner.ts
+++ b/packages/nx-oc/src/generators/setup-runner/setup-runner.ts
@@ -1,0 +1,84 @@
+import { Tree } from '@nx/devkit';
+import {
+  createGenericSecret,
+  ensureOcLogin,
+  rolloutRestartDeployment,
+  runOcCommand,
+} from '../../utils/oc-utils';
+import { checkGhCli, promptForGitHubPat, setGhVariable } from '../../utils/gh-utils';
+import { getGitHubRepo, getGitRemoteUrl } from '../../utils/git-utils';
+import { Schema } from './schema';
+
+const RUNNER_MANIFEST = '.openshift/github-runner/deployment.yml';
+
+// Provisions the self-hosted Playwright e2e runner as one cohesive unit: its
+// registration secret, the Deployment (piped from the tree, like apply-infra),
+// and the RUN_E2E gate. Runs after setup-secrets so the secret exists before the
+// Deployment. The optional goa-ca CA configmap stays manual — we don't have the
+// cert (see .openshift/github-runner/README.md).
+export default async function (host: Tree, options: Schema) {
+  if (!host.exists(RUNNER_MANIFEST)) {
+    console.log(
+      `\n⚠  No runner manifest at ${RUNNER_MANIFEST} — generate the pipeline first:\n` +
+      '   npx nx g @abgov/nx-oc:pipeline\n'
+    );
+    return;
+  }
+
+  try {
+    ensureOcLogin();
+  } catch (e) {
+    console.log(e instanceof Error ? e.message : String(e));
+    return;
+  }
+
+  const repo = getGitHubRepo(getGitRemoteUrl()?.trim());
+  if (!repo) {
+    console.log(
+      '\n⚠  No GitHub remote found — skipping e2e runner setup.\n' +
+      '   Push to GitHub first then re-run this generator.'
+    );
+    return;
+  }
+
+  try {
+    checkGhCli();
+  } catch (e) {
+    console.log(e instanceof Error ? e.message : String(e));
+    return;
+  }
+
+  // repo scope (admin:org for an org-wide runner) lets the runner self-register.
+  // The pipeline generator prompts once and passes the PAT in; a standalone run
+  // prompts here.
+  const pat = options.pat ?? await promptForGitHubPat(
+    'Enter a GitHub PAT with repo scope (admin:org for an org-wide runner) to register the e2e runner:'
+  );
+  if (!pat) return;
+
+  console.log('\nProvisioning the self-hosted e2e runner...');
+
+  const patSecret = createGenericSecret('github-runner-pat', { pat }, options.infra);
+  console.log(patSecret ? '✓ github-runner-pat secret created' : '✗ Failed to create github-runner-pat secret');
+  if (!patSecret) return;
+
+  const { success } = runOcCommand('apply', [], host.read(RUNNER_MANIFEST));
+  console.log(success ? '✓ e2e runner Deployment applied' : '✗ Failed to apply e2e runner Deployment');
+  if (!success) return;
+
+  // Restart so a re-run with a new PAT is picked up — the pod reads the secret
+  // only at start. Harmless on the first apply (the pod is just starting).
+  rolloutRestartDeployment('github-runner-playwright', options.infra);
+
+  const varSet = setGhVariable('RUN_E2E', 'true', repo);
+  console.log(
+    varSet
+      ? '✓ RUN_E2E enabled — e2e jobs will run on the runner'
+      : '✗ Failed to set RUN_E2E — enable it manually: gh variable set RUN_E2E --body true'
+  );
+  console.log(
+    '\n  The runner is registering under the repo\'s Settings → Actions → Runners\n' +
+    '  (label "playwright"). If internal routes use a private CA, also create the\n' +
+    '  optional goa-ca configmap — see .openshift/github-runner/README.md.\n'
+  );
+}

--- a/packages/nx-oc/src/generators/setup-secrets/schema.d.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/schema.d.ts
@@ -1,3 +1,8 @@
 export interface Schema {
   infra: string;
+  // PAT for the GHCR pull secret. Passed programmatically by the pipeline
+  // generator (prompted once, shared with setup-runner); when omitted, a
+  // standalone run prompts for it. Deliberately not a CLI flag — never pass a
+  // secret on the command line — so it's absent from schema.json.
+  pat?: string;
 }

--- a/packages/nx-oc/src/generators/setup-secrets/setup-secrets.spec.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/setup-secrets.spec.ts
@@ -8,9 +8,6 @@ import generator from './setup-secrets';
 jest.mock('../../utils/oc-utils');
 jest.mock('../../utils/gh-utils');
 jest.mock('../../utils/git-utils');
-jest.mock('enquirer', () => ({
-  prompt: jest.fn().mockResolvedValue({ pat: 'test-pat' }),
-}));
 
 const ocMock = ocUtils as jest.Mocked<typeof ocUtils>;
 const ghMock = ghUtils as jest.Mocked<typeof ghUtils>;
@@ -28,6 +25,7 @@ describe('Setup Secrets Generator', () => {
     ocMock.linkSecretToServiceAccount.mockReturnValue(true);
     ghMock.checkGhCli.mockImplementation(() => undefined);
     ghMock.setGhSecret.mockReturnValue(true);
+    ghMock.promptForGitHubPat.mockResolvedValue('test-pat');
     gitMock.getGitRemoteUrl.mockReturnValue('https://github.com/GovAlta/nx-tools.git');
     gitMock.getGitHubRepo.mockReturnValue('GovAlta/nx-tools');
     gitMock.deriveRegistryFromRemote.mockReturnValue('ghcr.io/GovAlta');
@@ -44,6 +42,22 @@ describe('Setup Secrets Generator', () => {
     );
     expect(ocMock.linkSecretToServiceAccount).toHaveBeenCalledWith(
       'ghcr-pull-secret', 'github-actions', 'my-infra'
+    );
+  });
+
+  it('prompts for a PAT when one is not passed in', async () => {
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, options);
+    expect(ghMock.promptForGitHubPat).toHaveBeenCalled();
+  });
+
+  it('reuses a PAT passed in by the caller without prompting', async () => {
+    const host = createTreeWithEmptyWorkspace();
+    await generator(host, { ...options, pat: 'passed-in-pat' });
+
+    expect(ghMock.promptForGitHubPat).not.toHaveBeenCalled();
+    expect(ocMock.createDockerRegistrySecret).toHaveBeenCalledWith(
+      'ghcr-pull-secret', 'ghcr.io', 'GovAlta', 'passed-in-pat', 'my-infra'
     );
   });
 

--- a/packages/nx-oc/src/generators/setup-secrets/setup-secrets.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/setup-secrets.ts
@@ -6,7 +6,7 @@ import {
   getSaToken,
   linkSecretToServiceAccount,
 } from '../../utils/oc-utils';
-import { checkGhCli, setGhSecret } from '../../utils/gh-utils';
+import { checkGhCli, promptForGitHubPat, setGhSecret } from '../../utils/gh-utils';
 import { deriveRegistryFromRemote, getGitHubRepo, getGitRemoteUrl } from '../../utils/git-utils';
 import { Schema } from './schema';
 
@@ -60,19 +60,12 @@ export default async function (host: Tree, options: Schema) {
     return;
   }
 
-  const { prompt } = await import('enquirer');
-  let pat: string;
-  try {
-    const answer = await prompt<{ pat: string }>({
-      type: 'password',
-      name: 'pat',
-      message: 'Enter a GitHub PAT with read:packages scope (for OpenShift image import):',
-    });
-    pat = answer.pat;
-  } catch {
-    return;
-  }
-
+  // read:packages lets OpenShift pull/import app images from GHCR. The pipeline
+  // generator prompts once and passes the PAT in (options.pat); a standalone run
+  // prompts here.
+  const pat = options.pat ?? await promptForGitHubPat(
+    'Enter a GitHub PAT with read:packages scope (for OpenShift image import):'
+  );
   if (!pat) return;
 
   const secretCreated = createDockerRegistrySecret('ghcr-pull-secret', 'ghcr.io', org, pat, options.infra);

--- a/packages/nx-oc/src/utils/gh-utils.ts
+++ b/packages/nx-oc/src/utils/gh-utils.ts
@@ -21,3 +21,31 @@ export function setGhSecret(name: string, value: string, repo: string): boolean 
     return false;
   }
 }
+
+export function setGhVariable(name: string, value: string, repo: string): boolean {
+  try {
+    execFileSync('gh', ['variable', 'set', name, '--repo', repo, '--body', value], {
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Prompts (masked) for a GitHub PAT. Returns undefined if the prompt is
+// cancelled or left empty. Callers that already hold a PAT (e.g. the pipeline
+// generator prompting once for several steps) pass it through and skip this.
+export async function promptForGitHubPat(message: string): Promise<string | undefined> {
+  const { prompt } = await import('enquirer');
+  try {
+    const { pat } = await prompt<{ pat: string }>({
+      type: 'password',
+      name: 'pat',
+      message,
+    });
+    return pat || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/nx-oc/src/utils/oc-utils.ts
+++ b/packages/nx-oc/src/utils/oc-utils.ts
@@ -72,6 +72,40 @@ export function createDockerRegistrySecret(
   }
 }
 
+// Creates (or updates) an opaque secret from literal key/values. Uses
+// `create --dry-run=client -o yaml | apply` so it's idempotent — re-running the
+// generator refreshes the value instead of failing on an existing secret.
+export function createGenericSecret(
+  name: string,
+  literals: Record<string, string>,
+  namespace: string
+): boolean {
+  try {
+    const manifest = execFileSync('oc', [
+      'create', 'secret', 'generic', name,
+      ...Object.entries(literals).map(([k, v]) => `--from-literal=${k}=${v}`),
+      '-n', namespace, '--dry-run=client', '-o', 'yaml',
+    ], { stdio: 'pipe' });
+    execFileSync('oc', ['apply', '-n', namespace, '-f', '-'], { stdio: 'pipe', input: manifest });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Restarts a Deployment's pods (patches the pod-template annotation). Needed
+// after changing a referenced Secret, since env vars from secretKeyRef are read
+// only at pod start. Best-effort — harmless right after first creating the
+// Deployment.
+export function rolloutRestartDeployment(name: string, namespace: string): boolean {
+  try {
+    execFileSync('oc', ['rollout', 'restart', `deployment/${name}`, '-n', namespace], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function linkSecretToServiceAccount(
   secretName: string,
   saName: string,


### PR DESCRIPTION
Implements deployed-environment **smoke e2e** in the generated pipeline (unauthenticated to start; prod excluded; authenticated `e2e-auth` is a later layer). Per `E2E_PIPELINE_PLAN.md`. Builds on the now-merged #312 (Playwright frontends).

## nx-oc `pipeline` generator
- **`pipeline.yml`** — after each `deploy<Env>`, an **`e2e<Env>`** job:
  - `runs-on: [self-hosted, playwright]` — dev/test URLs are network-private, unreachable from GitHub-hosted runners.
  - resolves each affected app's live route (`oc get route … → BASE_URL=https://<host>`, edge TLS) and runs its Playwright suite; skips apps with no Playwright e2e project or no Route.
  - **report-style** (doesn't gate promotion) and **gated on `vars.RUN_E2E`** so jobs never queue before a runner exists.
- **`.openshift/github-runner/{deployment.yml,README.md}`** — the runner Deployment referencing the shared **public** image `ghcr.io/govalta/github-runner-playwright` (no pull secret; `GITHUB_PAT` via Secret; `RUNNER_LABELS=playwright`; internal CA mounted at runtime, never baked), plus a one-time-setup runbook. owner/repo derived from the git remote.

## nx-adsp
- **`guardPlaywrightWebServer()`** post-processes the `@nx/playwright` config so its `webServer` only starts a local dev server when `BASE_URL` is unset — CI passes `BASE_URL` (deployed) and skips it; local `nx e2e` is unchanged. Applied by the vue/react/angular generators.

## Tests
- Pipeline spec asserts the `e2e<Env>` job (self-hosted, `RUN_E2E` gate, `oc get route`, `BASE_URL`, `nx e2e`) + the runner manifest/README.
- Frontend specs assert the generated Playwright config is `BASE_URL`-guarded.
- `nx-oc` (102) + `nx-adsp` (56) build/test/lint green.

The runner-image half is already done (validated + published from [GovAlta/github-runner-images](https://github.com/GovAlta/github-runner-images)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)