### PR TITLE
fix(nx-adsp): check for the required @nx/* peer plugin before ADSP auth

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -98,11 +98,18 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 
 
 export default async function (host: Tree, options: AngularAppGeneratorSchema) {
-  const normalizedOptions = await normalizeOptions(host, options);
-
+  // Checked before normalizeOptions, which resolves ADSP auth and can trigger
+  // an interactive login — a missing peer shouldn't surface only after that.
   const { applicationGenerator: initAngular } = await import(
     '@nx/angular/generators'
-  );
+  ).catch(() => {
+    throw new Error(
+      "The 'angular-app' generator requires the '@nx/angular' plugin. Install it and re-run:\n  npm i -D @nx/angular"
+    );
+  });
+
+  const normalizedOptions = await normalizeOptions(host, options);
+
   await initAngular(host, {
     name: options.name,
     prefix: normalizedOptions.projectName,

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -101,8 +101,8 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 }
 
 export default async function (host: Tree, options: Schema) {
-  const normalizedOptions = await normalizeOptions(host, options);
-
+  // Checked before normalizeOptions, which resolves ADSP auth and can trigger
+  // an interactive login — a missing peer shouldn't surface only after that.
   const { applicationGenerator: initExpress } = await import('@nx/express').catch(
     () => {
       throw new Error(
@@ -110,6 +110,9 @@ export default async function (host: Tree, options: Schema) {
       );
     }
   );
+
+  const normalizedOptions = await normalizeOptions(host, options);
+
   await initExpress(host, {
     ...options,
     skipFormat: true,

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -103,8 +103,8 @@ function removeFiles(host: Tree, options: NormalizedSchema) {
 }
 
 export default async function (host: Tree, options: Schema) {
-  const normalizedOptions = await normalizeOptions(host, options);
-
+  // Checked before normalizeOptions, which resolves ADSP auth and can trigger
+  // an interactive login — a missing peer shouldn't surface only after that.
   const { applicationGenerator: initReact } = await import('@nx/react').catch(
     () => {
       throw new Error(
@@ -112,6 +112,8 @@ export default async function (host: Tree, options: Schema) {
       );
     }
   );
+
+  const normalizedOptions = await normalizeOptions(host, options);
 
   // Setting strict to false because of: https://github.com/nrwl/nx/issues/8180
   await initReact(host, {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -66,13 +66,16 @@ function addFiles(host: Tree, options: NormalizedSchema) {
 }
 
 export default async function (host: Tree, options: Schema) {
-  const normalizedOptions = await normalizeOptions(host, options);
-
+  // Checked before normalizeOptions, which resolves ADSP auth and can trigger
+  // an interactive login — a missing peer shouldn't surface only after that.
   const { applicationGenerator: initVue } = await import('@nx/vue').catch(() => {
     throw new Error(
       "The 'vue-app' generator requires the '@nx/vue' plugin. Install it and re-run:\n  npm i -D @nx/vue"
     );
   });
+
+  const normalizedOptions = await normalizeOptions(host, options);
+
   await initVue(host, {
     name: options.name,
     style: 'css',


### PR DESCRIPTION
## Summary
- `vue-app`, `express-service`, `react-app`, and `angular-app` each dynamically import their required `@nx/*` plugin (`@nx/vue`, `@nx/express`, `@nx/react`, `@nx/angular` — all declared as optional peers in `nx-adsp/package.json`, so npm never auto-installs them and doesn't even warn when they're missing), but the check ran *after* `normalizeOptions`, which resolves ADSP auth (`getAdspConfiguration`) and can trigger an interactive login or, later in the generator, Keycloak client provisioning.
- Reproduced live per `PEVN-SANDBOX-LIVE-RUN-FINDINGS.md` #2 / friction spec #2: a missing `@nx/express` peer surfaced only after Keycloak client work had already happened — a correct error message, but only after side effects the generator can't undo.
- Moved each peer-plugin check to the very first line of the generator, before any ADSP/Keycloak work.
- `angular-app` had no guard at all — a raw `await import('@nx/angular/generators')` with no `.catch()`, so a missing peer there surfaced as a cryptic module-not-found error. Added a guard matching the other three's message shape.

## Verification
- Confirmed by reading each generator's `normalizeOptions` that it calls `getAdspConfiguration` (a side-effecting ADSP auth resolution) before the peer-plugin check previously ran.
- `nx lint nx-adsp` / `nx test nx-adsp` / `nx build nx-adsp` all pass (71/71 tests), confirming no regression to the happy path.
- No new test added — this is a straightforward statement reordering (peer-plugin check moved above the auth call), not a behavioral change reachable by existing tests' mocks; verified via code review rather than new mocking infrastructure.

## Test plan
- [x] `nx lint/test/build nx-adsp` pass
- [x] Confirmed via code review that each generator's peer-plugin check now runs before any ADSP/Keycloak side effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)