### PR TITLE
feat(nx-agent): ensure CLAUDE.md imports AGENTS.md

### DIFF
--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -76,6 +76,10 @@ Currently sets up:
    removes them and writes the current structure in their place, so simply re-running `init` is
    enough to pick up changes; no separate migration step.
 
+   Also ensures `CLAUDE.md` imports it (`@AGENTS.md`, appended if missing) — Claude Code reads
+   `CLAUDE.md` natively, not `AGENTS.md` directly, so without this the guidance above never
+   reaches a Claude Code session. Same one-line convention nx-adsp's own generators already use.
+
 5. **A Claude Code deny-list** (`.claude/settings.json`), hard-blocking shell patterns with no
    legitimate agent-initiated use case — `rm -rf` rooted at `/`/`~`/`$HOME`, `sudo`, `mkfs`,
    `chmod -R 777 /`, system shutdown/reboot, history-rewriting/reflog-destroying git commands,

--- a/packages/nx-agent/src/generators/init/init.spec.ts
+++ b/packages/nx-agent/src/generators/init/init.spec.ts
@@ -374,4 +374,29 @@ Old secret-scan wording.
     expect(settings.permissions.deny).toHaveLength(17)
     expect(settings.permissions.deny.filter((p: string) => p === 'Bash(sudo:*)')).toHaveLength(1)
   })
+
+  it('creates CLAUDE.md importing AGENTS.md from scratch', async () => {
+    await generator(host, {})
+
+    expect(host.read('CLAUDE.md').toString()).toBe('@AGENTS.md\n')
+  })
+
+  it('appends the @AGENTS.md import to an existing CLAUDE.md without disturbing its content', async () => {
+    host.write('CLAUDE.md', '# Team notes\n\nSome existing hand-authored content.\n')
+
+    await generator(host, {})
+
+    const claudeMd = host.read('CLAUDE.md').toString()
+    expect(claudeMd).toContain('# Team notes')
+    expect(claudeMd).toContain('Some existing hand-authored content.')
+    expect(claudeMd).toContain('@AGENTS.md')
+  })
+
+  it('does not duplicate the @AGENTS.md import on a second run', async () => {
+    await generator(host, {})
+    await generator(host, {})
+
+    const claudeMd = host.read('CLAUDE.md').toString()
+    expect(claudeMd.split('@AGENTS.md').length - 1).toBe(1)
+  })
 })

--- a/packages/nx-agent/src/generators/init/init.ts
+++ b/packages/nx-agent/src/generators/init/init.ts
@@ -306,6 +306,31 @@ function applyDenyRulesStep(host: Tree): void {
   writeJson(host, CLAUDE_SETTINGS_PATH, { permissions: { deny: CLAUDE_DENY_PATTERNS } })
 }
 
+const CLAUDE_MD_PATH = 'CLAUDE.md'
+const AGENTS_MD_IMPORT = '@AGENTS.md'
+
+// Claude Code reads CLAUDE.md natively, not AGENTS.md directly — without this
+// import, everything applyAgentGuidance writes never reaches a Claude Code
+// session. Matches the `@AGENTS.md`-only CLAUDE.md__tmpl__ already used by
+// nx-adsp's express-service/vue-app/react-app/angular-app generators; unlike
+// those (scaffolding into an empty directory), this runs against a workspace
+// that may already have its own CLAUDE.md, so it merges rather than
+// overwrites — same idiom as ensureGitignoreEntries/appendHookBlock.
+function ensureClaudeMdImportsAgentsMd(host: Tree): void {
+  if (!host.exists(CLAUDE_MD_PATH)) {
+    host.write(CLAUDE_MD_PATH, `${AGENTS_MD_IMPORT}\n`)
+    return
+  }
+
+  const existing = host.read(CLAUDE_MD_PATH).toString()
+  if (existing.includes(AGENTS_MD_IMPORT)) {
+    return
+  }
+
+  const trimmed = existing.replace(/\n+$/, '')
+  host.write(CLAUDE_MD_PATH, `${trimmed}\n\n${AGENTS_MD_IMPORT}\n`)
+}
+
 // Every capability contributes to one shared section, grouped by kind,
 // instead of writing its own top-level AGENTS.md heading — keeps the
 // growing list of practices reading as one coherent reference rather than
@@ -316,6 +341,7 @@ function applyAgentGuidance(host: Tree, options: NormalizedSchema): void {
   }
 
   mergeManagedSection(host, AGENT_GUIDANCE_SECTION_ID, buildAgentGuidance(options))
+  ensureClaudeMdImportsAgentsMd(host)
 }
 
 export default async function (host: Tree, rawOptions: Schema) {


### PR DESCRIPTION
## Summary

Claude Code reads `CLAUDE.md` natively, not `AGENTS.md` directly — without this, every guidance item `applyAgentGuidance` writes (the six-group practice set, the domain-term pointer, the dependency-audit reminder, the deny-list note, etc.) never reaches a Claude Code session unless the workspace already happens to have its own `CLAUDE.md` doing the importing. `init` had no mechanism for this at all before this change.

`init` now seeds/merges a one-line `@AGENTS.md` import into `CLAUDE.md` — the same convention `nx-adsp`'s own `express-service`/`vue-app`/`react-app`/`angular-app` generators already use (confirmed via their `CLAUDE.md__tmpl__` files, each containing just `@AGENTS.md`). The difference: those scaffold into an empty directory, so they can write the file unconditionally. `nx-agent:init` runs against a workspace that may already have a hand-authored `CLAUDE.md`, so this appends the import line only if missing, rather than overwriting — same idempotent-merge idiom already used by `ensureGitignoreEntries`/`appendHookBlock`.

## Test plan

- [x] `nx lint nx-agent` / `nx test nx-agent` (41/41, 3 new) / `nx build nx-agent` all pass
- [x] New tests cover: creates `CLAUDE.md` from scratch when missing; appends the import to an existing hand-authored `CLAUDE.md` without disturbing its content; does not duplicate the import on a second `init` run