### PR TITLE
feat(nx-adsp): add OpenAPI support to express-service, for ADSP doc aggregation

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -67,6 +67,8 @@ When `--database postgres` is selected the generator scaffolds a Drizzle setup �
 
 The generated `src/main.ts` includes `authorize`, `createValidationHandler`, and `createErrorHandler` from `@abgov/adsp-service-sdk`, and an example `POST /v1/example` route that shows the full pattern: role check → input validation (Zod schema) → domain event publish → error forwarding to `createErrorHandler`. Replace or remove the example route once you have real business logic.
 
+OpenAPI docs are generated from the same Zod schemas already used for request validation (`@asteasolutions/zod-to-openapi` — see `src/openapi.ts`) and served at `/swagger/docs/v1`, with a matching `docs` link on the root `/` endpoint. This is what ADSP's directory service polls to aggregate the service's API docs into `https://api.adsp.alberta.ca/{tenant}`, once the service has a directory entry (a one-time setup step, outside this generator).
+
 ```typescript
 // Pattern used in the generated example route — adapt for your routes:
 app.post(

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -107,6 +107,12 @@ npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 | `tenantRealm` | `-tr` | No | Keycloak realm UUID; overrides the realm resolved from `--tenant` |
 | `accessToken` | `-at` | No | Access token for non-interactive retrieval of ADSP configuration |
 
+OpenAPI docs are generated from the same Zod schemas already used for request validation
+(`@asteasolutions/zod-to-openapi`) and served at `/swagger/docs/v1` — no separate spec to
+hand-maintain. The root `/` endpoint's `_links.docs` points at it, which is what ADSP's directory
+service polls to aggregate the service's API docs into `https://api.adsp.alberta.ca/{tenant}` (once
+the service has a directory entry — a one-time setup step outside this generator).
+
 ---
 
 ### `react-app`

--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -44,6 +44,40 @@ describe('Express Service Generator', () => {
     expect(host.exists('apps/test/src/environments/environment.ts')).toBeFalsy();
   }, 60000);
 
+  it('serves generated OpenAPI docs, discoverable via the root _links convention', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    // Shared registry module: extends Zod once, exports the registry every
+    // router registers its paths into.
+    expect(host.exists('apps/test/src/openapi.ts')).toBeTruthy();
+    const openapiTs = host.read('apps/test/src/openapi.ts').toString();
+    expect(openapiTs).toContain('extendZodWithOpenApi');
+    expect(openapiTs).toContain('export const registry');
+
+    // main.ts builds the doc from the registry once at startup and serves it
+    // at the conventional path; the root endpoint's _links gains a docs entry
+    // pointing at it — this is what ADSP's directory service polls for.
+    const mainTs = host.read('apps/test/src/main.ts').toString();
+    expect(mainTs).toContain('OpenApiGeneratorV3');
+    expect(mainTs).toContain('/swagger/docs/v1');
+    expect(mainTs).toContain("docs: { href: new URL('/swagger/docs/v1', rootUrl).href }");
+    // Document-level default security — without it, routes with no explicit
+    // `security` override (e.g. /private) would inherit nothing at all,
+    // rather than the accessToken requirement they actually enforce.
+    expect(mainTs).toContain('security: [{ accessToken: [] }]');
+
+    // The shipped example router documents its own routes, reusing the same
+    // schema already passed to createValidationHandler (no separate spec).
+    const routerTs = host.read('apps/test/src/routes/example.ts').toString();
+    expect(routerTs).toContain('registry.registerPath');
+    expect(routerTs).toContain("import { registry } from '../openapi'");
+
+    // Runtime dependency (built at app startup), not a devDependency.
+    const pkgJson = readJson(host, 'package.json');
+    expect(pkgJson.dependencies['@asteasolutions/zod-to-openapi']).toBeTruthy();
+  }, 60000);
+
   it('wires the ADSP SDK MCP server into the workspace .mcp.json', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, options);

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -86,6 +86,7 @@ export default async function (host: Tree, options: Schema) {
     host,
     {
       '@abgov/adsp-service-sdk': '^2.23.0',
+      '@asteasolutions/zod-to-openapi': '^7.3.4',
       compression: '^1.8.1',
       cors: '^2.8.5',
       dotenv: '^16.4.7',

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -156,8 +156,28 @@ import { Router } from 'express';
 import { authorize, createValidationHandler } from '@abgov/adsp-service-sdk';
 import { z } from 'zod';
 import * as items from '../services/items';
+import { registry } from '../openapi';
 
 const CreateItem = z.object({ name: z.string().trim().min(1) });
+const BASE = '/<%= projectName %>/v1/items';
+
+// Reuses CreateItem — the same schema passed to createValidationHandler below
+// — so the served OpenAPI doc can't drift from what's actually validated. See
+// "Why this matters for ADSP" below.
+registry.registerPath({
+  method: 'get',
+  path: BASE,
+  summary: 'List items.',
+  security: [], // anonymous is allowed on the /v1 prefix — see the router below
+  responses: { 200: { description: 'The items.', content: { 'application/json': { schema: z.array(CreateItem) } } } },
+});
+registry.registerPath({
+  method: 'post',
+  path: BASE,
+  summary: 'Create an item.',
+  request: { body: { content: { 'application/json': { schema: CreateItem } } } },
+  responses: { 201: { description: 'The created item.', content: { 'application/json': { schema: CreateItem } } } },
+});
 
 export function itemsRouter(): Router {
   const router = Router();
@@ -211,6 +231,17 @@ app.use('/<%= projectName %>/v1/items', itemsRouter());
 `req.body` directly in the handler and assert its type (`req.body as
 z.infer<typeof Schema>`) — that's the raw, unparsed body, not the validated
 one; parse it again with the same schema instead, as above.
+
+### Why this matters for ADSP
+
+`main.ts`'s root `/` handler returns a `docs` link pointing at `/swagger/docs/v1`, which serves an
+OpenAPI document built at startup from every `registry.registerPath()` call across all mounted
+routers (see `src/openapi.ts`). ADSP's directory service polls each registered service's root
+endpoint and, when it finds that `docs` link, aggregates the spec into
+`https://api.adsp.alberta.ca/{tenant}` — so every route added here (following the pattern above)
+becomes part of the platform's aggregated API docs automatically, with no separate file to update.
+This requires the service to already have a directory entry — a one-time setup step outside this
+generator, done via the Tenant Management Webapp's directory admin UI.
 
 ## Recipe: add a resource end to end
 

--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -1,4 +1,5 @@
 import { AdspId, createErrorHandler, initializeService } from '@abgov/adsp-service-sdk';
+import { OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
@@ -12,6 +13,7 @@ import { connectDatabase, disconnectDatabase } from './database';
 <% } %>
 import { environment } from './environment';
 import { exampleEventDefinition } from './events';
+import { registry } from './openapi';
 import { exampleRouter } from './routes/example';
 
 async function initializeApp() {
@@ -57,6 +59,26 @@ async function initializeApp() {
     res.json({ ...platform });
   });
 
+  // Generated once from the routers' registry.registerPath() calls (see
+  // routes/example.ts) — every router imported above has already registered
+  // its paths by the time this runs. Served statically; ADSP's directory
+  // service polls the `docs` link below to aggregate this into
+  // https://api.adsp.alberta.ca/{tenant} (see AGENTS.md's "Why this matters
+  // for ADSP" — requires the service to have a directory entry, set up
+  // separately from this generator).
+  const openApiDoc = new OpenApiGeneratorV3(registry.definitions).generateDocument({
+    openapi: '3.0.0',
+    info: { title: '<%= projectName %>', version: '0.0.0' },
+    // Document-level default — an operation with no security override (e.g.
+    // /private, /example in routes/example.ts) inherits this; a route that's
+    // actually anonymous-accessible must set `security: []` explicitly, as
+    // the shipped example's index and /public routes do.
+    security: [{ accessToken: [] }],
+  });
+  app.get('/swagger/docs/v1', (_req, res) => {
+    res.json(openApiDoc);
+  });
+
   app.get('/', (req, res) => {
     const rootUrl = new URL(`${req.protocol}://${req.get('host')}`);
     res.json({
@@ -64,6 +86,7 @@ async function initializeApp() {
         self: { href: new URL(req.originalUrl, rootUrl).href },
         health: { href: new URL('/health', rootUrl).href },
         api: { href: new URL('/<%= projectName %>/v1', rootUrl).href },
+        docs: { href: new URL('/swagger/docs/v1', rootUrl).href },
       },
     });
   });

--- a/packages/nx-adsp/src/generators/express-service/files/src/openapi.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/openapi.ts__tmpl__
@@ -1,0 +1,19 @@
+import { extendZodWithOpenApi, OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+// Extends Zod schemas with a .openapi() method — must run before any schema
+// calls it, which route modules importing `registry` from here already
+// guarantee (Node evaluates this module's body once, on first import).
+extendZodWithOpenApi(z);
+
+// Shared across every route module: each router registers its own paths here,
+// re-using the same Zod schemas already passed to createValidationHandler —
+// one source of truth for validation and API docs, no separate spec to
+// hand-maintain. main.ts generates the served document from this registry.
+export const registry = new OpenAPIRegistry();
+
+registry.registerComponent('securitySchemes', 'accessToken', {
+  type: 'http',
+  scheme: 'bearer',
+  bearerFormat: 'JWT',
+});

--- a/packages/nx-adsp/src/generators/express-service/files/src/routes/example.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/routes/example.ts__tmpl__
@@ -3,9 +3,82 @@ import { Router } from 'express';
 import passport from 'passport';
 import { z } from 'zod';
 import { createExampleEvent } from '../events';
+import { registry } from '../openapi';
 
 const ExampleRequestSchema = z.object({
   id: z.string().min(1),
+});
+
+const IndexResponseSchema = z.object({
+  _links: z.object({
+    self: z.object({ href: z.string() }),
+    public: z.object({ href: z.string() }),
+    private: z.object({ href: z.string() }),
+  }),
+});
+
+const MessageResponseSchema = z.object({ message: z.string() });
+
+const BASE = '/<%= projectName %>/v1';
+
+// One registry.registerPath() per route, reusing the same schemas passed to
+// createValidationHandler below — this keeps the served OpenAPI doc (see
+// AGENTS.md's "Why this matters for ADSP") in sync with actual validation
+// automatically. The mount in main.ts applies tenant-or-anonymous auth to
+// every route here; /private and /example additionally require a real
+// tenant user, so only the index and /public get an explicit `security: []`
+// override.
+registry.registerPath({
+  method: 'get',
+  path: BASE,
+  summary: 'Resource index for the example API.',
+  security: [],
+  responses: {
+    200: {
+      description: 'Hypermedia links to this resource\'s routes.',
+      content: { 'application/json': { schema: IndexResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: `${BASE}/public`,
+  summary: 'Public endpoint — no authentication required.',
+  security: [],
+  responses: {
+    200: {
+      description: 'A greeting message.',
+      content: { 'application/json': { schema: MessageResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'get',
+  path: `${BASE}/private`,
+  summary: 'Private endpoint — requires an authenticated tenant user.',
+  responses: {
+    200: {
+      description: 'A greeting message with the caller\'s name.',
+      content: { 'application/json': { schema: MessageResponseSchema } },
+    },
+  },
+});
+
+registry.registerPath({
+  method: 'post',
+  path: `${BASE}/example`,
+  summary: 'Protected route demonstrating authorize, validation, and a domain event.',
+  request: {
+    body: { content: { 'application/json': { schema: ExampleRequestSchema } } },
+  },
+  responses: {
+    200: {
+      description: 'The submitted id, echoed back.',
+      content: { 'application/json': { schema: ExampleRequestSchema } },
+    },
+  },
 });
 
 // Thin HTTP handlers for the example resource, grouped in an express.Router().


### PR DESCRIPTION
## Summary
- ADSP's directory service aggregates each registered service's API docs into `https://api.adsp.alberta.ca/{tenant}` by polling the service's root `/` endpoint for a `_links.docs.href` pointing at a real OpenAPI document. `express-service` had zero wiring for this.
- Uses `@asteasolutions/zod-to-openapi` (not the legacy `swagger-jsdoc-webpack-plugin` + hand-written `.swagger.yml` convention every hand-built ADSP Node service uses) — generates the OpenAPI document directly from the same Zod schemas already passed to `createValidationHandler`, so there's one source of truth and no YAML files or webpack build step.
- **Pinned to `@asteasolutions/zod-to-openapi@7.3.4`, not the current `9.x`**: `@abgov/adsp-service-sdk`'s `createValidationHandler` is typed against Zod v3's `ZodSchema` (it bundles `"zod": "^3.25.76"` itself), and `9.x` requires Zod v4 as a peer — bumping is blocked upstream, not a judgment call.
- `src/openapi.ts` (new): `extendZodWithOpenApi` + a shared `OpenAPIRegistry`, with the `accessToken` bearer security scheme registered once.
- `routes/example.ts`: registers all four example paths via `registry.registerPath()`, reusing the existing validation schema; the anonymous-allowed routes get an explicit `security: []` override.
- `main.ts`: builds the document once at startup and serves it at `/swagger/docs/v1`; adds the matching `docs` link to the root `_links`.
- `AGENTS.md`: "Adding routes" now shows `registerPath` alongside the existing validation pattern, plus a short "Why this matters for ADSP" section.

## Verification
- Found and fixed a real bug via a scratch run against the actual installed package: without a document-level default `security`, routes with no per-path override (like `/private`) inherited **no** security requirement at all rather than the `accessToken` requirement they actually enforce. Added `security: [{ accessToken: [] }]` at the document level; public routes keep their explicit `security: []` override.
- Type-checked the full resolved `main.ts`/`openapi.ts`/`routes/example.ts`/`events.ts`/`environment.ts` against the real, installed `@asteasolutions/zod-to-openapi@7.3.4` and `@abgov/adsp-service-sdk` type declarations — zero errors.
- Ran a real Express server serving the actual generated routes and curled both endpoints: `GET /` returns a `docs` link that resolves; `GET /swagger/docs/v1` returns a document with a top-level `openapi` key, all four expected paths, and correct security inheritance.
- `nx lint/test/build` pass for `nx-adsp` (74 tests).

## Scope note
Implementing the `docs` link is necessary but not sufficient for a service to actually appear in the aggregator — directory-service only polls hosts it already has a registered entry for. Auto-registering that entry (a real API exists for it, with an exact existing precedent in `nx-oc`'s `sandbox` generator) is a deliberate, separate follow-up — different package, different generator, not part of this PR.

## Test plan
- [x] `nx lint/test/build nx-adsp` pass
- [x] Real scratch-workspace type-check against installed dependencies (zero errors)
- [x] Real HTTP verification: `/` → `docs` link resolves; `/swagger/docs/v1` → valid OpenAPI document with correct security semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)