### PR TITLE
fix(nx-adsp): move CLIENT_SECRET to .env.local instead of .env

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,8 +170,8 @@ oc create secret generic my-app-service-database \
 
 **ADSP client secret** — the service authenticates with the access service using
 its confidential Keycloak client secret. Scaffolding writes it to the service's
-`.env` (`CLIENT_SECRET=...`) for the generator's tenant; each environment runs
-against its own tenant, so create the Secret per environment with that
+`.env.local` (`CLIENT_SECRET=...`) for the generator's tenant; each environment
+runs against its own tenant, so create the Secret per environment with that
 environment's client secret:
 
 ```bash
@@ -182,12 +182,12 @@ oc create secret generic my-app-service-secrets \
 # Repeat for test and prod (each has its own client secret)
 ```
 
-> The `dev` value is in `apps/my-app-service/.env` after scaffolding. For
+> The `dev` value is in `apps/my-app-service/.env.local` after scaffolding. For
 > test/prod, get the client secret from that environment's ADSP tenant admin
 > (Keycloak) for client `urn:ads:<tenant>:my-app-service`.
 
 The sandbox deploy (`nx run my-app-service:sandbox`) creates this Secret
-automatically from the service's `.env` — the manual step is only for the
+automatically from the service's `.env.local` — the manual step is only for the
 GitHub Actions / `apply-envs` environments.
 
 ### 7. Apply environment resources to OpenShift

--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -3,6 +3,7 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import * as utils from '@abgov/nx-oc';
 import { environments } from '@abgov/nx-oc';
+import * as keycloakAdmin from '../../utils/keycloak-admin';
 import { Schema } from './schema';
 import generator from './express-service';
 
@@ -16,6 +17,9 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
 });
 utilsMock.deploymentGenerator.mockResolvedValue(undefined);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
+
+jest.mock('../../utils/keycloak-admin');
+const keycloakAdminMock = keycloakAdmin as jest.Mocked<typeof keycloakAdmin>;
 
 describe('Express Service Generator', () => {
   const options: Schema = {
@@ -167,5 +171,59 @@ describe('Express Service Generator', () => {
     expect((config.tags ?? []).some((t) => t.startsWith('adsp:database:'))).toBe(
       false
     );
+  }, 60000);
+
+  it('writes a provisioned CLIENT_SECRET to .env.local, not .env', async () => {
+    keycloakAdminMock.ensureServiceClient.mockResolvedValueOnce('super-secret');
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, { ...options, accessToken: 'test-token' });
+
+    expect(host.read('apps/test/.env.local').toString()).toContain('CLIENT_SECRET=super-secret');
+    expect(host.exists('apps/test/.env')).toBeFalsy();
+  }, 60000);
+
+  it('does not modify .gitignore for the provisioned secret', async () => {
+    keycloakAdminMock.ensureServiceClient.mockResolvedValueOnce('super-secret');
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    const gitignoreBefore = host.read('.gitignore')?.toString() ?? '';
+    await generator(host, { ...options, accessToken: 'test-token' });
+
+    expect(host.read('.gitignore')?.toString() ?? '').toBe(gitignoreBefore);
+  }, 60000);
+
+  it('does not overwrite or duplicate an existing CLIENT_SECRET in .env.local', async () => {
+    keycloakAdminMock.ensureServiceClient.mockResolvedValueOnce('freshly-provisioned-secret');
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    // express-service is a one-shot scaffolder (re-running it against an
+    // existing project throws in @nx/express), so this exercises the guard
+    // directly rather than by calling the generator twice: a CLIENT_SECRET
+    // already present in .env.local (e.g. set by hand) must survive untouched.
+    host.write('apps/test/.env.local', 'CLIENT_SECRET=already-there\n');
+    await generator(host, { ...options, accessToken: 'test-token' });
+
+    const envLocal = host.read('apps/test/.env.local').toString();
+    expect(envLocal).toContain('CLIENT_SECRET=already-there');
+    expect(envLocal).not.toContain('freshly-provisioned-secret');
+    expect(envLocal.split('CLIENT_SECRET=').length - 1).toBe(1);
+  }, 60000);
+
+  it('preserves an existing .env.local value (e.g. a prior dev-db run) alongside CLIENT_SECRET', async () => {
+    keycloakAdminMock.ensureServiceClient.mockResolvedValueOnce('super-secret');
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    host.write('apps/test/.env.local', 'DATABASE_URL=postgresql://test:test@localhost:5432/test_dev\n');
+    await generator(host, { ...options, accessToken: 'test-token' });
+
+    const envLocal = host.read('apps/test/.env.local').toString();
+    expect(envLocal).toContain('DATABASE_URL=postgresql://test:test@localhost:5432/test_dev');
+    expect(envLocal).toContain('CLIENT_SECRET=super-secret');
+  }, 60000);
+
+  it('writes nothing when no secret is provisioned', async () => {
+    keycloakAdminMock.ensureServiceClient.mockResolvedValueOnce(null);
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, { ...options, accessToken: 'test-token' });
+
+    expect(host.exists('apps/test/.env.local')).toBeFalsy();
+    expect(host.exists('apps/test/.env')).toBeFalsy();
   }, 60000);
 });

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -246,17 +246,17 @@ export default async function (host: Tree, options: Schema) {
       accessToken
     );
     if (clientSecret) {
-      const envPath = `${normalizedOptions.projectRoot}/.env`;
-      const existing = host.exists(envPath) ? host.read(envPath).toString() : '';
+      // .env.local, not .env: CLIENT_SECRET is a generated, local-only value — the
+      // same tier `nx dev-db` already uses for DATABASE_URL/MONGODB_URI — and
+      // already unconditionally gitignored by create-nx-workspace's default
+      // .gitignore (.env.local, .env.*.local), so no gitignore management is
+      // needed here at all. .env itself is left alone: it holds non-secret,
+      // developer-owned config too (KEYCLOAK_ROOT_URL, DIRECTORY_URL, etc.) and
+      // shouldn't be blanket-gitignored.
+      const envLocalPath = `${normalizedOptions.projectRoot}/.env.local`;
+      const existing = host.exists(envLocalPath) ? host.read(envLocalPath).toString() : '';
       if (!existing.includes('CLIENT_SECRET=')) {
-        host.write(envPath, `${existing ? existing.trimEnd() + '\n' : ''}CLIENT_SECRET=${clientSecret}\n`);
-      }
-      const gitignorePath = '.gitignore';
-      if (host.exists(gitignorePath)) {
-        const gitignoreContent = host.read(gitignorePath).toString();
-        if (!gitignoreContent.includes('.env')) {
-          host.write(gitignorePath, `${gitignoreContent.trimEnd()}\n${normalizedOptions.projectRoot}/.env\n`);
-        }
+        host.write(envLocalPath, `${existing ? existing.trimEnd() + '\n' : ''}CLIENT_SECRET=${clientSecret}\n`);
       }
     }
   }

--- a/packages/nx-adsp/src/generators/express-service/files-mongo/.env.example__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-mongo/.env.example__tmpl__
@@ -1,8 +1,12 @@
-# Copy this file to .env and set CLIENT_SECRET.
-# MONGODB_URI is written automatically to .env.local by 'nx dev-db <%= projectName %>'.
+# Every value below already has a matching default in src/environment.ts — you
+# only need to copy this to .env if you want to override one (e.g. point at a
+# different environment temporarily).
+#
+# CLIENT_SECRET is written automatically to .env.local after Keycloak
+# provisioning (or set it there yourself, as CLIENT_SECRET=<value>, for manual
+# setup). MONGODB_URI is written automatically to .env.local by
+# 'nx dev-db <%= projectName %>'. Neither belongs here.
 KEYCLOAK_ROOT_URL=<%= accessServiceUrl %>
 DIRECTORY_URL=<%= directoryServiceUrl %>
 TENANT_REALM=<%= tenantRealm %>
 CLIENT_ID=urn:ads:<%= tenant %>:<%= projectName %>
-CLIENT_SECRET=
-MONGODB_URI=mongodb://localhost:27017/<%= projectName %>_dev

--- a/packages/nx-adsp/src/generators/express-service/files-mongo/scripts/dev-db.sh__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-mongo/scripts/dev-db.sh__tmpl__
@@ -32,7 +32,12 @@ until podman exec "${CONTAINER}" mongosh --quiet --eval "quit()" &>/dev/null; do
 done
 echo "MongoDB is ready."
 
-# Write MONGODB_URI to .env.local so the app picks it up without manual .env editing.
-# Overridden by the Secret in OpenShift at runtime.
-echo "MONGODB_URI=mongodb://localhost:${PORT}/${DB_NAME}" > .env.local
+# Merge MONGODB_URI into .env.local rather than overwriting it wholesale —
+# CLIENT_SECRET (written once by the generator after Keycloak provisioning) may
+# already be there. Overridden by the Secret in OpenShift at runtime.
+if [ -f .env.local ]; then
+  grep -v '^MONGODB_URI=' .env.local > .env.local.tmp || true
+  mv .env.local.tmp .env.local
+fi
+echo "MONGODB_URI=mongodb://localhost:${PORT}/${DB_NAME}" >> .env.local
 echo "MONGODB_URI written to .env.local"

--- a/packages/nx-adsp/src/generators/express-service/files-postgres/.env.example__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-postgres/.env.example__tmpl__
@@ -1,8 +1,12 @@
-# Copy this file to .env and set CLIENT_SECRET.
-# DATABASE_URL is written automatically to .env.local by 'nx dev-db <%= projectName %>'.
+# Every value below already has a matching default in src/environment.ts — you
+# only need to copy this to .env if you want to override one (e.g. point at a
+# different environment temporarily).
+#
+# CLIENT_SECRET is written automatically to .env.local after Keycloak
+# provisioning (or set it there yourself, as CLIENT_SECRET=<value>, for manual
+# setup). DATABASE_URL is written automatically to .env.local by
+# 'nx dev-db <%= projectName %>'. Neither belongs here.
 KEYCLOAK_ROOT_URL=<%= accessServiceUrl %>
 DIRECTORY_URL=<%= directoryServiceUrl %>
 TENANT_REALM=<%= tenantRealm %>
 CLIENT_ID=urn:ads:<%= tenant %>:<%= projectName %>
-CLIENT_SECRET=
-DATABASE_URL=postgresql://<%= projectName %>:<%= projectName %>@localhost:5432/<%= projectName %>_dev

--- a/packages/nx-adsp/src/generators/express-service/files-postgres/scripts/dev-db.sh__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-postgres/scripts/dev-db.sh__tmpl__
@@ -37,7 +37,12 @@ until podman exec "${CONTAINER}" pg_isready -U "${DB_USER}" -d "${DB_NAME}" &>/d
 done
 echo "Postgres is ready."
 
-# Write DATABASE_URL to .env.local so Drizzle and the app pick it up without
-# manual .env editing. Overridden by the SECRET in OpenShift at runtime.
-echo "DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@localhost:${PORT}/${DB_NAME}" > .env.local
+# Merge DATABASE_URL into .env.local rather than overwriting it wholesale —
+# CLIENT_SECRET (written once by the generator after Keycloak provisioning) may
+# already be there. Overridden by the SECRET in OpenShift at runtime.
+if [ -f .env.local ]; then
+  grep -v '^DATABASE_URL=' .env.local > .env.local.tmp || true
+  mv .env.local.tmp .env.local
+fi
+echo "DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@localhost:${PORT}/${DB_NAME}" >> .env.local
 echo "DATABASE_URL written to .env.local"

--- a/packages/nx-adsp/src/generators/express-service/files/src/environment.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/environment.ts__tmpl__
@@ -5,13 +5,13 @@ import { resolve } from 'path';
 config({
   path: resolve(process.cwd(), '<%= projectRoot %>/.env'),
 });
-<% if (database !== 'none') { %>
-// .env.local is written by 'nx dev-db' with the local database connection string.
+// .env.local holds generated, local-only values: CLIENT_SECRET (written once by
+// this generator after Keycloak provisioning) and, when a database is
+// configured, the connection string written by 'nx dev-db'.
 config({
   path: resolve(process.cwd(), '<%= projectRoot %>/.env.local'),
   override: true,
 });
-<% } %>
 
 export const environment = cleanEnv(process.env, {
   KEYCLOAK_ROOT_URL: str({ default: '<%= accessServiceUrl %>' }),

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -74,11 +74,16 @@ describe('sandbox executor', () => {
     expect(idx('oc import-image')).toBeLessThan(idx('oc rollout restart'));
   });
 
-  it('mirrors CLIENT_SECRET for a node service only', async () => {
+  it('mirrors CLIENT_SECRET for a node service only, read from .env.local', async () => {
     await runExecutor(baseOptions, context());
     expect(
       commands().some(
-        (c) => c.includes('oc create secret generic test-secrets') && c.includes('CLIENT_SECRET')
+        (c) =>
+          c.includes('oc create secret generic test-secrets') &&
+          c.includes('CLIENT_SECRET') &&
+          // CLIENT_SECRET lives in .env.local, not .env - @abgov/nx-adsp's
+          // express-service writes it there, not to .env.
+          c.includes('.env.local')
       )
     ).toBe(true);
 

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -159,12 +159,15 @@ export default async function runExecutor(
     }
 
     // ---- service client secret (node services authenticate to ADSP) ----
-    // Upserted from the current .env so re-runs pick up a rotated secret.
+    // Upserted from the current .env.local so re-runs pick up a rotated secret.
+    // CLIENT_SECRET lives in .env.local, not .env (@abgov/nx-adsp's
+    // express-service writes it there — it's a generated, local-only value,
+    // the same tier `nx dev-db` uses for DATABASE_URL/MONGODB_URI).
     if (appType === 'node') {
       run(
         'Upsert CLIENT_SECRET',
         `oc create secret generic ${projectName}-secrets ` +
-          `--from-literal=CLIENT_SECRET="$(grep -E '^CLIENT_SECRET=' ${projectRoot}/.env 2>/dev/null | cut -d= -f2-)" ` +
+          `--from-literal=CLIENT_SECRET="$(grep -E '^CLIENT_SECRET=' ${projectRoot}/.env.local 2>/dev/null | cut -d= -f2-)" ` +
           `-n ${sandboxProject} --dry-run=client -o yaml | oc apply -f -`,
         cwd
       );


### PR DESCRIPTION
## Summary

`express-service` wrote the real Keycloak `CLIENT_SECRET` to `.env`, then tried to gitignore that file, guarded by `!gitignoreContent.includes('.env')`. `create-nx-workspace`'s default `.gitignore` already contains `.env.local`/`.env.*.local` (both contain the substring `.env`), so the guard was already true, the append silently never fired, and the real secret ended up in a tracked file. This is live-run finding #9 in `PEVN-SANDBOX-LIVE-RUN-FINDINGS.md` — reproduced for real this session, caught only by hand-inspecting `git status` before staging.

**Fixing just the substring check was considered and rejected.** It would only make the generator correctly gitignore the *entire* `.env` file — which is wrong on its own terms. `.env.example`'s own documented setup path already treats `.env` as legitimately mixed (`KEYCLOAK_ROOT_URL`/`DIRECTORY_URL`/`TENANT_REALM`/`CLIENT_ID` alongside the secret) — blanket-gitignoring it would also silently hide any future non-secret value a developer adds there.

**Moves `CLIENT_SECRET` to `.env.local` instead** — already unconditionally gitignored by `create-nx-workspace`'s default `.gitignore`, and already the established tier `nx dev-db` uses for `DATABASE_URL`/`MONGODB_URI`. This removes the gitignore-management code from `express-service.ts` entirely rather than fixing it.

Two coordinated changes make this safe rather than a regression (both confirmed by reading the actual templates, not assumed):

- `environment.ts`'s `.env.local` load was conditional on `database !== 'none'`, unrelated to `CLIENT_SECRET` — a `--database none` service would never have loaded it. Now unconditional.
- Both `dev-db.sh` templates (postgres, mongo) blindly overwrote `.env.local` (`echo ... > .env.local`). If `CLIENT_SECRET` landed there first, the next `nx dev-db` — which `serve` already depends on automatically — would have silently erased it. Both now merge via a portable filter-then-append instead of `sed -i`, which has incompatible flag syntax between BSD and GNU.

Also updates both `.env.example` templates: `CLIENT_SECRET` and the DB connection line are both `.env.local`-bound and don't belong in the documented `.env` body — found while touching this file for the same root cause, not a separate ask.

**Second commit — caught before merge, not after:** asked whether the sandbox deployment (`@abgov/nx-oc`) depends on `.env` at all. It does: `sandbox.ts`'s own `CLIENT_SECRET` upsert (`oc create secret generic ${projectName}-secrets`) read directly from `${projectRoot}/.env` via `grep`. Left alone, this PR would have shipped a real regression on merge — every sandbox deploy of a node service would grep an empty result from `.env`, upsert an empty `CLIENT_SECRET`, and silently break ADSP auth for that service. Fixed to read from `.env.local`, matching where it's now written. Grepped every `CLIENT_SECRET`/`.env` reference across all of `nx-oc` to confirm this was the only place reading it directly (`deployment.ts`'s own `CLIENT_SECRET` references are for the OpenShift-native Secret injection path, populated by a human via `oc create secret`, not a local file read). Also fixed three stale `.env` references in `docs/getting-started.md`.

## Test plan

- [x] `nx lint`/`nx test`/`nx build` pass for both `nx-adsp` (69/69, 5 new) and `nx-oc` (110/110, 1 strengthened)
- [x] Confirmed the `express-service.ts` code path was **completely untested before**: every existing test omits `tenant`/`accessToken`, so `ensureServiceClient` always short-circuited to `null` before any network call, and the `CLIENT_SECRET` block never executed in any test. New tests mock `ensureServiceClient` (same pattern already used for `@abgov/nx-oc`) to actually exercise it: writes to `.env.local` not `.env`, doesn't touch `.gitignore`, doesn't overwrite/duplicate an existing `CLIENT_SECRET`, preserves an existing `DATABASE_URL` line alongside it, and writes nothing when no secret is provisioned.
- [x] Confirmed `mern`/`mean`/`pern`/`pean`/`pevn`/`mevn` all delegate to `express-service.ts` for the backend half with no `CLIENT_SECRET`/`.env` logic of their own, so this fix covers all six composites.
- [x] Strengthened the existing `sandbox.spec.ts` test (previously only checked for the `CLIENT_SECRET` substring, not the path) to assert the command targets `.env.local`.
- [ ] Full live end-to-end verification (real ADSP tenant scaffold → `nx dev-db` → sandbox deploy → confirm the OpenShift Secret has the real value) **not possible in this environment** — no ADSP credentials, `podman`, or `oc` cluster access available here. Verified everything reachable without those: exact template/executor diffs, and that existing tests (including the database-scaffolding existence checks, which would fail on any EJS syntax error) still pass.