### PR TITLE
feat(nx-agent): add secret scanning and gitignore baseline to init

### DIFF
--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -41,6 +41,34 @@ Currently sets up:
    This section is centrally maintained: re-running `init` refreshes its wording in place rather
    than leaving it frozen at first-generation content.
 
+3. **A secret-scanning hook block**, appended to the same `.husky/pre-commit`, scanning staged
+   files for committed credentials with [secretlint](https://github.com/secretlint/secretlint):
+
+   ```sh
+   secretlint_files=$(git diff --cached --name-only --diff-filter=ACMR)
+   if [ -n "$secretlint_files" ]; then
+     echo "$secretlint_files" | xargs npx secretlint || exit 1
+   fi
+   ```
+
+   Adds `secretlint` and `@secretlint/secretlint-rule-preset-recommend` as devDependencies, and a
+   `.secretlintrc.json` if one doesn't already exist (never overwritten once created — rules are
+   the kind of thing a team tunes, unlike the AGENTS.md guidance above).
+
+4. **Baseline `.gitignore` entries** for common local-credential filenames — `.env.local`,
+   `.env.*.local`, `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `credentials.json` — added only if
+   missing, appended alongside whatever's already there. Deliberately excludes bare `.env`: it's
+   dual-purpose (plain workspace config as well as secrets), so a blanket rule would be a false
+   positive on legitimate use. This is preventive rather than detective — once a pattern is in
+   `.gitignore`, git itself refuses to stage a matching file via `git add .`/`git add -A`, so no
+   separate pre-commit check is needed on top of it. It does nothing for a file that was already
+   tracked before `init` ran; gitignore never retroactively untracks anything.
+
+5. **A second `AGENTS.md` guidance section** naming the specific risk this addresses for a coding
+   agent — live session secrets (a `gh auth token`, a `.env` value, a test API key) that an agent
+   may paste literally where a human wouldn't as instinctively catch themselves — and steering it
+   toward environment-variable references instead.
+
 ### Options
 
 | Option | Default | Description |

--- a/packages/nx-agent/src/generators/init/init.spec.ts
+++ b/packages/nx-agent/src/generators/init/init.spec.ts
@@ -107,4 +107,99 @@ describe('nx-agent init generator', () => {
     expect(agentsMd).toContain('Some existing stack-specific guidance.')
     expect(agentsMd).toContain('<!-- nx-agent:managed:check-hook -->')
   })
+
+  it('exits the check-hook block on failure even once another block follows it', async () => {
+    await generator(host, {})
+
+    const preCommit = host.read('.husky/pre-commit').toString()
+    expect(preCommit).toContain(
+      'git diff --cached --name-only --diff-filter=ACMR | npx nx affected -t lint,test,build --stdin || exit 1'
+    )
+  })
+
+  it('adds secretlint, its config, the secret-scan hook block, and the AGENTS.md section from scratch', async () => {
+    await generator(host, {})
+
+    const pkg = readJson(host, 'package.json')
+    expect(pkg.devDependencies.secretlint).toBeDefined()
+    expect(pkg.devDependencies['@secretlint/secretlint-rule-preset-recommend']).toBeDefined()
+
+    const config = readJson(host, '.secretlintrc.json')
+    expect(config.rules).toEqual([{ id: '@secretlint/secretlint-rule-preset-recommend' }])
+
+    const preCommit = host.read('.husky/pre-commit').toString()
+    expect(preCommit).toContain('git diff --cached --name-only --diff-filter=ACMR')
+    expect(preCommit).toContain('xargs npx secretlint || exit 1')
+
+    const agentsMd = host.read('AGENTS.md').toString()
+    expect(agentsMd).toContain('<!-- nx-agent:managed:secret-scan -->')
+    expect(agentsMd).toContain('gh auth token')
+  })
+
+  it('does not overwrite an existing .secretlintrc.json', async () => {
+    host.write('.secretlintrc.json', JSON.stringify({ rules: [{ id: 'custom-rule' }] }))
+
+    await generator(host, {})
+
+    const config = readJson(host, '.secretlintrc.json')
+    expect(config.rules).toEqual([{ id: 'custom-rule' }])
+  })
+
+  it('keeps both hook blocks and both AGENTS.md sections independent and non-duplicated on a second run', async () => {
+    await generator(host, {})
+    await generator(host, {})
+
+    const preCommit = host.read('.husky/pre-commit').toString()
+    expect(preCommit.split('npx nx affected').length - 1).toBe(1)
+    expect(preCommit.split('npx secretlint').length - 1).toBe(1)
+
+    const agentsMd = host.read('AGENTS.md').toString()
+    expect(agentsMd.split('<!-- nx-agent:managed:check-hook -->').length - 1).toBe(1)
+    expect(agentsMd.split('<!-- nx-agent:managed:secret-scan -->').length - 1).toBe(1)
+  })
+
+  it('preserves an unrelated pre-commit line alongside both generated blocks', async () => {
+    host.write('.husky/pre-commit', 'npx lint-staged\n')
+
+    await generator(host, {})
+
+    const preCommit = host.read('.husky/pre-commit').toString()
+    expect(preCommit).toContain('npx lint-staged')
+    expect(preCommit).toContain('npx nx affected')
+    expect(preCommit).toContain('npx secretlint')
+  })
+
+  it('creates .gitignore with the baseline credential patterns when missing', async () => {
+    await generator(host, {})
+
+    const gitignore = host.read('.gitignore').toString()
+    expect(gitignore).toContain('.env.local')
+    expect(gitignore).toContain('*.pem')
+    expect(gitignore).toContain('id_rsa')
+    expect(gitignore).toContain('credentials.json')
+    // deliberately not a false positive on a bare .env, which is dual-purpose
+    expect(gitignore).not.toMatch(/^\.env$/m)
+  })
+
+  it('appends only the missing patterns to an existing .gitignore, preserving its content', async () => {
+    host.write('.gitignore', '/dist\n/node_modules\n*.pem\n')
+
+    await generator(host, {})
+
+    const gitignore = host.read('.gitignore').toString()
+    expect(gitignore).toContain('/dist')
+    expect(gitignore).toContain('/node_modules')
+    expect(gitignore.split('*.pem').length - 1).toBe(1)
+    expect(gitignore).toContain('.env.local')
+    expect(gitignore).toContain('id_rsa')
+  })
+
+  it('does not duplicate gitignore entries on a second run', async () => {
+    await generator(host, {})
+    await generator(host, {})
+
+    const gitignore = host.read('.gitignore').toString()
+    expect(gitignore.split('.env.local').length - 1).toBe(1)
+    expect(gitignore.split('id_rsa').length - 1).toBe(1)
+  })
 })

--- a/packages/nx-agent/src/generators/init/init.ts
+++ b/packages/nx-agent/src/generators/init/init.ts
@@ -5,6 +5,7 @@ import {
   installPackagesTask,
   logger,
   updateJson,
+  writeJson,
 } from '@nx/devkit'
 import { mergeManagedSection } from '../../utils/agents-md'
 import { NormalizedSchema, Schema } from './schema'
@@ -12,8 +13,24 @@ import { NormalizedSchema, Schema } from './schema'
 const DEFAULT_TARGETS = ['lint', 'test', 'build']
 const DEFAULT_BASE = 'main'
 const HUSKY_VERSION = '^9.0.0'
+const SECRETLINT_VERSION = '^13.0.0'
 const PRE_COMMIT_PATH = '.husky/pre-commit'
-const CHECK_MARKER = 'npx nx affected'
+const SECRETLINT_CONFIG_PATH = '.secretlintrc.json'
+const AFFECTED_CHECK_MARKER = 'npx nx affected'
+const SECRETLINT_MARKER = 'npx secretlint'
+const GITIGNORE_PATH = '.gitignore'
+// Deliberately excludes bare `.env` — it's dual-purpose (plain workspace
+// config as well as secrets; nx-tools' own root .env is a real example of
+// the former), so a blanket rule would be a false positive on legitimate use.
+const CREDENTIAL_GITIGNORE_PATTERNS = [
+  '.env.local',
+  '.env.*.local',
+  '*.pem',
+  '*.key',
+  'id_rsa',
+  'id_ed25519',
+  'credentials.json',
+]
 
 function normalizeOptions(options: Schema): NormalizedSchema {
   return {
@@ -42,21 +59,29 @@ function addPrepareScript(host: Tree): void {
   })
 }
 
-function addPreCommitHook(host: Tree, targets: string[]): void {
-  const checkLine = `git diff --cached --name-only --diff-filter=ACMR | npx nx affected -t ${targets.join(',')} --stdin`
-
+// Appends an independent, idempotent block to .husky/pre-commit. Each block
+// must end its own failure path (e.g. `|| exit 1`) — blocks run sequentially
+// and are not aware of each other's exit status, so each is responsible for
+// stopping the commit on its own failure rather than relying on a combined
+// exit-code scheme that would need rewriting every time a block is added.
+function appendHookBlock(host: Tree, marker: string, block: string): void {
   if (!host.exists(PRE_COMMIT_PATH)) {
-    host.write(PRE_COMMIT_PATH, `${checkLine}\n`)
+    host.write(PRE_COMMIT_PATH, `${block}\n`)
     return
   }
 
   const existing = host.read(PRE_COMMIT_PATH).toString()
-  if (existing.includes(CHECK_MARKER)) {
+  if (existing.includes(marker)) {
     return
   }
 
-  const separator = existing.endsWith('\n') ? '' : '\n'
-  host.write(PRE_COMMIT_PATH, `${existing}${separator}${checkLine}\n`)
+  const trimmed = existing.replace(/\n+$/, '')
+  host.write(PRE_COMMIT_PATH, `${trimmed}\n\n${block}\n`)
+}
+
+function addPreCommitHook(host: Tree, targets: string[]): void {
+  const checkLine = `git diff --cached --name-only --diff-filter=ACMR | npx nx affected -t ${targets.join(',')} --stdin || exit 1`
+  appendHookBlock(host, AFFECTED_CHECK_MARKER, checkLine)
 }
 
 function addAgentsMdGuidance(host: Tree, targets: string[], base: string): void {
@@ -84,10 +109,96 @@ function applyCheckHookStep(host: Tree, options: NormalizedSchema): void {
   addAgentsMdGuidance(host, options.targets, options.base)
 }
 
+function addSecretlintDependencies(host: Tree): void {
+  addDependenciesToPackageJson(
+    host,
+    {},
+    {
+      secretlint: SECRETLINT_VERSION,
+      '@secretlint/secretlint-rule-preset-recommend': SECRETLINT_VERSION,
+    },
+    undefined,
+    true
+  )
+}
+
+function addSecretlintConfig(host: Tree): void {
+  // Team-owned once created — secretlint rules are the kind of thing a team
+  // tunes (ignore patterns, extra rules), unlike the AGENTS.md guidance
+  // below. Never overwritten on re-run, even if our default content drifts.
+  if (host.exists(SECRETLINT_CONFIG_PATH)) {
+    return
+  }
+  writeJson(host, SECRETLINT_CONFIG_PATH, {
+    rules: [{ id: '@secretlint/secretlint-rule-preset-recommend' }],
+  })
+}
+
+function addSecretScanHook(host: Tree): void {
+  // secretlint scans the whole cwd recursively when given zero file
+  // arguments — it does not no-op — so an empty staged-file list must be
+  // guarded explicitly rather than left to xargs's empty-stdin behavior.
+  const block = `secretlint_files=$(git diff --cached --name-only --diff-filter=ACMR)
+if [ -n "$secretlint_files" ]; then
+  echo "$secretlint_files" | xargs npx secretlint || exit 1
+fi`
+  appendHookBlock(host, SECRETLINT_MARKER, block)
+}
+
+function addSecretScanGuidance(host: Tree): void {
+  const content = `## Working with a coding agent — secret scanning
+
+A pre-commit hook scans your staged changes for committed credentials (API keys, tokens, private
+keys) before every commit. You may have real secrets on hand mid-session — a token from
+\`gh auth token\`, a value read from \`.env\`, a key provided for testing — that you might paste
+literally if asked to "add a working example," in a way a human wouldn't as instinctively catch in
+themselves. Reference an environment variable or a secrets manager instead — never a literal
+value, even in a comment or test fixture. If the hook blocks a commit, remove the value and rotate
+it if it was ever pushed anywhere; don't just delete the line and recommit.
+
+Local credential files (\`.env.local\`, \`*.pem\`, \`id_rsa\`, etc.) are gitignored by default, so
+they can't be staged accidentally — if you create a new kind of local secret file, add its pattern
+to \`.gitignore\` too rather than relying on the scan above to catch it after the fact.`
+
+  mergeManagedSection(host, 'secret-scan', content)
+}
+
+// Preventive, not detective: once these patterns are in .gitignore, git
+// itself refuses to stage a matching file via `git add .`/`git add -A` (a
+// deliberate `git add -f` would be needed to override it) — so there's no
+// separate pre-commit check needed on top of this for files that match.
+// Doesn't help a file that was already tracked before this ran; gitignore
+// never retroactively untracks anything.
+function ensureGitignoreEntries(host: Tree): void {
+  if (!host.exists(GITIGNORE_PATH)) {
+    host.write(GITIGNORE_PATH, `${CREDENTIAL_GITIGNORE_PATTERNS.join('\n')}\n`)
+    return
+  }
+
+  const existing = host.read(GITIGNORE_PATH).toString()
+  const existingLines = new Set(existing.split('\n').map((line) => line.trim()))
+  const missing = CREDENTIAL_GITIGNORE_PATTERNS.filter((pattern) => !existingLines.has(pattern))
+  if (missing.length === 0) {
+    return
+  }
+
+  const trimmed = existing.replace(/\n+$/, '')
+  host.write(GITIGNORE_PATH, `${trimmed}\n\n${missing.join('\n')}\n`)
+}
+
+function applySecretScanStep(host: Tree): void {
+  addSecretlintDependencies(host)
+  addSecretlintConfig(host)
+  addSecretScanHook(host)
+  ensureGitignoreEntries(host)
+  addSecretScanGuidance(host)
+}
+
 export default async function (host: Tree, rawOptions: Schema) {
   const options = normalizeOptions(rawOptions)
 
   applyCheckHookStep(host, options)
+  applySecretScanStep(host)
 
   await formatFiles(host)
 


### PR DESCRIPTION
## Summary
- Extends `@abgov/nx-agent:init` with a second, independent pre-commit hook block that scans staged files for committed credentials via [secretlint](https://github.com/secretlint/secretlint) (`secretlint` + `@secretlint/secretlint-rule-preset-recommend`, ^13.0.0), writing `.secretlintrc.json` once and never touching it again (team-owned, same as any rules config).
- Adds baseline `.gitignore` entries for common local-credential filenames (`.env.local`, `.env.*.local`, `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `credentials.json`) — added only if missing, deliberately excluding bare `.env` since it's dual-purpose (this repo's own root `.env` is a real example of legitimate, non-secret use). This is preventive rather than detective: once a pattern is gitignored, `git add`/`git add -A` refuses to stage a matching file on its own, so no separate pre-commit check is needed on top of it.
- Generalizes the `.husky/pre-commit`-editing logic (`appendHookBlock`) so each capability's block is independently idempotent, rather than one-off string logic per capability.
- **Fixes a latent gap in the already-merged check-hook block**: it had no explicit exit-on-failure, which only worked by accident as the sole/last line in the file — appending a second block after it would have silently swallowed an `nx affected` failure. Existing installs pick this up on their next `init` re-run.
- Adds a second `AGENTS.md` guidance section naming the specific risk for a coding agent: live session secrets (`gh auth token`, a `.env` value, a test API key) it may paste literally in a way a human wouldn't as instinctively catch.

## Test plan
- [x] `nx lint nx-agent`, `nx test nx-agent` (20/20 passing), `nx build nx-agent` all pass
- [x] Verified secretlint's own package names/config/CLI behavior against the npm registry and a real install before wiring it in, including a real gotcha: secretlint scans the whole cwd recursively when given zero file arguments (not a no-op), so the hook explicitly guards on an empty staged-file list rather than relying on `xargs`'s empty-stdin behavior
- [x] Ran the real generated secret-scan block against a real Husky install: a correctly-formatted fake GitHub token genuinely blocks `git commit` (`husky - pre-commit script failed`), the file stays uncommitted, and a subsequent clean commit succeeds
- [x] Confirmed empirically (not just asserted) that `git add` refuses a file matching a gitignored pattern (`hint: Use -f if you really want to add them`), validating the gitignore-only design with no extra check needed
- [x] Checked this repo's own state before design: root `.gitignore` had zero credential-pattern entries; only one of `nx-adsp`'s generators (`express-service`) had any gitignore-writing logic at all, and it's narrower than this baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)