### PR TITLE
fix(nx-adsp,nx-oc): resolve nx-oc:sandbox's env/tenant against the target app

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -19,6 +19,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 
 describe('angular app generator', () => {
   let appTree: Tree;

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -1,4 +1,4 @@
-import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
+import { adspProjectTags, deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import { confirmAfterAgentInterrupt, consultAgent } from '../../utils/agent';
 import { ensureAudienceMapper, ensureClientRoleScope, ensurePublicClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
@@ -189,6 +189,13 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
       proxyConfig: `${normalizedOptions.projectRoot}/proxy.conf.json`,
     };
   }
+
+  config.tags = [
+    ...(config.tags ?? []),
+    ...adspProjectTags(normalizedOptions.env, normalizedOptions.adsp.tenant).filter(
+      (tag) => !(config.tags ?? []).includes(tag)
+    ),
+  ];
 
   updateProjectConfiguration(host, options.name, config);
 

--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -15,6 +15,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.deploymentGenerator.mockResolvedValue(undefined);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -1,4 +1,4 @@
-import { deploymentGenerator, environments, getAdspConfiguration, getServiceUrls, ensureAdspToken, ADSP_ADMIN_SCOPE } from '@abgov/nx-oc';
+import { adspProjectTags, deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -25,48 +25,7 @@ async function normalizeOptions(
   const projectName = names(options.name).fileName;
   const projectRoot = `${getWorkspaceLayout(host).appsDir}/${projectName}`;
 
-  let adsp: import('@abgov/nx-oc').AdspConfiguration;
-
-  if (options.tenant) {
-    // Resolve realm from tenant name via the public tenant service API (no auth required),
-    // then obtain a token for that realm via @abgov/adsp-cli.
-    const env = environments[options.env ?? 'prod'];
-    const tenantServiceUrl = (await getServiceUrls(env.directoryServiceUrl))['urn:ads:platform:tenant-service'];
-
-    const { default: axios } = await import('axios');
-    const { data } = await axios.get<{ results: { name: string; realm: string }[] }>(
-      new URL('/api/tenant/v2/tenants', tenantServiceUrl).href,
-      { params: { name: options.tenant } }
-    );
-
-    const tenantInfo = data?.results?.[0];
-    if (!tenantInfo) {
-      throw new Error(`Tenant "${options.tenant}" not found in ${env.directoryServiceUrl}.`);
-    }
-
-    const tenantRealm = options.tenantRealm ?? tenantInfo.realm;
-
-    if (!options.accessToken) {
-      options = {
-        ...options,
-        accessToken: await ensureAdspToken({
-          env: options.env ?? 'prod',
-          realm: tenantRealm,
-          tenant: options.tenant,
-          scopes: [ADSP_ADMIN_SCOPE],
-        }).catch(() => undefined),
-      };
-    }
-
-    adsp = {
-      tenant: tenantInfo.name,
-      tenantRealm,
-      accessServiceUrl: env.accessServiceUrl,
-      directoryServiceUrl: env.directoryServiceUrl,
-    };
-  } else {
-    adsp = await getAdspConfiguration(host, options);
-  }
+  const adsp = await getAdspConfiguration(host, options);
 
   return {
     ...options,
@@ -224,11 +183,11 @@ export default async function (host: Tree, options: Schema) {
   // Record the database as a project tag so the nx-oc sandbox generator can
   // wire DATABASE_URL + the migrate init container without a --database flag.
   const dbTag = `adsp:database:${normalizedOptions.database}`;
-  const tags =
-    normalizedOptions.database !== 'none' &&
-    !(projectConfig.tags ?? []).includes(dbTag)
-      ? [...(projectConfig.tags ?? []), dbTag]
-      : projectConfig.tags;
+  const newTags = [
+    ...(normalizedOptions.database !== 'none' ? [dbTag] : []),
+    ...adspProjectTags(normalizedOptions.env, normalizedOptions.adsp.tenant),
+  ].filter((tag) => !(projectConfig.tags ?? []).includes(tag));
+  const tags = [...(projectConfig.tags ?? []), ...newTags];
 
   updateProjectConfiguration(host, normalizedOptions.projectName, {
     ...projectConfig,

--- a/packages/nx-adsp/src/generators/mean/mean.spec.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.spec.ts
@@ -18,6 +18,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.deploymentGenerator.mockResolvedValue(undefined);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 

--- a/packages/nx-adsp/src/generators/mern/mern.spec.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.spec.ts
@@ -19,6 +19,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 
 describe('MERN Generator', () => {

--- a/packages/nx-adsp/src/generators/mevn/mevn.spec.ts
+++ b/packages/nx-adsp/src/generators/mevn/mevn.spec.ts
@@ -19,6 +19,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 
 describe('MEVN Generator', () => {

--- a/packages/nx-adsp/src/generators/pean/pean.spec.ts
+++ b/packages/nx-adsp/src/generators/pean/pean.spec.ts
@@ -19,6 +19,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 
 describe('PEAN Generator', () => {

--- a/packages/nx-adsp/src/generators/pern/pern.spec.ts
+++ b/packages/nx-adsp/src/generators/pern/pern.spec.ts
@@ -19,6 +19,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 
 describe('PERN Generator', () => {

--- a/packages/nx-adsp/src/generators/pevn/pevn.spec.ts
+++ b/packages/nx-adsp/src/generators/pevn/pevn.spec.ts
@@ -19,6 +19,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 utilsMock.ensureAdspToken.mockResolvedValue('test-token');
 
 describe('PEVN Generator', () => {

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -14,6 +14,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 
 describe('React App Generator', () => {
   const options: Schema = {

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -1,4 +1,4 @@
-import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
+import { adspProjectTags, deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import { confirmAfterAgentInterrupt, consultAgent } from '../../utils/agent';
 import { ensureAudienceMapper, ensureClientRoleScope, ensurePublicClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
@@ -188,6 +188,13 @@ export default async function (host: Tree, options: Schema) {
       proxyConfig: `${normalizedOptions.projectRoot}/proxy.conf.json`,
     };
   }
+
+  config.tags = [
+    ...(config.tags ?? []),
+    ...adspProjectTags(normalizedOptions.env, normalizedOptions.adsp.tenant).filter(
+      (tag) => !(config.tags ?? []).includes(tag)
+    ),
+  ];
 
   updateProjectConfiguration(host, options.name, config);
 

--- a/packages/nx-adsp/src/generators/react-dotnet/react-dotnet.spec.ts
+++ b/packages/nx-adsp/src/generators/react-dotnet/react-dotnet.spec.ts
@@ -15,6 +15,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 
 jest.mock('../dotnet-service/dotnet-service');
 const serviceGeneratorMock = serviceGenerator as jest.Mocked<

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -23,6 +23,11 @@ utilsMock.getAdspConfiguration.mockResolvedValue({
   accessServiceUrl: environments.test.accessServiceUrl,
   directoryServiceUrl: environments.test.directoryServiceUrl,
 });
+// jest.mock('@abgov/nx-oc') automocks adspProjectTags too — restore the real
+// (pure, no I/O) implementation so tag-writing behavior is actually exercised.
+utilsMock.adspProjectTags.mockImplementation(
+  jest.requireActual('@abgov/nx-oc').adspProjectTags
+);
 
 describe('Vue App Generator', () => {
   let host: Tree;
@@ -47,6 +52,13 @@ describe('Vue App Generator', () => {
     expect(host.exists('apps/test/vite.config.mts')).toBeFalsy();
     // build output mirrors the workspace layout under the root dist/.
     expect(config.targets.build.options.outputPath).toBe('dist/apps/test');
+  }, 30000);
+
+  it('records the resolved env/tenant as project tags for the sandbox generator', async () => {
+    await generator(host, options);
+    const config = readProjectConfiguration(host, 'test');
+    expect(config.tags).toContain('adsp:scaffold-env:dev');
+    expect(config.tags).toContain('adsp:scaffold-tenant:test');
   }, 30000);
 
   it('scaffolds a Playwright e2e project (consistent across frontends)', async () => {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -1,4 +1,4 @@
-import { deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
+import { adspProjectTags, deploymentGenerator, getAdspConfiguration } from '@abgov/nx-oc';
 import { confirmAfterAgentInterrupt, consultAgent } from '../../utils/agent';
 import { ensureAudienceMapper, ensureClientRoleScope, ensurePublicClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
@@ -183,6 +183,13 @@ export default async function (host: Tree, options: Schema) {
       `adsp:proxy-service:${pairedService}:${port}`,
     ];
   }
+
+  config.tags = [
+    ...(config.tags ?? []),
+    ...adspProjectTags(normalizedOptions.env, normalizedOptions.adsp.tenant).filter(
+      (tag) => !(config.tags ?? []).includes(tag)
+    ),
+  ];
 
   updateProjectConfiguration(host, options.name, config);
 

--- a/packages/nx-oc/src/adsp/adsp-utils.spec.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.spec.ts
@@ -1,0 +1,44 @@
+import { adspProjectTags, detectAdspEnv, detectAdspTenant } from './adsp-utils';
+
+describe('adspProjectTags', () => {
+  it('always includes the env tag', () => {
+    expect(adspProjectTags('dev', undefined)).toEqual(['adsp:scaffold-env:dev']);
+  });
+
+  it('includes a tenant tag when given a tenant', () => {
+    expect(adspProjectTags('test', 'autotest')).toEqual([
+      'adsp:scaffold-env:test',
+      'adsp:scaffold-tenant:autotest',
+    ]);
+  });
+});
+
+describe('detectAdspEnv', () => {
+  it('finds the adsp:scaffold-env: tag among other tags', () => {
+    expect(detectAdspEnv(['adsp:database:postgres', 'adsp:scaffold-env:dev'])).toBe('dev');
+  });
+
+  it('returns undefined when no adsp:scaffold-env: tag is present', () => {
+    expect(detectAdspEnv(['adsp:database:postgres'])).toBeUndefined();
+  });
+
+  it('returns undefined for an undefined tags array', () => {
+    expect(detectAdspEnv(undefined)).toBeUndefined();
+  });
+});
+
+describe('detectAdspTenant', () => {
+  it('finds the adsp:scaffold-tenant: tag among other tags', () => {
+    expect(detectAdspTenant(['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:autotest'])).toBe(
+      'autotest'
+    );
+  });
+
+  it('returns undefined when no adsp:scaffold-tenant: tag is present', () => {
+    expect(detectAdspTenant([])).toBeUndefined();
+  });
+
+  it('returns undefined for an undefined tags array', () => {
+    expect(detectAdspTenant(undefined)).toBeUndefined();
+  });
+});

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -31,6 +31,41 @@ export function hasDependency(host: Tree, dependency: string): boolean {
 // everyone else, so requesting it is always safe.
 export const ADSP_ADMIN_SCOPE = 'adsp-cli-admin';
 
+const ADSP_ENV_TAG_PREFIX = 'adsp:scaffold-env:';
+const ADSP_TENANT_TAG_PREFIX = 'adsp:scaffold-tenant:';
+
+// App generators (express-service, vue-app, react-app, angular-app) record the
+// *single* env/tenant they were scaffolded against as project tags, mirroring
+// the existing adsp:database:*/adsp:proxy-service:* convention. This is only
+// meaningful for a generator with the same single-target shape — nx-oc:sandbox
+// reads it back via detectAdspEnv/detectAdspTenant so a personal sandbox
+// targets the same ADSP environment the app was actually scaffolded against,
+// instead of silently falling back to its own schema default.
+//
+// Deliberately NOT read by nx-oc:deployment/pipeline: a real deployment spans
+// multiple ADSP environments over its lifecycle (e.g. ADSP test for pre-prod,
+// ADSP prod for prod) that have nothing to do with which single env the
+// project happened to be generated against — deployment's own --env is
+// required per invocation for exactly this reason. Don't wire this tag into
+// that path; there's no single "the" env to default to.
+export function adspProjectTags(
+  env: EnvironmentName,
+  tenant: string | undefined
+): string[] {
+  const tags = [`${ADSP_ENV_TAG_PREFIX}${env}`];
+  if (tenant) tags.push(`${ADSP_TENANT_TAG_PREFIX}${tenant}`);
+  return tags;
+}
+
+export function detectAdspEnv(tags: string[] | undefined): EnvironmentName | undefined {
+  const tag = (tags ?? []).find((t) => t.startsWith(ADSP_ENV_TAG_PREFIX));
+  return tag ? (tag.slice(ADSP_ENV_TAG_PREFIX.length) as EnvironmentName) : undefined;
+}
+
+export function detectAdspTenant(tags: string[] | undefined): string | undefined {
+  const tag = (tags ?? []).find((t) => t.startsWith(ADSP_TENANT_TAG_PREFIX));
+  return tag ? tag.slice(ADSP_TENANT_TAG_PREFIX.length) : undefined;
+}
 
 /** Resolve the `adsp` binary shipped by the @abgov/adsp-cli dependency. */
 function adspCliBinPath(): string {

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -313,6 +313,65 @@ describe('Sandbox Generator', () => {
     });
   });
 
+  describe('env/tenant auto-detection (no --env/--tenant flag)', () => {
+    function addServiceProject(host, extra: Record<string, unknown> = {}) {
+      addProjectConfiguration(host, 'test', {
+        root: 'apps/test',
+        projectType: 'application',
+        targets: {
+          build: {
+            executor: '@nx/webpack:webpack',
+            options: { compiler: 'tsc', target: 'node' },
+          },
+        },
+        ...extra,
+      });
+    }
+
+    // A sandbox targeting a different ADSP environment than the app itself
+    // would resolve a mismatched tenant/token — defaulting to the app's own
+    // recorded env/tenant (not the generator's own schema default) avoids that.
+    it("defaults env/tenant to the target project's adsp:scaffold-env/adsp:scaffold-tenant tags", async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host, { tags: ['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:autotest'] });
+      utilsMock.detectAdspEnv.mockReturnValueOnce('dev');
+      utilsMock.detectAdspTenant.mockReturnValueOnce('autotest');
+
+      await generator(host, options); // options has no env/tenant
+
+      expect(utilsMock.getAdspConfiguration).toHaveBeenCalledWith(
+        host,
+        expect.objectContaining({ env: 'dev', tenant: 'autotest' })
+      );
+    });
+
+    it('falls back to test/undefined when no adsp:scaffold-env/adsp:scaffold-tenant tag is present', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host);
+
+      await generator(host, options);
+
+      expect(utilsMock.getAdspConfiguration).toHaveBeenCalledWith(
+        host,
+        expect.objectContaining({ env: 'test', tenant: undefined })
+      );
+    });
+
+    it('an explicit --env/--tenant overrides the recorded tags', async () => {
+      const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+      addServiceProject(host, { tags: ['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:autotest'] });
+      utilsMock.detectAdspEnv.mockReturnValueOnce('dev');
+      utilsMock.detectAdspTenant.mockReturnValueOnce('autotest');
+
+      await generator(host, { ...options, env: 'prod', tenant: 'other-tenant' });
+
+      expect(utilsMock.getAdspConfiguration).toHaveBeenCalledWith(
+        host,
+        expect.objectContaining({ env: 'prod', tenant: 'other-tenant' })
+      );
+    });
+  });
+
   it('registers the deployment Route redirect URI for a frontend client', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     addFrontendProject(host);

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -10,7 +10,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import * as path from 'path';
-import { getAdspConfiguration, addClientRedirectUris } from '../../adsp';
+import { getAdspConfiguration, addClientRedirectUris, detectAdspEnv, detectAdspTenant } from '../../adsp';
 import {
   getGitRemoteUrl,
   deriveRegistryFromRemote,
@@ -106,9 +106,17 @@ async function normalizeOptions(
   const config = readProjectConfiguration(host, projectName);
   const appType = options.appType ?? detectApplicationType(config);
 
+  // Default to whatever env/tenant the target project was actually scaffolded
+  // against (recorded as a tag by express-service/vue-app/react-app/angular-app)
+  // rather than silently assuming 'test' — a sandbox targeting a different ADSP
+  // environment than the app itself would resolve a mismatched tenant/token.
+  const env = (options.env as 'dev' | 'test' | 'prod' | undefined) ?? detectAdspEnv(config.tags) ?? 'test';
+  const tenant = options.tenant ?? detectAdspTenant(config.tags);
+
   const adsp = await getAdspConfiguration(host, {
     ...options,
-    env: (options.env as 'dev' | 'test' | 'prod') ?? 'dev',
+    env,
+    tenant,
   });
 
   const remoteUrl = getGitRemoteUrl();

--- a/packages/nx-oc/src/generators/sandbox/schema.json
+++ b/packages/nx-oc/src/generators/sandbox/schema.json
@@ -31,8 +31,7 @@
     },
     "env": {
       "type": "string",
-      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to test.",
-      "default": "test",
+      "description": "ADSP environment / access service to target: test = access-uat.alberta.ca (UAT — use for dev and pre-prod), prod = access.alberta.ca, dev = ADSP platform dev (restricted). Defaults to whatever env the target project was scaffolded against (recorded as an adsp:scaffold-env:* tag), then 'test' if that can't be determined.",
       "enum": ["test", "prod", "dev"]
     },
     "accessToken": {
@@ -42,7 +41,7 @@
     },
     "tenant": {
       "type": "string",
-      "description": "ADSP tenant name. Looks up the realm and does a single login, skipping the interactive tenant picker."
+      "description": "ADSP tenant name. Looks up the realm and does a single login, skipping the interactive tenant picker. Defaults to whatever tenant the target project was scaffolded against (recorded as an adsp:scaffold-tenant:* tag) when omitted."
     },
     "tenantRealm": {
       "type": "string",


### PR DESCRIPTION
## Summary
- Addresses `PEVN-SANDBOX-LIVE-RUN-FINDINGS.md` #1: `nx-oc:sandbox` defaulted `env` to `'test'` regardless of what env/tenant the target app was actually scaffolded with (`--env dev --tenant <t>`). A sandbox targeting a different ADSP environment than the app resolves a mismatched tenant/token — reproduced live as `Not signed in to ADSP` even after a real login for the app's own env.
- Added `adspProjectTags()` / `detectAdspEnv()` / `detectAdspTenant()` to nx-oc's shared `adsp-utils`, mirroring the existing `adsp:database:*`/`adsp:proxy-service:*` tag convention: app generators record the env/tenant they resolved as project tags, and `nx-oc:sandbox` reads them back as its default before falling back to `'test'`.
- Wired the write side into `express-service`, `vue-app`, `react-app`, and `angular-app` — the four generators that resolve ADSP config directly.
- Removed the sandbox generator schema's `env` default (`"test"`) so `options.env` can distinguish "not passed" (falls through to the tag/`'test'` chain) from an explicit `--env`, which always wins.

## Also fixed in the same pass
Friction spec #4: `express-service` had its own duplicated tenant-resolution branch that diverged from the shared `getAdspConfiguration` util — defaulting `env` to `'prod'` (not `'test'`, everywhere else's default), hitting a legacy/versionless tenant-service API path, and never populating `adsp.accessToken` (silently compensated for downstream via a `?? options.accessToken` fallback). Deleted the divergent branch entirely; `express-service` now delegates to `getAdspConfiguration` like the other three generators already do. Found while touching this exact code path for the primary fix above, not a separate ask.

## Verification
- New tests: `adsp-utils.spec.ts` (pure-function coverage for the three new helpers), a new `env/tenant auto-detection` describe block in `sandbox.spec.ts` (defaults from tags, falls back to `test`/`undefined`, explicit flags override), and a tag assertion in `vue-app.spec.ts`.
- Existing `jest.mock('@abgov/nx-oc')`/`jest.mock('../../adsp')` automocks silently replaced `adspProjectTags` with a `jest.fn()` returning `undefined` in every spec that calls it transitively (vue-app, react-app, angular-app, express-service, and the six combo generators that compose them) — wired `jest.requireActual(...).adspProjectTags` back in everywhere so real tag-writing behavior is exercised, not a no-op.
- `nx lint/test/build` pass for both `nx-oc` (121 tests) and `nx-adsp` (72 tests).

## Test plan
- [x] New `adsp-utils.spec.ts` covers `adspProjectTags`/`detectAdspEnv`/`detectAdspTenant`
- [x] New `sandbox.spec.ts` tests cover tag-based defaulting and explicit-flag override
- [x] `nx lint/test/build` pass for nx-oc and nx-adsp

🤖 Generated with [Claude Code](https://claude.com/claude-code)