### PR TITLE
feat(nx-agent): seed a Claude Code deny-list for destructive commands

### DIFF
--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -76,6 +76,15 @@ Currently sets up:
    removes them and writes the current structure in their place, so simply re-running `init` is
    enough to pick up changes; no separate migration step.
 
+5. **A Claude Code deny-list** (`.claude/settings.json`), hard-blocking shell patterns with no
+   legitimate agent-initiated use case — `rm -rf` rooted at `/`/`~`/`$HOME`, `sudo`, `mkfs`,
+   `chmod -R 777 /`, system shutdown/reboot, history-rewriting/reflog-destroying git commands,
+   and whole-namespace OpenShift/Kubernetes deletion — absolute per Claude Code's own permission
+   model, holding even under `--dangerously-skip-permissions`. Merges into an existing file
+   rather than overwriting it. No equivalent exists yet for other tools (checked GitHub Copilot
+   CLI specifically — its absolute deny mechanism is CLI-flag-only, with no repo-committed file
+   to seed).
+
 ### Options
 
 | Option | Default | Description |

--- a/packages/nx-agent/src/generators/init/guidance/security-and-safety/destructive-operations.md
+++ b/packages/nx-agent/src/generators/init/guidance/security-and-safety/destructive-operations.md
@@ -1,7 +1,13 @@
 **Destructive operations.** `rm -rf`, `git checkout`/`restore`/`clean`, `git reset --hard`,
 force-pushing, dropping a database table — none of these are caught by the pre-commit hook; the
-damage happens before there's a commit to hook into. (Force-pushing can still be blocked by
-branch protection or a `pre-push` hook if configured; the rest have no git-level check at all.)
+damage happens before there's a commit to hook into. (On Claude Code, a `.claude/settings.json`
+deny-list now hard-blocks shell patterns with no legitimate agent-initiated use case — `rm -rf`
+rooted at `/`/`~`/`$HOME`, `sudo`, `mkfs`, `chmod -R 777 /`, `shutdown`/`reboot`/`halt`/`poweroff`,
+history-rewriting or reflog-destroying git commands, and whole-namespace OpenShift/Kubernetes
+deletion — regardless of permission mode; no equivalent exists for other tools yet, and it doesn't
+reach `checkout`/`restore`/`clean`/`reset --hard`, which are too routine to blanket-deny.
+Force-pushing can still be blocked by branch protection or a `pre-push` hook if configured; the
+rest have no other check.)
 Check what's actually at stake first — `git status` before anything that could discard uncommitted
 changes, confirmed scope before a force-push or a DB-level drop — and prefer a reversible step
 when one exists. Commit at a reasonable cadence rather than batching a session into one moment at

--- a/packages/nx-agent/src/generators/init/init.spec.ts
+++ b/packages/nx-agent/src/generators/init/init.spec.ts
@@ -316,4 +316,62 @@ Old secret-scan wording.
     expect(agentsMd).toContain('**Secrets.**')
     expect(agentsMd).toContain('**Choosing a dependency.**')
   })
+
+  it('creates .claude/settings.json with the default deny patterns from scratch', async () => {
+    await generator(host, {})
+
+    const settings = readJson(host, '.claude/settings.json')
+    expect(settings.permissions.deny).toEqual(
+      expect.arrayContaining([
+        'Bash(rm -rf /*)',
+        'Bash(rm -rf ~*)',
+        'Bash(rm -rf $HOME*)',
+        'Bash(sudo:*)',
+        'Bash(mkfs:*)',
+        'Bash(chmod -R 777 /*)',
+        'Bash(shutdown:*)',
+        'Bash(reboot:*)',
+        'Bash(halt:*)',
+        'Bash(poweroff:*)',
+        'Bash(git filter-branch:*)',
+        'Bash(git filter-repo:*)',
+        'Bash(git reflog expire:*)',
+        'Bash(git gc *--prune=now*)',
+        'Bash(oc delete project:*)',
+        'Bash(oc delete namespace:*)',
+        'Bash(kubectl delete namespace:*)',
+      ])
+    )
+    expect(settings.permissions.deny).toHaveLength(17)
+  })
+
+  it('merges into an existing .claude/settings.json without clobbering other settings', async () => {
+    host.write(
+      '.claude/settings.json',
+      JSON.stringify({
+        permissions: {
+          allow: ['Bash(npm run test:*)'],
+          deny: ['Bash(my-custom-deny:*)'],
+        },
+        model: 'opus',
+      })
+    )
+
+    await generator(host, {})
+
+    const settings = readJson(host, '.claude/settings.json')
+    expect(settings.model).toBe('opus')
+    expect(settings.permissions.allow).toEqual(['Bash(npm run test:*)'])
+    expect(settings.permissions.deny).toContain('Bash(my-custom-deny:*)')
+    expect(settings.permissions.deny).toContain('Bash(rm -rf /*)')
+  })
+
+  it('does not duplicate deny entries on a second run', async () => {
+    await generator(host, {})
+    await generator(host, {})
+
+    const settings = readJson(host, '.claude/settings.json')
+    expect(settings.permissions.deny).toHaveLength(17)
+    expect(settings.permissions.deny.filter((p: string) => p === 'Bash(sudo:*)')).toHaveLength(1)
+  })
 })

--- a/packages/nx-agent/src/generators/init/init.ts
+++ b/packages/nx-agent/src/generators/init/init.ts
@@ -253,6 +253,59 @@ function applySecretScanStep(host: Tree): void {
   ensureGitignoreEntries(host)
 }
 
+const CLAUDE_SETTINGS_PATH = '.claude/settings.json'
+// Absolute per Claude Code's own docs — deny beats ask/allow, holds even under
+// --dangerously-skip-permissions. Deliberately narrow: patterns with no legitimate
+// use case at all, not a general destructive-op guard (see the guidance note on why
+// git push --force is excluded — deny rules can't carry exceptions).
+const CLAUDE_DENY_PATTERNS = [
+  'Bash(rm -rf /*)',
+  'Bash(rm -rf ~*)',
+  'Bash(rm -rf $HOME*)',
+  'Bash(sudo:*)',
+  'Bash(mkfs:*)',
+  'Bash(chmod -R 777 /*)',
+  'Bash(shutdown:*)',
+  'Bash(reboot:*)',
+  'Bash(halt:*)',
+  'Bash(poweroff:*)',
+  // History-rewriting / reflog-destroying — no legitimate autonomous-agent use case, and the
+  // reflog one specifically destroys the exact recovery mechanism "Destructive operations"
+  // guidance relies on for a bad `reset --hard`.
+  'Bash(git filter-branch:*)',
+  'Bash(git filter-repo:*)',
+  'Bash(git reflog expire:*)',
+  'Bash(git gc *--prune=now*)', // scoped to the immediate-prune flag; plain `git gc` is routine
+  // Whole-namespace/project deletion — ecosystem-specific (nx-oc targets OpenShift). No conflict
+  // with nx-oc's own `teardown` generator, which is scoped to one app's resources within an
+  // environment, not the whole project/namespace.
+  'Bash(oc delete project:*)',
+  'Bash(oc delete namespace:*)',
+  'Bash(kubectl delete namespace:*)',
+]
+// npm publish/unpublish considered and excluded — real for nx-tools itself (a publishing
+// monorepo), but not a generally relevant default for the broader population of nx-agent
+// consumers, most of whom are deploying applications via nx-oc rather than publishing packages.
+
+function applyDenyRulesStep(host: Tree): void {
+  if (host.exists(CLAUDE_SETTINGS_PATH)) {
+    updateJson(host, CLAUDE_SETTINGS_PATH, (settings) => {
+      const permissions = settings.permissions ?? {}
+      const deny = permissions.deny ?? []
+      for (const pattern of CLAUDE_DENY_PATTERNS) {
+        if (!deny.includes(pattern)) {
+          deny.push(pattern)
+        }
+      }
+      permissions.deny = deny
+      settings.permissions = permissions
+      return settings
+    })
+    return
+  }
+  writeJson(host, CLAUDE_SETTINGS_PATH, { permissions: { deny: CLAUDE_DENY_PATTERNS } })
+}
+
 // Every capability contributes to one shared section, grouped by kind,
 // instead of writing its own top-level AGENTS.md heading — keeps the
 // growing list of practices reading as one coherent reference rather than
@@ -270,6 +323,7 @@ export default async function (host: Tree, rawOptions: Schema) {
 
   applyCheckHookStep(host, options)
   applySecretScanStep(host)
+  applyDenyRulesStep(host)
   applyAgentGuidance(host, options)
 
   await formatFiles(host)


### PR DESCRIPTION
## Summary

`init` now composes a fourth step, `applyDenyRulesStep`, seeding/merging `.claude/settings.json` with 17 `permissions.deny` patterns — commands with no legitimate agent-initiated use case: `rm -rf` rooted at `/`, `~`, or `$HOME`; `sudo`; `mkfs`; `chmod -R 777 /`; system shutdown/reboot; history-rewriting and reflog-destroying git commands (`git filter-branch`/`filter-repo`, `git reflog expire`, `git gc --prune=now`); and whole-namespace OpenShift/Kubernetes deletion.

**Why this is worth doing now**: confirmed via Claude Code's own docs that `permissions.deny` is absolute — it holds even under `--dangerously-skip-permissions`, unlike the general permission-prompt system, which is configuration- and attention-dependent. That makes this a declarative JSON seed, not a hook script to maintain (no `PreToolUse` script, no custom regex engine). GitHub Copilot CLI has the same absolute-deny property but no repo-committed file to persist it in — documented as a known gap rather than silently omitted.

**Deliberate exclusions**:
- `git push --force` — deny rules can't carry allowlist exceptions, and "GitHub Flow" guidance already permits force-pushing your own not-yet-reviewed branch.
- `npm publish`/`unpublish` — real for this monorepo specifically (a publishing workspace), but not a generally relevant default for the broader population of nx-agent consumers, who are mostly deploying applications via nx-oc rather than publishing packages.

**Merge behavior**: same idiom as `nx-adsp`'s `.mcp.json` merge (`updateJson` + append-if-missing) — preserves a team's own `permissions.allow`/custom deny entries and any unrelated top-level settings.json keys, never overwrites.

## Verification

- [x] `nx lint nx-agent` / `nx test nx-agent` (38/38) / `nx build nx-agent` all pass
- [x] **Tested against a real Claude Code session**, not just docs — temporarily seeded nx-tools' own root `.claude/settings.json`, attempted every pattern, removed it after. This caught a real bug: `'Bash(git gc * --prune=now*)'` had a spacing typo (`"git gc "` already ends in a space, so the extra literal space before `--prune=now` required two spaces where a real invocation has one) that let `git gc --prune=now` run **unblocked** against this repo before the fix. Corrected to `'Bash(git gc *--prune=now*)'` and reconfirmed blocked.
- [x] False-positive check: a relative-path `rm -rf` and a plain `git gc` (no `--prune=now`) both ran normally — confirms the patterns don't over-block routine operations.
- [x] 8 additional candidate patterns (curl/wget-pipe-to-shell, command-substitution-targeted `rm -rf`, DB-drop-via-CLI) were tested and **did not fire** — none are shipped. Kept as a documented gap in the design doc rather than silently dropped.