### PR TITLE
fix(nx-adsp): serialize express-service's migrate.ts with a Postgres advisory lock

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -105,6 +105,11 @@ describe('Express Service Generator', () => {
     expect(host.exists('apps/test/src/db/schema.ts')).toBeTruthy();
     expect(host.exists('apps/test/src/database.ts')).toBeTruthy();
     expect(host.exists('apps/test/src/migrate.ts')).toBeTruthy();
+    const migrateTs = host.read('apps/test/src/migrate.ts').toString();
+    // Guards against concurrent replicas racing drizzle-orm's migrate(), which has
+    // no built-in protection (drizzle-team/drizzle-orm#874).
+    expect(migrateTs).toContain('pg_advisory_lock');
+    expect(migrateTs).toContain('pg_advisory_unlock');
     expect(host.exists('apps/test/drizzle.config.ts')).toBeTruthy();
     expect(host.exists('apps/test/scripts/dev-db.sh')).toBeTruthy();
     expect(host.exists('apps/test/.env.example')).toBeTruthy();

--- a/packages/nx-adsp/src/generators/express-service/files-postgres/src/migrate.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-postgres/src/migrate.ts__tmpl__
@@ -4,6 +4,13 @@ import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import { Pool } from 'pg';
 
 const MIGRATIONS_FOLDER = 'drizzle';
+// Arbitrary, stable key — advisory locks are scoped per-database, not shared
+// across a Postgres instance (confirmed via the pg_locks documentation: "the
+// same advisory lock key can be held simultaneously in different databases
+// ... they don't conflict across DB boundaries"), so this only needs to be
+// unique within this app's own database, not across every app sharing a
+// sandbox Postgres instance.
+const MIGRATION_LOCK_KEY = 8812345;
 
 // Standalone migration runner — the deployment runs this as an init container
 // (`node migrate.js`) before the app starts. It uses only drizzle-orm + pg,
@@ -25,11 +32,24 @@ async function main() {
   }
 
   const pool = new Pool({ connectionString });
+  // drizzle-orm's migrate() has no protection against concurrent execution
+  // (github.com/drizzle-team/drizzle-orm/issues/874, open, acknowledged by
+  // its maintainers) — it reads the last-applied migration with a plain
+  // SELECT before opening a transaction, so two replicas starting at once can
+  // both see "nothing applied yet" and both try to run the same migration.
+  // A session-scoped advisory lock on a dedicated connection serializes
+  // concurrent runs of this script: whichever loses blocks here until the
+  // winner releases the lock, then proceeds against an already-migrated
+  // database — a safe no-op, since __drizzle_migrations already records it.
+  const lockClient = await pool.connect();
   try {
+    await lockClient.query('SELECT pg_advisory_lock($1)', [MIGRATION_LOCK_KEY]);
     await migrate(drizzle(pool), { migrationsFolder: MIGRATIONS_FOLDER });
     // eslint-disable-next-line no-console
     console.log('Migrations applied.');
   } finally {
+    await lockClient.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]);
+    lockClient.release();
     await pool.end();
   }
 }


### PR DESCRIPTION
## Summary
- `drizzle-orm`'s `migrate()` has no built-in protection against concurrent execution ([drizzle-team/drizzle-orm#874](https://github.com/drizzle-team/drizzle-orm/issues/874), open, acknowledged upstream) — it reads the last-applied migration with a plain `SELECT` before opening a transaction, so two replicas starting at once can both see "nothing applied yet" and race to run the same migration.
- Wraps the `migrate()` call in `migrate.ts__tmpl__` with a session-scoped `pg_advisory_lock`/`pg_advisory_unlock` on a dedicated connection, serializing concurrent invocations: the losing process blocks until the winner commits, then proceeds against an already-migrated database (a safe no-op, since `__drizzle_migrations` already records it).
- Addresses `PEVN-SANDBOX-LIVE-RUN-FINDINGS.md` #5 (tier 3): the sandbox's first-deploy migration race condition.

## Verification
- Reproduced the race for real against an isolated Postgres 16 container: two concurrent unlocked runs against a fresh migration set — one succeeded, the other crashed on `CREATE SCHEMA IF NOT EXISTS "drizzle"` (a genuine race, not a hypothetical).
- Confirmed the fix resolves it across 4 repeated concurrent runs with the lock in place — both processes always complete cleanly, and exactly one row lands in `__drizzle_migrations` each time (no double-apply).
- Added a content assertion in `express-service.spec.ts` asserting the generated `migrate.ts` contains the lock/unlock calls (previously only existence was tested).
- `nx lint nx-adsp`, `nx test nx-adsp`, `nx build nx-adsp` all pass.

## Test plan
- [x] Reproduced the unlocked race against a real Postgres container
- [x] Confirmed the locked fix resolves it across repeated concurrent runs
- [x] `nx lint/test/build nx-adsp` pass
- [x] New test asserts generated `migrate.ts` contains the advisory lock calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)