### PR TITLE
fix(nx-adsp): make a freshly generated vue-components lib work out of the box

### DIFF
--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -246,6 +246,38 @@ describe('nx-adsp e2e', () => {
       const result = await runNxCommandAsync(`build ${plugin}`);
       expect(result.stdout).toContain('Successfully ran target');
     }, 240000);
+
+    // vue-app co-generates the shared vue-components wrapper lib. Guard the real
+    // out-of-the-box breakages tree-content unit tests can't see.
+    // Not exercised here (both need a different workspace flavour than this legacy
+    // path-alias preset): TS-solution package.json `exports` resolution, and
+    // `nx lint` on the lib (gated on the workspace's @vue/eslint-config-typescript
+    // version — it's config-invalid on some, unrelated to our rules).
+    it('co-generates a vue-components lib whose test target passes', async () => {
+      const plugin = uniq('vue-app');
+      await runNxCommandAsync(
+        `generate @abgov/nx-adsp:vue-app ${plugin} dev --tenant=test --accessToken=mock-token --skipAgent`
+      );
+      checkFilesExist(
+        'vue-components/src/index.ts',
+        'vue-components/src/lib/GoabModal.vue',
+        'vue-components/src/vue-components.spec.ts',
+      );
+
+      // Guards the "no test files found" regression — the lib ships a spec, so
+      // its vitest target passes instead of exiting non-zero.
+      const test = await runNxCommandAsync(`test vue-components`);
+      expect(test.stdout).toContain('Successfully ran target');
+
+      // Guards GoabModal's native goa-modal `slot` against vue/no-deprecated-slot-
+      // attribute (whose --fix rewrites it into a build-crashing form). Asserted on
+      // the generated eslint config rather than by running lint (see above).
+      const eslintrc = readFileSync(
+        join(tmpProjPath(), 'vue-components/.eslintrc.json'),
+        'utf-8'
+      );
+      expect(eslintrc).toContain('"vue/no-deprecated-slot-attribute": "off"');
+    }, 300000);
   });
 
   it('should generate angular app and build', async () => {

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/GoabModal.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/GoabModal.vue__tmpl__
@@ -25,6 +25,7 @@ function onClose() {
 <template>
   <goa-modal :open="open" @_close="onClose">
     <slot />
+    <!-- `slot="actions"` is goa-modal's native web-component slot, not the Vue 2 slot syntax. The vue/no-deprecated-slot-attribute rule is turned off for this lib (see .eslintrc.json). -->
     <div v-if="slots.actions" slot="actions">
       <slot name="actions" />
     </div>

--- a/packages/nx-adsp/src/generators/vue-components/files/src/vue-components.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/vue-components.spec.ts__tmpl__
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import * as lib from './index';
+
+// Smoke test: the barrel resolves and every wrapper SFC compiles under the test
+// runner. It also gives the library a test target with real content, so
+// `nx test vue-components` doesn't fail on "no test files found".
+describe('vue-components', () => {
+  it('exports every GoA wrapper', () => {
+    for (const name of [
+      'GoabInput',
+      'GoabTextarea',
+      'GoabDropdown',
+      'GoabCheckbox',
+      'GoabRadioGroup',
+      'GoabButton',
+      'GoabModal',
+    ]) {
+      expect(lib[name as keyof typeof lib]).toBeTruthy();
+    }
+  });
+});

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -35,6 +35,11 @@ describe('Vue Components Generator', () => {
     // on "no test files found").
     expect(host.exists('libs/vue-components/src/vue-components.spec.ts')).toBeTruthy();
 
+    // GoabModal uses goa-modal's native `slot` attribute (web component, not the
+    // deprecated Vue 2 slot syntax) — the rule is turned off for this lib.
+    const eslintrc = host.read('libs/vue-components/.eslintrc.json').toString();
+    expect(eslintrc).toContain('"vue/no-deprecated-slot-attribute": "off"');
+
     // Ships agent direction for maintaining the (interim) lib, incl. a recipe
     // for wrapping additional components.
     expect(host.exists('libs/vue-components/AGENTS.md')).toBeTruthy();

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -1,6 +1,6 @@
 import { readProjectConfiguration, Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import generator, { vueComponentsImportPath } from './vue-components';
+import generator, { ensurePackageExports, vueComponentsImportPath } from './vue-components';
 
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
@@ -58,5 +58,33 @@ describe('Vue Components Generator', () => {
 
   it('derives the import path from the workspace scope', () => {
     expect(vueComponentsImportPath(host)).toMatch(/\/vue-components$/);
+  });
+
+  describe('ensurePackageExports (TS-solution resolution fix)', () => {
+    it('backfills exports/main/types when a lib package.json exists', () => {
+      host.write('libs/vue-components/package.json', JSON.stringify({ name: '@proj/vue-components' }));
+      ensurePackageExports(host, 'libs/vue-components');
+
+      const pkg = JSON.parse(host.read('libs/vue-components/package.json').toString());
+      expect(pkg.main).toBe('./src/index.ts');
+      expect(pkg.types).toBe('./src/index.ts');
+      expect(pkg.exports['.'].import).toBe('./src/index.ts');
+    });
+
+    it('does not clobber exports @nx/vue already wrote', () => {
+      host.write(
+        'libs/vue-components/package.json',
+        JSON.stringify({ name: '@proj/vue-components', exports: { '.': './dist/index.js' } })
+      );
+      ensurePackageExports(host, 'libs/vue-components');
+
+      const pkg = JSON.parse(host.read('libs/vue-components/package.json').toString());
+      expect(pkg.exports['.']).toBe('./dist/index.js');
+    });
+
+    it('is a no-op for a legacy lib with no package.json', () => {
+      ensurePackageExports(host, 'libs/vue-components');
+      expect(host.exists('libs/vue-components/package.json')).toBeFalsy();
+    });
   });
 });

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -31,6 +31,10 @@ describe('Vue Components Generator', () => {
     expect(index).toContain("export { default as GoabInput }");
     expect(index).toContain('@abgov/vue-components'); // interim marker
 
+    // Ships a spec so the vitest test target isn't empty (vitest exits non-zero
+    // on "no test files found").
+    expect(host.exists('libs/vue-components/src/vue-components.spec.ts')).toBeTruthy();
+
     // Ships agent direction for maintaining the (interim) lib, incl. a recipe
     // for wrapping additional components.
     expect(host.exists('libs/vue-components/AGENTS.md')).toBeTruthy();

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.ts
@@ -3,8 +3,40 @@ import {
   getWorkspaceLayout,
   readProjectConfiguration,
   Tree,
+  updateJson,
 } from '@nx/devkit';
 import * as path from 'path';
+
+interface EslintRc {
+  overrides?: { files?: string[]; rules?: Record<string, string> }[];
+}
+
+// Turns off vue/no-deprecated-slot-attribute for the lib. GoabModal projects into
+// goa-modal's native web-component slot via `slot="actions"` — legitimate custom-
+// element usage, not the deprecated Vue 2 component-slot syntax the rule targets.
+// The whole lib wraps web components, so it's scoped to the lib (consuming apps,
+// which use `<template #actions>`, are unaffected).
+function disableSlotAttributeRule(host: Tree, libRoot: string): void {
+  const eslintrc = `${libRoot}/.eslintrc.json`;
+  if (!host.exists(eslintrc)) {
+    console.warn(
+      `\n⚠  ${eslintrc} not found — could not disable vue/no-deprecated-slot-attribute.\n` +
+      `   GoabModal uses goa-modal's native \`slot\` attribute; if lint flags it, turn\n` +
+      `   that rule off for this library.\n`
+    );
+    return;
+  }
+  updateJson<EslintRc, EslintRc>(host, eslintrc, (json) => {
+    const overrides = (json.overrides ??= []);
+    let vueOverride = overrides.find((o) => o.files?.some((f) => f.includes('vue')));
+    if (!vueOverride) {
+      vueOverride = { files: ['*.vue'], rules: {} };
+      overrides.push(vueOverride);
+    }
+    (vueOverride.rules ??= {})['vue/no-deprecated-slot-attribute'] = 'off';
+    return json;
+  });
+}
 
 export const LIB_NAME = 'vue-components';
 
@@ -56,6 +88,7 @@ export default async function (host: Tree) {
       importPath: vueComponentsImportPath(host),
       skipFormat: true,
     });
+    disableSlotAttributeRule(host, libRoot);
   }
 
   generateFiles(host, path.join(__dirname, 'files'), libRoot, { tmpl: '' });

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.ts
@@ -11,6 +11,29 @@ interface EslintRc {
   overrides?: { files?: string[]; rules?: Record<string, string> }[];
 }
 
+// Backfills package.json module-resolution fields for the library. In a TS-solution
+// workspace @nx/vue's library resolves via package.json `exports`, but its
+// programmatic default (useProjectJson skips writing them here) leaves them off, so
+// the import path fails to resolve and the build breaks. Point them at the source
+// entry (the lib is non-buildable — consumers compile it). A no-op in legacy
+// path-alias workspaces (no lib package.json — resolution is via tsconfig paths),
+// and idempotent (never clobbers fields @nx/vue did write).
+export function ensurePackageExports(host: Tree, libRoot: string): void {
+  const pkgPath = `${libRoot}/package.json`;
+  if (!host.exists(pkgPath)) return;
+  const SRC = './src/index.ts';
+  updateJson<Record<string, unknown>, Record<string, unknown>>(host, pkgPath, (pkg) => {
+    pkg.main ??= SRC;
+    pkg.module ??= SRC;
+    pkg.types ??= SRC;
+    pkg.exports ??= {
+      './package.json': './package.json',
+      '.': { types: SRC, import: SRC, default: SRC },
+    };
+    return pkg;
+  });
+}
+
 // Turns off vue/no-deprecated-slot-attribute for the lib. GoabModal projects into
 // goa-modal's native web-component slot via `slot="actions"` — legitimate custom-
 // element usage, not the deprecated Vue 2 component-slot syntax the rule targets.
@@ -89,6 +112,7 @@ export default async function (host: Tree) {
       skipFormat: true,
     });
     disableSlotAttributeRule(host, libRoot);
+    ensurePackageExports(host, libRoot);
   }
 
   generateFiles(host, path.join(__dirname, 'files'), libRoot, { tmpl: '' });


### PR DESCRIPTION
Follow-up to #314. Three out-of-the-box failures a freshly generated `vue-components` lib hits — all invisible to the generator's tree-content unit tests, found by actually running the generated project's targets (build / lint / test).

## 1. `@<scope>/vue-components` didn't resolve → production build broke

In a TS-solution workspace the library resolves via package.json `exports`. `@nx/vue`'s `libraryGenerator`, called **programmatically**, leaves `useProjectJson` at its default and skips writing `exports`/`main`/`types` — so the import path fails to resolve and the build breaks. (Confirmed: a direct `nx g @nx/vue:library` wires it correctly; only the programmatic call path is affected.) The generator now backfills those fields pointing at the source entry (the lib is non-buildable, so consumers compile it). Guarded on the lib `package.json` existing — legacy path-alias workspaces have none and resolve via tsconfig paths — and idempotent (never clobbers what `@nx/vue` wrote).

## 2. `nx test vue-components` failed on "no test files found"

`@nx/vue:library` with `component: false` creates a vitest target + config but no spec files, and vitest exits non-zero when nothing matches. The generator now ships `src/vue-components.spec.ts` — a barrel smoke test asserting all 7 wrappers export and compile under the test runner.

## 3. `nx lint` flagged `GoabModal`, and `--fix` actively broke it

`GoabModal` projects footer buttons into `goa-modal`'s **native web-component slot** via `slot="actions"`. The `vue3-essential` rule `vue/no-deprecated-slot-attribute` flags that as deprecated Vue 2 syntax, and its `--fix` rewrites the working `<div slot="actions">` into `<template #actions>` on a custom element — which crashes `@vue/compiler-core` codegen in the build. Verified the usual escapes don't work (inline `eslint-disable` comments aren't honored in vue templates; `:slot` still trips it; the rule's `ignore` only matches the slot-bearing `div`). So the generator turns the rule off in the lib's own `.eslintrc.json` — which both clears the false positive and stops `--fix` from re-breaking it. Scoped to the lib (consuming apps use `<template #actions>` on the `GoabModal` *component*, which is valid).

All three are guarded by generator-spec assertions. Verified in a real generated workspace. nx-adsp 63 tests + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)