### PR TITLE
feat(nx-adsp,nx-oc): bump @abgov/adsp-cli for interactive tenant creation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -63,7 +63,11 @@ Repeat for every environment project.
 
 ### ADSP tenant
 
-An existing ADSP tenant is required. The `pevn` generator provisions Keycloak clients and environment config against it. Have the tenant name ready.
+The `pevn` generator provisions Keycloak clients and environment config against an ADSP tenant.
+Have the tenant name ready if you already have one. If you don't, run `pevn` without `--tenant` and
+its interactive login flow offers **+ Create a new tenant** — available in `dev`/`test` (never
+`prod`) for eligible accounts; see [nx-adsp's Authentication section](https://github.com/GovAlta/nx-tools/blob/main/packages/nx-adsp/README.md#authentication)
+for the exact rules.
 
 > The generated public client allows local development (`http://localhost:4200/*`) out of the box. For **deployed** environments you must register each environment's Route URL with the client — see [Configure sign-in redirect URIs per environment](#configure-sign-in-redirect-uris-per-environment).
 

--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -342,7 +342,10 @@ Most generators call ADSP APIs during generation to retrieve tenant-specific con
 | `--tenantRealm <uuid>` | Use when you already know the realm UUID; can be combined with `--tenant` to override the auto-resolved realm |
 | `--accessToken <token>` | Use in CI or scripts to skip interactive login entirely |
 
-If none are provided, the generator will prompt interactively.
+If none are provided, the generator will prompt interactively. Don't have a tenant yet? That prompt
+also offers a **+ Create a new tenant** choice, in `dev`/`test` (never `prod`), for eligible
+accounts — see the [package README](https://github.com/GovAlta/nx-tools/blob/main/packages/nx-adsp/README.md#authentication)
+for the exact eligibility rules.
 
 ## Agent consultation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abgov/adsp-cli": "^1.1.1",
+        "@abgov/adsp-cli": "^1.5.2",
         "@angular/core": "21.2.17",
         "@nx/devkit": "23.0.1",
         "json-schema-to-typescript": "^13.0.1",
@@ -78,13 +78,14 @@
       }
     },
     "node_modules/@abgov/adsp-cli": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.1.1.tgz",
-      "integrity": "sha512-yovakZjCEJc+5F7CBp3AFkjm5uRchwEbZS7zJRL8+6mQXy1auEfccgE6O9nU2VTYCHXjD9YilPU21lCf19RbMA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.5.2.tgz",
+      "integrity": "sha512-O2VyNZBoCcSr+D82YsszKSg7M0kKAuj3SiJ2Hii+5XYhyqbk6bD0cPFFPDUKtwBiNvffgfCalGUDg9Lj0qbkUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.3.6",
         "express": "^4.22.1",
+        "jwt-decode": "^3.1.2",
         "open": "^8.4.0",
         "simple-oauth2": "^5.0.0",
         "tslib": "^2.3.0"
@@ -20631,6 +20632,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "license": "MIT"
     },
     "node_modules/karma-source-map-support": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "18.3.1",
     "react-is": "18.3.1",
     "socket.io-client": "^4.8.3",
-    "@abgov/adsp-cli": "^1.1.1"
+    "@abgov/adsp-cli": "^1.5.2"
   },
   "devDependencies": {
     "@abgov/nx-release": "^12.0.0",

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -224,7 +224,13 @@ Generator flags that steer which tenant/token is used:
 | `--tenantRealm <uuid>` | Use the realm UUID directly; combine with `--tenant` to override the resolved realm |
 | `--accessToken <token>` | Supply a pre-obtained token directly (CI/CD), bypassing the CLI |
 
-With none of these, the generator lets `adsp login`'s interactive picker resolve the tenant.
+With none of these, the generator lets `adsp login`'s interactive picker resolve the tenant. Don't
+have a tenant yet? That picker also offers a **+ Create a new tenant** choice — available in
+`dev`/`test` (never `prod`), for an account whose core-realm roles include `beta-tester` or
+`tenant-service-admin`, and (unless `tenant-service-admin`) that doesn't already own a tenant (one
+per admin email). Picking it prompts for a name and waits for the new realm to finish provisioning
+before continuing the login as that tenant. Requires `@abgov/adsp-cli` ^1.4.0+ (this plugin pins
+^1.5.2 or later).
 
 ## Agent consultation
 

--- a/packages/nx-oc/package.json
+++ b/packages/nx-oc/package.json
@@ -14,7 +14,7 @@
     "tslib": "^2.0.0"
   },
   "dependencies": {
-    "@abgov/adsp-cli": "^1.1.1",
+    "@abgov/adsp-cli": "^1.5.2",
     "axios": "^1.16.0",
     "enquirer": "^2.3.6",
     "yaml": "~2.9.0"


### PR DESCRIPTION
## Summary
- `@abgov/adsp-cli` added a **+ Create a new tenant** choice to the no-args `login` command's interactive tenant picker — available in `dev`/`test` (never `prod`), for accounts whose core-realm roles include `beta-tester` or `tenant-service-admin`, and (unless `tenant-service-admin`) that don't already own a tenant.
- Verified by extracting and diffing the published tarballs for every version 1.1.1 through 1.5.2: the feature's code first appears in **1.4.0**. `getAccessToken`/`getStatus` — the only two exports this repo's code actually calls — are byte-identical (`.d.ts`) across all of them, so this is a pure capability gain, no API surface change to account for.
- Bumped the pin from `^1.1.1` to `^1.5.2` in `package.json` (root) and `packages/nx-oc/package.json` (the two declared dependents), and updated `package-lock.json`.
- **No code changes needed beyond the version bump** — every generator that resolves ADSP config already calls the CLI's no-args interactive `login` when neither `--tenant` nor `--tenantRealm` is passed, so a user without an existing tenant now gets offered tenant creation inline, for free.
- Documented the new option in the three places that already describe "the generator lets `adsp login`'s interactive picker resolve the tenant": `packages/nx-adsp/README.md` (canonical location, with the exact eligibility rules), the docs site's `nx-adsp` page, and `docs/getting-started.md`'s "An existing ADSP tenant is required" line, which was no longer an accurate blanket statement.

## Verification
- Confirmed via `npm audit`: the vulnerability count (33: 4 moderate, 29 high) is unchanged before/after this bump — pre-existing, unrelated (traced to `@angular-devkit/build-angular`'s `webpack-dev-server` dependency), not introduced by this change.
- `nx lint/test/build` pass for both `nx-oc` and `nx-adsp`.

## Test plan
- [x] Confirmed the feature's code (not just README text) first appears in adsp-cli 1.4.0 by diffing extracted tarballs
- [x] Confirmed `getAccessToken`/`getStatus` type signatures are unchanged between 1.1.1 and 1.5.2
- [x] `nx lint/test/build` pass for nx-oc and nx-adsp
- [x] Confirmed the new vulnerability count is pre-existing, not caused by this bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)