### PR TITLE
docs: add nx-agent to the GitHub Pages site and root docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ tooling for consuming workspaces.
 nx-tools/
 ├── packages/           # publishable Nx plugin libraries (libsDir)
 │   ├── nx-adsp/        # Angular/React/Dotnet app scaffolding for ADSP
-│   ├── nx-agent/       # AI-agent development tooling (pre-commit affected-check hook, AGENTS.md guidance)
+│   ├── nx-agent/       # AI-agent dev tooling (pre-commit checks, secret scanning, Claude Code deny-list, AGENTS.md guidance, domain-term generator)
 │   ├── nx-oc/          # OpenShift pipeline generators + oc CLI executors
 │   ├── nx-release/     # semantic-release generator + monorepo commit-filter plugin
 │   └── semantic-release-nuget/  # NuGet push plugin for semantic-release

--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ This is a monorepo of the Government of Alberta's custom plugins for [Nx](https:
 [Nx ADSP Plugin](./packages/nx-adsp/README.md) - includes generators for application, service, and fullstack solution quick starts.
 
 [Semantic Release Nuget](./packages/semantic-release-nuget/README.md) - [semantic-release](https://github.com/semantic-release/semantic-release) plugin for publishing nuget packages.
+
+[Nx Agent Plugin](./packages/nx-agent/README.md) - AI-agent development tooling: pre-commit checks, secret scanning, a Claude Code deny-list, AGENTS.md guidance, and a domain-vocabulary generator.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Government of Alberta's Nx Tools are a set of [Nx](https://nx.dev) plugins for b
 | [@abgov/nx-oc](nx-oc/nx-oc) | Generators and executor for OpenShift CI/CD pipelines and deployments |
 | [@abgov/nx-release](nx-release/nx-release) | Semantic-release configuration generator for Nx monorepos |
 | [semantic-release-nuget](nx-release/semantic-release-nuget) | Semantic-release plugin for publishing NuGet packages |
+| [@abgov/nx-agent](nx-agent/nx-agent) | AI-agent development tooling — pre-commit checks, secret scanning, a Claude Code deny-list, AGENTS.md guidance, and a domain-vocabulary generator |
 
 ## Version compatibility
 

--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -1,0 +1,175 @@
+---
+layout: page
+title: NX Agent plugin
+nav_order: 5
+has_children: true
+---
+
+<details open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+# @abgov/nx-agent
+
+Nx plugin for AI-agent development tooling — capabilities that steer a coding agent's day-to-day
+work, as opposed to `@abgov/nx-adsp`/`@abgov/nx-oc`'s scaffolding and deployment concerns.
+
+## Installation
+
+```bash
+npm i -D @abgov/nx-agent
+```
+
+## Quick start
+
+```bash
+npx nx g @abgov/nx-agent:init
+```
+
+---
+
+## `init`
+
+A single, prescriptive entry point — run once per workspace. It's expected to grow as more
+capabilities are added; running it again after an upgrade re-applies whatever's new without
+disturbing anything it already set up.
+
+Currently sets up:
+
+1. **A Husky pre-commit hook** (`.husky/pre-commit`) that runs `nx affected` lint/test/build
+   against your *staged* changes before every commit:
+
+   ```sh
+   git diff --cached --name-only --diff-filter=ACMR | npx nx affected -t lint,test,build --stdin
+   ```
+
+   Adds `husky` as a devDependency and a `"prepare": "husky"` script if not already present.
+
+2. **A secret-scanning hook block**, appended to the same `.husky/pre-commit`, scanning staged
+   files for committed credentials with [secretlint](https://github.com/secretlint/secretlint):
+
+   ```sh
+   secretlint_files=$(git diff --cached --name-only --diff-filter=ACMR)
+   if [ -n "$secretlint_files" ]; then
+     echo "$secretlint_files" | xargs npx secretlint || exit 1
+   fi
+   ```
+
+   Adds `secretlint` and `@secretlint/secretlint-rule-preset-recommend` as devDependencies, and a
+   `.secretlintrc.json` if one doesn't already exist (never overwritten once created — rules are
+   the kind of thing a team tunes, unlike the AGENTS.md guidance below).
+
+3. **Baseline `.gitignore` entries** for common local-credential filenames — `.env.local`,
+   `.env.*.local`, `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `credentials.json` — added only if
+   missing, appended alongside whatever's already there. Deliberately excludes bare `.env`: it's
+   dual-purpose (plain workspace config as well as secrets), so a blanket rule would be a false
+   positive on legitimate use. This is preventive rather than detective — once a pattern is in
+   `.gitignore`, git itself refuses to stage a matching file via `git add .`/`git add -A`, so no
+   separate pre-commit check is needed on top of it. It does nothing for a file that was already
+   tracked before `init` ran; gitignore never retroactively untracks anything.
+
+4. **One consolidated `AGENTS.md` section**, `## Working with a coding agent`, organized into six
+   `###` groups — ordered roughly by stakes, highest first — each holding several related `**`
+   items rather than one flat, ever-growing list of top-level headings:
+   - **Security and safety** — secrets, PII/sensitive data, destructive operations, untrusted
+     content and instructions, trust boundaries.
+   - **Dependency hygiene** — choosing a dependency (existence/currency/license, checking whether
+     an existing dependency already covers the need, and not scrolling past what `npm install`
+     itself reports about known vulnerabilities).
+   - **Verifying your work** — the pre-commit-check habit above, plus respecting whatever
+     style/format/complexity tooling a project already has configured.
+   - **Version control practices** — atomic Conventional Commits, GitHub Flow, linear history.
+   - **Conventions and consistency** — ubiquitous language (domain vocabulary, and the
+     `domain-term` generator below), matching this project's own established patterns (including
+     `project-docs/`, if present), and following framework/library idioms.
+   - **Code quality** — scope discipline, comments (why, not what), reuse before reinventing
+     (existing generators and workspace ESLint rules over bespoke code), error handling, TODO
+     transparency (including deliberately-accepted findings), test quality.
+
+   The whole section is centrally maintained: re-running `init` refreshes it in place rather than
+   leaving it frozen at first-generation wording, assembled from `guidance/<group>/<item>.md`
+   files (one file per item, grouped into folders matching the six groups above) so the content
+   previews as plain markdown rather than escaped TypeScript string literals. `init` is also
+   self-migrating — if it finds section markers from an older, pre-consolidation version, it
+   removes them and writes the current structure in their place, so simply re-running `init` is
+   enough to pick up changes; no separate migration step.
+
+   Also ensures `CLAUDE.md` imports it (`@AGENTS.md`, appended if missing) — Claude Code reads
+   `CLAUDE.md` natively, not `AGENTS.md` directly, so without this the guidance above never
+   reaches a Claude Code session. Same one-line convention nx-adsp's own generators already use.
+
+5. **A Claude Code deny-list** (`.claude/settings.json`), hard-blocking shell patterns with no
+   legitimate agent-initiated use case — `rm -rf` rooted at `/`/`~`/`$HOME`, `sudo`, `mkfs`,
+   `chmod -R 777 /`, system shutdown/reboot, history-rewriting/reflog-destroying git commands,
+   and whole-namespace OpenShift/Kubernetes deletion — absolute per Claude Code's own permission
+   model, holding even under `--dangerously-skip-permissions`. Merges into an existing file
+   rather than overwriting it. No equivalent exists yet for other tools (checked GitHub Copilot
+   CLI specifically — its absolute deny mechanism is CLI-flag-only, with no repo-committed file
+   to seed).
+
+### `init` options
+
+| Option | Default | Description |
+|---|---|---|
+| `targets` | `lint,test,build` | Targets run by both the pre-commit hook and the AGENTS.md guidance's self-check command |
+| `base` | `main` | Base branch used only in the AGENTS.md guidance's self-check command (not the pre-commit hook, which always diffs against staged changes) |
+
+```bash
+npx nx g @abgov/nx-agent:init --targets=lint,test --base=develop
+```
+
+---
+
+## `domain-term`
+
+Adds one domain term — the ubiquitous language `init`'s guidance asks the agent to use, but gives
+it nowhere to check or record. Unlike `init`, this is repeatable — run it once per term, whenever
+one needs adding, not once per workspace:
+
+```bash
+npx nx g @abgov/nx-agent:domain-term Case
+```
+
+Creates `project-docs/domain-terms/case.md`:
+
+```markdown
+---
+term: Case
+aliases: []
+not_confused_with: []
+---
+
+<!-- Definition: describe this term in the domain's own language. -->
+```
+
+- `term` — the canonical name, matching the filename.
+- `aliases` — other words that mean the same thing.
+- `not_confused_with` — similar-sounding terms this one is deliberately distinct from, and why.
+
+One file per term rather than a single flat glossary, so frontmatter (a per-file construct in
+every tool that uses the term) is meaningful, and so listing the folder — cheap, just filenames —
+is enough to check the existing vocabulary before coining a new name.
+
+Also bootstraps `project-docs/domain-terms/README.md` on first use, explaining the convention to
+whoever (human or agent) opens the folder next. That file has no value on its own — it exists only
+to explain the convention for the term about to be added — so there's no separate "set up the
+glossary" generator; `domain-term` composes it as an internal step.
+
+### `domain-term` options
+
+| Option | Default | Description |
+|---|---|---|
+| `term` | — (required, positional) | The canonical domain term, as domain experts use it |
+| `project` | workspace root | Scope the term to a specific project's `project-docs/domain-terms/` instead — use when a bounded context spans a domain library and its consuming apps |
+
+```bash
+npx nx g @abgov/nx-agent:domain-term Case --project=domain-lib
+```
+
+Re-adding a term that already exists throws rather than silently overwriting or duplicating it —
+edit the file directly instead.


### PR DESCRIPTION
## Summary

`nx-agent` had grown to five `init` capabilities plus the `domain-term` generator without ever being added to the published docs site ([govalta.github.io/nx-tools](https://govalta.github.io/nx-tools/)) or the root README's plugin list — `nx-adsp`, `nx-oc`, and `nx-release` all have pages; `nx-agent` had none.

- `docs/nx-agent/nx-agent.md` — new page, same layout/frontmatter shape as the other three plugin pages (`layout: page`, `nav_order: 5`, `has_children: true`), content adapted from the package's own README
- `docs/index.md` — adds the missing row to the Plugins table
- `README.md` — adds the missing entry to the root Plugins list
- `AGENTS.md` — refreshes the one-line `nx-agent` description in the repository structure tree, which still only mentioned the earliest two capabilities (pre-commit hook, AGENTS.md guidance) from before this session's later work (secret scanning, the Claude Code deny-list, the `CLAUDE.md` import, `domain-term`)

## Test plan

- [x] New page's YAML frontmatter parses correctly (verified with a real YAML parser) and its code fences are balanced (12, even)
- [ ] Full local Jekyll build **not verified** — `bundle install` fails on this environment's Ruby 2.6.10 due to a transitive gem requiring Ruby 3.0+. Confirmed this is pre-existing and unrelated to this change by reproducing the identical failure with these changes stashed against plain `main`. No `Gemfile.lock` is committed either way — GitHub Pages' legacy build service resolves its own gem versions server-side, independent of local bundler state — so this should build fine once merged, but worth a look at the live site after merge to be sure.