### PR TITLE
feat(nx-agent): add domain-term generator

### DIFF
--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -86,3 +86,52 @@ Currently sets up:
 ```bash
 npx nx g @abgov/nx-agent:init --targets=lint,test --base=develop
 ```
+
+## `domain-term`
+
+Adds one domain term — the ubiquitous language `init`'s guidance asks the agent to use, but gives
+it nowhere to check or record. Unlike `init`, this is repeatable — run it once per term, whenever
+one needs adding, not once per workspace:
+
+```bash
+npx nx g @abgov/nx-agent:domain-term Case
+```
+
+Creates `project-docs/domain-terms/case.md`:
+
+```markdown
+---
+term: Case
+aliases: []
+not_confused_with: []
+---
+
+<!-- Definition: describe this term in the domain's own language. -->
+```
+
+- `term` — the canonical name, matching the filename.
+- `aliases` — other words that mean the same thing.
+- `not_confused_with` — similar-sounding terms this one is deliberately distinct from, and why.
+
+One file per term rather than a single flat glossary, so frontmatter (a per-file construct in
+every tool that uses the term) is meaningful, and so listing the folder — cheap, just filenames —
+is enough to check the existing vocabulary before coining a new name.
+
+Also bootstraps `project-docs/domain-terms/README.md` on first use, explaining the convention to
+whoever (human or agent) opens the folder next. That file has no value on its own — it exists only
+to explain the convention for the term about to be added — so there's no separate "set up the
+glossary" generator; `domain-term` composes it as an internal step.
+
+### Options
+
+| Option | Default | Description |
+|---|---|---|
+| `term` | — (required, positional) | The canonical domain term, as domain experts use it |
+| `project` | workspace root | Scope the term to a specific project's `project-docs/domain-terms/` instead — use when a bounded context spans a domain library and its consuming apps |
+
+```bash
+npx nx g @abgov/nx-agent:domain-term Case --project=domain-lib
+```
+
+Re-adding a term that already exists throws rather than silently overwriting or duplicating it —
+edit the file directly instead.

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -7,6 +7,11 @@
       "factory": "./src/generators/init/init",
       "schema": "./src/generators/init/schema.json",
       "description": "Sets up recommended AI-agent development tooling for this workspace (currently: a pre-commit affected-check hook and AGENTS.md guidance)."
+    },
+    "domain-term": {
+      "factory": "./src/generators/domain-term/domain-term",
+      "schema": "./src/generators/domain-term/schema.json",
+      "description": "Adds one domain term under project-docs/domain-terms/, with structured frontmatter and a free-text definition."
     }
   }
 }

--- a/packages/nx-agent/src/generators/domain-term/README.template.md
+++ b/packages/nx-agent/src/generators/domain-term/README.template.md
@@ -1,0 +1,31 @@
+# Domain terms
+
+The ubiquitous language for this project — domain terms as the business actually uses them, not
+translated into technical jargon.{{SHARED_CONTEXT_NOTE}} One file per term, so each stays
+independently reviewable, and so listing this folder (cheap — just filenames) is enough to check
+the existing vocabulary before coining a new name; only open a file when you need its full
+definition.
+
+Add a term with `nx g @abgov/nx-agent:domain-term <name>` — don't hand-author files here, so the
+frontmatter shape stays consistent. Each file:
+
+    ---
+    term: Case
+    aliases: []
+    not_confused_with:
+      - term: File
+        reason: File is the underlying record storage; Case is the workflow around it.
+    ---
+
+    A single citizen-facing request being tracked from intake through resolution.
+
+- `term` — the canonical name, matching the filename.
+- `aliases` — other words that mean the *same* thing; recording them here heads off a synonym
+  drifting into use unchecked elsewhere.
+- `not_confused_with` — similar-sounding terms this one is deliberately distinct from, and why.
+  Leave it empty if there's no real ambiguity to guard against.
+
+The body is free text — the actual definition, in domain language, with as much nuance as the
+term needs. Keep it current: when a term gets clarified (with a domain expert, in a requirements
+doc, in conversation), update its file rather than letting the answer live only in one commit
+message or one person's memory.

--- a/packages/nx-agent/src/generators/domain-term/domain-term.spec.ts
+++ b/packages/nx-agent/src/generators/domain-term/domain-term.spec.ts
@@ -1,0 +1,93 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
+import { Tree, addProjectConfiguration } from '@nx/devkit'
+import generator from './domain-term'
+
+describe('nx-agent domain-term generator', () => {
+  let host: Tree
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' })
+  })
+
+  it('creates the term file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { term: 'Case' })
+
+    const content = host.read('project-docs/domain-terms/case.md').toString()
+    expect(content).toContain('term: Case')
+    expect(content).toContain('aliases: []')
+    expect(content).toContain('not_confused_with: []')
+  })
+
+  it('derives the filename slug from a multi-word term', async () => {
+    await generator(host, { term: 'Service Provider' })
+
+    expect(host.exists('project-docs/domain-terms/service-provider.md')).toBe(true)
+  })
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { term: 'Case' })
+
+    const readme = host.read('project-docs/domain-terms/README.md').toString()
+    expect(readme).toContain('# Domain terms')
+    expect(readme).toContain('nx g @abgov/nx-agent:domain-term')
+  })
+
+  it('does not duplicate or alter the README when a second, different term is added', async () => {
+    await generator(host, { term: 'Case' })
+    const readmeBefore = host.read('project-docs/domain-terms/README.md').toString()
+
+    await generator(host, { term: 'File' })
+
+    const readmeAfter = host.read('project-docs/domain-terms/README.md').toString()
+    expect(readmeAfter).toBe(readmeBefore)
+    expect(host.exists('project-docs/domain-terms/case.md')).toBe(true)
+    expect(host.exists('project-docs/domain-terms/file.md')).toBe(true)
+  })
+
+  it('throws and makes no changes when the term file already exists', async () => {
+    await generator(host, { term: 'Case' })
+    const before = host.read('project-docs/domain-terms/case.md').toString()
+
+    await expect(generator(host, { term: 'Case' })).rejects.toThrow(/already exists/)
+
+    expect(host.read('project-docs/domain-terms/case.md').toString()).toBe(before)
+  })
+
+  it('scopes the term file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    })
+
+    await generator(host, { term: 'Case', project: 'domain-lib' })
+
+    expect(host.exists('libs/domain-lib/project-docs/domain-terms/case.md')).toBe(true)
+    expect(host.exists('project-docs/domain-terms/case.md')).toBe(false)
+  })
+
+  it('adds the shared-context note to the README only when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    })
+
+    await generator(host, { term: 'Case', project: 'domain-lib' })
+
+    const scopedReadme = host.read('libs/domain-lib/project-docs/domain-terms/README.md').toString()
+    expect(scopedReadme).toContain('shared by every project that depends on this library')
+
+    await generator(host, { term: 'File' })
+
+    const rootReadme = host.read('project-docs/domain-terms/README.md').toString()
+    expect(rootReadme).not.toContain('shared by every project that depends on this library')
+  })
+
+  it('instructs listing the directory before coining a new term', async () => {
+    await generator(host, { term: 'Case' })
+
+    const readme = host.read('project-docs/domain-terms/README.md').toString()
+    expect(readme).toContain('listing this folder')
+  })
+})

--- a/packages/nx-agent/src/generators/domain-term/domain-term.ts
+++ b/packages/nx-agent/src/generators/domain-term/domain-term.ts
@@ -1,0 +1,63 @@
+import { Tree, formatFiles, joinPathFragments, names, readProjectConfiguration } from '@nx/devkit'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { Schema } from './schema'
+
+const DOMAIN_TERMS_SUBDIR = 'project-docs/domain-terms'
+const README_TEMPLATE_PATH = join(__dirname, 'README.template.md')
+
+function resolveTargetRoot(host: Tree, project?: string): string {
+  return project ? readProjectConfiguration(host, project).root : '.'
+}
+
+// The container has no standalone value on its own (its README only exists to
+// explain the convention for the term about to be added), so this is an
+// internal step composed by domain-term rather than its own generator.
+function ensureContainerReadme(host: Tree, containerDir: string, scoped: boolean): void {
+  const readmePath = joinPathFragments(containerDir, 'README.md')
+  if (host.exists(readmePath)) {
+    return
+  }
+  const sharedNote = scoped
+    ? ' This is shared by every project that depends on this library — keep the vocabulary consistent across the service and its frontends rather than letting each drift toward its own terms.'
+    : ''
+  const content = readFileSync(README_TEMPLATE_PATH, 'utf-8')
+    .split('{{SHARED_CONTEXT_NOTE}}')
+    .join(sharedNote)
+  host.write(readmePath, content)
+}
+
+export default async function (host: Tree, options: Schema) {
+  const targetRoot = resolveTargetRoot(host, options.project)
+  const containerDir = joinPathFragments(targetRoot, DOMAIN_TERMS_SUBDIR)
+  const slug = names(options.term).fileName
+  const termPath = joinPathFragments(containerDir, `${slug}.md`)
+
+  // A repeat/typo'd invocation should fail loudly rather than silently
+  // clobbering or duplicating a term — unlike the "never overwrite, skip
+  // silently" posture used for one-shot config like .secretlintrc.json,
+  // re-adding an existing term is almost always a mistake, not an
+  // idempotent re-run. Checked before ensureContainerReadme so a failing
+  // run has no side effects.
+  if (host.exists(termPath)) {
+    throw new Error(
+      `[nx-agent] ${termPath} already exists — edit it directly rather than regenerating it.`
+    )
+  }
+
+  ensureContainerReadme(host, containerDir, !!options.project)
+
+  const content = [
+    '---',
+    `term: ${options.term}`,
+    'aliases: []',
+    'not_confused_with: []',
+    '---',
+    '',
+    "<!-- Definition: describe this term in the domain's own language. -->",
+    '',
+  ].join('\n')
+  host.write(termPath, content)
+
+  await formatFiles(host)
+}

--- a/packages/nx-agent/src/generators/domain-term/schema.d.ts
+++ b/packages/nx-agent/src/generators/domain-term/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  term: string
+  project?: string
+}

--- a/packages/nx-agent/src/generators/domain-term/schema.json
+++ b/packages/nx-agent/src/generators/domain-term/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentDomainTerm",
+  "title": "Add a domain term",
+  "description": "Creates one file for a domain term under project-docs/domain-terms/, with structured frontmatter (aliases, disambiguation) and a free-text definition body. Bootstraps the domain-terms/README.md convention doc on first use.",
+  "type": "object",
+  "properties": {
+    "term": {
+      "type": "string",
+      "description": "The canonical domain term, as domain experts use it (e.g. \"Case\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What is the domain term?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this term to a specific project's project-docs/domain-terms/ instead of the workspace root — use when a bounded context spans a domain library and its consuming apps."
+    }
+  },
+  "required": ["term"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/init/guidance/code-quality/reuse-before-reinventing.md
+++ b/packages/nx-agent/src/generators/init/guidance/code-quality/reuse-before-reinventing.md
@@ -2,4 +2,7 @@
 well-established library — before writing it yourself. Bias toward a proven library over local
 code even more strongly for security-sensitive logic (cryptography, auth, encoding, randomness):
 a plausible-looking custom implementation is exactly where testing is least likely to surface a
-subtle flaw.
+subtle flaw. The same applies to repeated artifacts, not just logic — use an existing generator
+(e.g. `nx g @abgov/nx-agent:domain-term`) instead of hand-authoring a file it would create; if a
+genuinely new, repeated kind of artifact is needed that nothing generates yet, add a
+workspace-local Nx generator rather than hand-authoring instances one at a time.

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-conventions.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-conventions.md
@@ -1,4 +1,7 @@
 **Project conventions.** Before writing something new, check how similar things are already done
 in this codebase and match that pattern, rather than introducing an equally-valid but different
 one. A codebase with five ways of doing the same thing is harder to maintain than one with a
-single, slightly-imperfect way applied everywhere.
+single, slightly-imperfect way applied everywhere. This applies to generated documentation too —
+if a `project-docs/` folder exists, it's the convention home for that kind of artifact; match its
+established shape (one file per instance, YAML frontmatter for structured fields, free text for
+the rest) even when adding a kind of artifact it doesn't have a subfolder for yet.

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/ubiquitous-language.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/ubiquitous-language.md
@@ -2,6 +2,8 @@
 experts describe them, not translated into generic technical terms (`Manager`, `Handler`,
 `data`). Stay consistent with names the codebase already uses rather than inventing a synonym; if
 the actual domain term is unknown, that's a stop-and-ask signal, not something to guess at — a
-guessed term tends to propagate and compound the confusion. Prefer domain-oriented module
-structure for new code where the layout allows it, but don't retrofit existing structure to
-satisfy this.
+guessed term tends to propagate and compound the confusion. If this workspace has a
+`project-docs/domain-terms/` folder, check it before naming something new, and add a missing term
+with `nx g @abgov/nx-agent:domain-term <name>` rather than letting the answer live only in one
+commit message or one person's memory. Prefer domain-oriented module structure for new code where
+the layout allows it, but don't retrofit existing structure to satisfy this.


### PR DESCRIPTION
## Summary

- Adds `@abgov/nx-agent:domain-term`, which creates one file per domain term under `project-docs/domain-terms/<slug>.md` — YAML frontmatter for structured fields (`term`, `aliases`, `not_confused_with`), free text for the definition body.
- Bootstraps `project-docs/domain-terms/README.md` on first use (an internal step, not its own generator — the README has no standalone value outside "explain the convention for the term about to be added"). Supports `--project` to scope a term to a specific library's bounded context, adding a shared-context note to the README in that case.
- Re-adding an existing term throws rather than silently overwriting/duplicating it.
- Points three existing AGENTS.md guidance items at the new mechanism, so it's actually adopted rather than rediscovered by hand each time:
  - **Ubiquitous language** — check `project-docs/domain-terms/` before naming something new.
  - **Project conventions** — generated documentation should live in and match the shape of `project-docs/`, even for artifact types it doesn't have a subfolder for yet.
  - **Reuse before reinventing** — use an existing generator instead of hand-authoring a file it would create; add a workspace-local Nx generator for a genuinely new repeated artifact type rather than hand-authoring instances one at a time.

One generator, not two — considered and dropped a separate init-only "set up the glossary" generator; unlike `@nx/react:init`, the container has no value except as a precursor to adding a term, so `domain-term` composes that step internally.

## Test plan

- [x] `nx lint nx-agent` / `nx test nx-agent` (35/35, including 8 new `domain-term.spec.ts` tests) / `nx build nx-agent` all pass
- [x] Verified end-to-end in a throwaway `create-nx-workspace` copy with the built package installed: first term creates the README + term file; re-adding the same term throws without side effects; adding a second term doesn't touch the first term or the README; `--project=<lib>` scopes output under the library root and adds the shared-context note; re-running `init` picks up the updated "Ubiquitous language" guidance text