### PR TITLE
feat(nx-agent): add three guidance follow-ups from harness gap analysis

### DIFF
--- a/packages/nx-agent/src/generators/init/guidance/code-quality/reuse-before-reinventing.md
+++ b/packages/nx-agent/src/generators/init/guidance/code-quality/reuse-before-reinventing.md
@@ -5,4 +5,7 @@ a plausible-looking custom implementation is exactly where testing is least like
 subtle flaw. The same applies to repeated artifacts, not just logic — use an existing generator
 (e.g. `nx g @abgov/nx-agent:domain-term`) instead of hand-authoring a file it would create; if a
 genuinely new, repeated kind of artifact is needed that nothing generates yet, add a
-workspace-local Nx generator rather than hand-authoring instances one at a time.
+workspace-local Nx generator rather than hand-authoring instances one at a time. The same goes for
+a recurring defect worth permanently guarding against — add a workspace ESLint rule
+(`nx g @nx/eslint:workspace-rule`, proven with `RuleTester` before trusting it) rather than a
+bespoke check; the pre-commit hook's lint step already enforces it for free.

--- a/packages/nx-agent/src/generators/init/guidance/code-quality/todo-transparency.md
+++ b/packages/nx-agent/src/generators/init/guidance/code-quality/todo-transparency.md
@@ -1,2 +1,3 @@
 **TODO transparency.** If a stub genuinely has to be left behind, say so explicitly rather than
-committing it silently.
+committing it silently. The same goes for a finding you're deliberately not fixing — mark it
+explicitly (e.g. `RISK_ACCEPTED: <why>`) rather than silently suppressing it.

--- a/packages/nx-agent/src/generators/init/guidance/dependency-hygiene/choosing-a-dependency.md
+++ b/packages/nx-agent/src/generators/init/guidance/dependency-hygiene/choosing-a-dependency.md
@@ -5,4 +5,7 @@ confirm the package exists and check its current version — training data has a
 plausible-sounding name isn't a guarantee it's real. An actively-maintained library also likely
 has capabilities and fixes a stale one doesn't. Check the license too: prefer permissive ones
 (`MIT`, `Apache-2.0`, `BSD`, `ISC`); treat a missing license or a copyleft one (`GPL`, `AGPL`,
-`LGPL`) as a stop-and-ask signal — these carry legal obligations, not engineering ones.
+`LGPL`) as a stop-and-ask signal — these carry legal obligations, not engineering ones. Don't
+scroll past what `npm install` reports, either — it audits by default, and a high-severity or
+unfixable finding is the same stop-and-ask signal (only for what's being added now, not drift in
+dependencies already installed).


### PR DESCRIPTION
## Summary

Follow-up to #328. Comparing nx-agent's guidance against two real AI-coding-agent harnesses (Keystone, goa-software-factory) surfaced a few gaps — each one turned out to collapse into an existing mechanism rather than needing new plumbing, so this is guidance-only, no code changes:

- **Choosing a dependency**: `npm install` already runs an audit by default and prints a vulnerability count — confirmed empirically (installed a known-vulnerable package, got the warning unprompted). The gap wasn't a missing check, it was an easy-to-miss signal. Adds: don't scroll past it; treat a high-severity/unfixable finding on something you're adding as the same stop-and-ask signal as a missing/copyleft license. Explicitly scoped to new additions, not drift in already-installed dependencies (that's Dependabot's job, not this).
- **Reuse before reinventing**: a recurring, mechanically-checkable defect (e.g. "no console.log in prod code") should become a workspace ESLint rule via the existing `nx g @nx/eslint:workspace-rule`, proven with `RuleTester` before trusting it — not a bespoke pattern-matching mechanism. Already enforced for free by the pre-commit hook's existing lint step.
- **TODO transparency**: extends the existing "say so explicitly rather than committing a stub silently" principle to cover deliberately-unfixed findings too — mark with something like `RISK_ACCEPTED: <why>` rather than silently suppressing a warning.

## Test plan

- [x] `nx lint nx-agent` / `nx test nx-agent` (35/35) / `nx build nx-agent` all pass on the new branch (rebuilt off latest `main`, which already includes #328)