### PR TITLE
feat(nx-agent): add bounded-context and domain-model artifacts

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -165,11 +165,11 @@ glossary" generator; `domain-term` composes it as an internal step.
 
 ### `domain-term` options
 
-| Option            | Default                  | Description                                                                                                                                            |
-| ----------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `term`            | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                    |
-| `project`         | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — use when a bounded context spans a domain library and its consuming apps |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                         |
+| Option                 | Default                  | Description                                                                                                                                                                                                |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `term`                 | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                                                                        |
+| `project`              | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — prefer this whenever the term already has a natural code home (usually a domain library), not just workspace root by default |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                                                                        |
 
 ```bash
 npx nx g @abgov/nx-agent:domain-term Case --project=domain-lib
@@ -179,6 +179,78 @@ npx nx g @abgov/nx-agent:domain-term "Collision Report" --project-docs-ancestors
 Re-adding a term that already exists throws rather than silently overwriting or duplicating it —
 edit the file directly instead. A `--project-docs-ancestors` path that doesn't resolve to an existing
 artifact throws the same way, before anything is written.
+
+---
+
+## `bounded-context`
+
+A domain term's meaning only holds within a bounded context — the boundary past which the same word
+can mean something else entirely. Adds one:
+
+```bash
+npx nx g @abgov/nx-agent:bounded-context "Collision Reporting"
+```
+
+Creates `project-docs/bounded-contexts/collision-reporting.md`:
+
+```markdown
+---
+name: Collision Reporting
+aliases: []
+not_confused_with: []
+---
+
+<!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->
+```
+
+### `bounded-context` options
+
+| Option    | Default                  | Description                                                                                                                                                                                                          |
+| --------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`    | — (required, positional) | The canonical name of the bounded context                                                                                                                                                                            |
+| `project` | workspace root           | Scope the context to a specific project's `project-docs/bounded-contexts/` instead — prefer this whenever the context already has a natural code home (usually a domain library), not just workspace root by default |
+
+```bash
+npx nx g @abgov/nx-agent:bounded-context "Collision Reporting" --project=domain-lib
+```
+
+Re-adding a context that already exists throws rather than silently overwriting or duplicating it.
+
+---
+
+## `domain-model`
+
+The actual design — aggregates, entities, invariants — built from a bounded context and the domain
+terms it's composed from:
+
+```bash
+npx nx g @abgov/nx-agent:domain-model "Collision Report Lifecycle" \
+  --project-docs-ancestors=project-docs/bounded-contexts/collision-reporting.md \
+  --project-docs-ancestors=project-docs/domain-terms/collision-report.md
+```
+
+Creates `project-docs/domain-models/collision-report-lifecycle.md`:
+
+```markdown
+---
+name: Collision Report Lifecycle
+project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]
+---
+
+<!-- Design: describe the aggregates, entities, value objects, and invariants here. -->
+```
+
+### `domain-model` options
+
+| Option                 | Default                  | Description                                                                                                                                                                                                   |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | — (required, positional) | The canonical name of the domain model                                                                                                                                                                        |
+| `project`              | workspace root           | Scope the model to a specific project's `project-docs/domain-models/` instead — prefer this whenever the model already has a natural code home (usually a domain library), not just workspace root by default |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this model derives from — repeatable; normally the bounded context it belongs to plus the domain terms it's composed from                                         |
+
+Re-adding a model that already exists throws rather than silently overwriting or duplicating it. A
+`--project-docs-ancestors` path that doesn't resolve to an existing artifact throws the same way,
+before anything is written.
 
 ---
 
@@ -209,6 +281,25 @@ project, so a reference's meaning never depends on where it's found.
 
 Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself (or `--dry-run`
 it in your own CI) after adding or changing a reference.
+
+### `project-docs/artifact-schema.json`
+
+An artifact-producing generator (`domain-term`, `bounded-context`, `domain-model`) self-registers its
+own entry here on first use, declaring what ancestor type its kind normally expects — e.g.
+`domain-terms` expects a `bounded-contexts` ancestor:
+
+```json
+{
+  "bounded-contexts": { "expectedAncestorTypes": [] },
+  "domain-terms": { "expectedAncestorTypes": ["bounded-contexts"] },
+  "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] }
+}
+```
+
+`project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
+a hand-added entry for a custom artifact kind gets the same check for free. An artifact whose type has
+an entry here but no ancestor of an expected type is reported (not thrown, since this is a convention
+nudge rather than a hard rule) as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 
 ### Programmatic access
 

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -140,11 +140,11 @@ glossary" generator; `domain-term` composes it as an internal step.
 
 ### Options
 
-| Option            | Default                  | Description                                                                                                                                            |
-| ----------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `term`            | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                    |
-| `project`         | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — use when a bounded context spans a domain library and its consuming apps |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                         |
+| Option                 | Default                  | Description                                                                                                                                                                                                |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `term`                 | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                                                                        |
+| `project`              | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — prefer this whenever the term already has a natural code home (usually a domain library), not just workspace root by default |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                                                                        |
 
 ```bash
 npx nx g @abgov/nx-agent:domain-term Case --project=domain-lib
@@ -154,6 +154,74 @@ npx nx g @abgov/nx-agent:domain-term "Collision Report" --project-docs-ancestors
 Re-adding a term that already exists throws rather than silently overwriting or duplicating it —
 edit the file directly instead. A `--project-docs-ancestors` path that doesn't resolve to an existing
 artifact throws the same way, before anything is written.
+
+## `bounded-context`
+
+A domain term's meaning only holds within a bounded context — the boundary past which the same word
+can mean something else entirely. Adds one:
+
+```bash
+npx nx g @abgov/nx-agent:bounded-context "Collision Reporting"
+```
+
+Creates `project-docs/bounded-contexts/collision-reporting.md`:
+
+```markdown
+---
+name: Collision Reporting
+aliases: []
+not_confused_with: []
+---
+
+<!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->
+```
+
+### Options
+
+| Option    | Default                  | Description                                                                                                                                                                                                          |
+| --------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`    | — (required, positional) | The canonical name of the bounded context                                                                                                                                                                            |
+| `project` | workspace root           | Scope the context to a specific project's `project-docs/bounded-contexts/` instead — prefer this whenever the context already has a natural code home (usually a domain library), not just workspace root by default |
+
+```bash
+npx nx g @abgov/nx-agent:bounded-context "Collision Reporting" --project=domain-lib
+```
+
+Re-adding a context that already exists throws rather than silently overwriting or duplicating it.
+
+## `domain-model`
+
+The actual design — aggregates, entities, invariants — built from a bounded context and the domain
+terms it's composed from:
+
+```bash
+npx nx g @abgov/nx-agent:domain-model "Collision Report Lifecycle" \
+  --project-docs-ancestors=project-docs/bounded-contexts/collision-reporting.md \
+  --project-docs-ancestors=project-docs/domain-terms/collision-report.md
+```
+
+Creates `project-docs/domain-models/collision-report-lifecycle.md`:
+
+```markdown
+---
+name: Collision Report Lifecycle
+project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]
+---
+
+<!-- Design: describe the aggregates, entities, value objects, and invariants here. -->
+```
+
+### Options
+
+| Option                 | Default                  | Description                                                                                                                                                                                                   |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | — (required, positional) | The canonical name of the domain model                                                                                                                                                                        |
+| `project`              | workspace root           | Scope the model to a specific project's `project-docs/domain-models/` instead — prefer this whenever the model already has a natural code home (usually a domain library), not just workspace root by default |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this model derives from — repeatable; normally the bounded context it belongs to plus the domain terms it's composed from                                         |
+
+Re-adding a model that already exists throws rather than silently overwriting or duplicating it. A
+`--project-docs-ancestors` path that doesn't resolve to an existing artifact throws the same way,
+before anything is written.
 
 ## `project-docs-lineage`
 
@@ -182,6 +250,25 @@ project, so a reference's meaning never depends on where it's found.
 
 Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself (or `--dry-run`
 it in your own CI) after adding or changing a reference.
+
+### `project-docs/artifact-schema.json`
+
+An artifact-producing generator (`domain-term`, `bounded-context`, `domain-model`) self-registers its
+own entry here on first use, declaring what ancestor type its kind normally expects — e.g.
+`domain-terms` expects a `bounded-contexts` ancestor:
+
+```json
+{
+  "bounded-contexts": { "expectedAncestorTypes": [] },
+  "domain-terms": { "expectedAncestorTypes": ["bounded-contexts"] },
+  "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] }
+}
+```
+
+`project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
+a hand-added entry for a custom artifact kind gets the same check for free. An artifact whose type has
+an entry here but no ancestor of an expected type is reported (not thrown, since this is a convention
+nudge rather than a hard rule) as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 
 ### Programmatic access
 

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -13,6 +13,16 @@
       "schema": "./src/generators/domain-term/schema.json",
       "description": "Adds one domain term under project-docs/domain-terms/, with structured frontmatter and a free-text definition."
     },
+    "bounded-context": {
+      "factory": "./src/generators/bounded-context/bounded-context",
+      "schema": "./src/generators/bounded-context/schema.json",
+      "description": "Adds one bounded context under project-docs/bounded-contexts/, with structured frontmatter and a free-text boundary description."
+    },
+    "domain-model": {
+      "factory": "./src/generators/domain-model/domain-model",
+      "schema": "./src/generators/domain-model/schema.json",
+      "description": "Adds one domain model under project-docs/domain-models/, with a project-docs-ancestors frontmatter list and a free-text design body."
+    },
     "project-docs-lineage": {
       "factory": "./src/generators/project-docs-lineage/project-docs-lineage",
       "schema": "./src/generators/project-docs-lineage/schema.json",

--- a/packages/nx-agent/src/generators/bounded-context/README.template.md
+++ b/packages/nx-agent/src/generators/bounded-context/README.template.md
@@ -1,0 +1,31 @@
+# Bounded contexts
+
+The boundaries within which this project's domain vocabulary and model apply — the same word can
+mean something different once you cross into another context, so keeping each one's boundary
+explicit is what keeps a domain term's meaning unambiguous.{{SHARED_CONTEXT_NOTE}} One file per
+context, so listing this folder (cheap — just filenames) is enough to see the whole map before
+adding a new one.
+
+Add a context with `nx g @abgov/nx-agent:bounded-context <name>` — don't hand-author files here, so
+the frontmatter shape stays consistent. Each file:
+
+    ---
+    name: Collision Reporting
+    aliases: []
+    not_confused_with:
+      - term: Case Management
+        reason: Case Management spans multiple contexts; Collision Reporting is one narrow slice of it.
+    ---
+
+    Everything from intake of a collision report through its initial triage. Excludes the
+    downstream investigation and resolution workflow, which belongs to Case Management.
+
+- `name` — the canonical name, matching the filename.
+- `aliases` — other words or abbreviations that mean the _same_ context.
+- `not_confused_with` — similarly-named contexts this one is deliberately distinct from, and why.
+  Leave it empty if there's no real ambiguity to guard against.
+
+The body is free text — describe what's inside the boundary and, just as importantly, what's
+explicitly outside it and belongs to a different context instead. A domain term
+(`nx g @abgov/nx-agent:domain-term ... --project-docs-ancestors <this-file>`) should normally derive
+from the bounded context its meaning depends on.

--- a/packages/nx-agent/src/generators/bounded-context/bounded-context.spec.ts
+++ b/packages/nx-agent/src/generators/bounded-context/bounded-context.spec.ts
@@ -1,0 +1,137 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
+import generator from './bounded-context';
+
+describe('nx-agent bounded-context generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('creates the context file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { name: 'Collision Reporting' });
+
+    const content = host
+      .read('project-docs/bounded-contexts/collision-reporting.md')
+      .toString();
+    expect(content).toContain('name: Collision Reporting');
+    expect(content).toContain('aliases: []');
+    expect(content).toContain('not_confused_with: []');
+  });
+
+  it('derives the filename slug from a multi-word name', async () => {
+    await generator(host, { name: 'Collision Reporting' });
+
+    expect(
+      host.exists('project-docs/bounded-contexts/collision-reporting.md'),
+    ).toBe(true);
+  });
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { name: 'Collision Reporting' });
+
+    const readme = host
+      .read('project-docs/bounded-contexts/README.md')
+      .toString();
+    expect(readme).toContain('# Bounded contexts');
+    expect(readme).toContain('nx g @abgov/nx-agent:bounded-context');
+  });
+
+  it('does not duplicate or alter the README when a second, different context is added', async () => {
+    await generator(host, { name: 'Collision Reporting' });
+    const readmeBefore = host
+      .read('project-docs/bounded-contexts/README.md')
+      .toString();
+
+    await generator(host, { name: 'Case Management' });
+
+    const readmeAfter = host
+      .read('project-docs/bounded-contexts/README.md')
+      .toString();
+    expect(readmeAfter).toBe(readmeBefore);
+    expect(
+      host.exists('project-docs/bounded-contexts/collision-reporting.md'),
+    ).toBe(true);
+    expect(
+      host.exists('project-docs/bounded-contexts/case-management.md'),
+    ).toBe(true);
+  });
+
+  it('throws and makes no changes when the context file already exists', async () => {
+    await generator(host, { name: 'Collision Reporting' });
+    const before = host
+      .read('project-docs/bounded-contexts/collision-reporting.md')
+      .toString();
+
+    await expect(
+      generator(host, { name: 'Collision Reporting' }),
+    ).rejects.toThrow(/already exists/);
+
+    expect(
+      host
+        .read('project-docs/bounded-contexts/collision-reporting.md')
+        .toString(),
+    ).toBe(before);
+  });
+
+  it('scopes the context file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      name: 'Collision Reporting',
+      project: 'domain-lib',
+    });
+
+    expect(
+      host.exists(
+        'libs/domain-lib/project-docs/bounded-contexts/collision-reporting.md',
+      ),
+    ).toBe(true);
+    expect(
+      host.exists('project-docs/bounded-contexts/collision-reporting.md'),
+    ).toBe(false);
+  });
+
+  it('adds the shared-context note to the README only when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      name: 'Collision Reporting',
+      project: 'domain-lib',
+    });
+
+    const scopedReadme = host
+      .read('libs/domain-lib/project-docs/bounded-contexts/README.md')
+      .toString();
+    expect(scopedReadme).toContain(
+      'shared by every project that depends on this library',
+    );
+
+    await generator(host, { name: 'Case Management' });
+
+    const rootReadme = host
+      .read('project-docs/bounded-contexts/README.md')
+      .toString();
+    expect(rootReadme).not.toContain(
+      'shared by every project that depends on this library',
+    );
+  });
+
+  it('registers its own artifact-schema entry with no expected ancestor types', async () => {
+    await generator(host, { name: 'Collision Reporting' });
+
+    expect(readArtifactSchema(host)).toEqual({
+      'bounded-contexts': { expectedAncestorTypes: [] },
+    });
+  });
+});

--- a/packages/nx-agent/src/generators/bounded-context/bounded-context.ts
+++ b/packages/nx-agent/src/generators/bounded-context/bounded-context.ts
@@ -1,0 +1,69 @@
+import {
+  Tree,
+  formatFiles,
+  joinPathFragments,
+  names,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
+import { ensureReadme } from '../../utils/readme';
+import { Schema } from './schema';
+
+const BOUNDED_CONTEXTS_SUBDIR = 'project-docs/bounded-contexts';
+const README_TEMPLATE_PATH = join(__dirname, 'README.template.md');
+
+function resolveTargetRoot(host: Tree, project?: string): string {
+  return project ? readProjectConfiguration(host, project).root : '.';
+}
+
+// The container has no standalone value on its own (its README only exists to
+// explain the convention for the context about to be added), so this is an
+// internal step composed by bounded-context rather than its own generator.
+function ensureContainerReadme(
+  host: Tree,
+  containerDir: string,
+  scoped: boolean,
+): void {
+  const sharedNote = scoped
+    ? ' This is shared by every project that depends on this library — keep the boundary consistent across the service and its consumers rather than letting each drift toward its own interpretation.'
+    : '';
+  const content = readFileSync(README_TEMPLATE_PATH, 'utf-8')
+    .split('{{SHARED_CONTEXT_NOTE}}')
+    .join(sharedNote);
+  ensureReadme(host, containerDir, content);
+}
+
+export default async function (host: Tree, options: Schema) {
+  const targetRoot = resolveTargetRoot(host, options.project);
+  const containerDir = joinPathFragments(targetRoot, BOUNDED_CONTEXTS_SUBDIR);
+  const slug = names(options.name).fileName;
+  const contextPath = joinPathFragments(containerDir, `${slug}.md`);
+
+  // A repeat/typo'd invocation should fail loudly rather than silently
+  // clobbering or duplicating a context — same posture as domain-term.
+  // Checked before any write so a failing run has no side effects.
+  if (host.exists(contextPath)) {
+    throw new Error(
+      `[nx-agent] ${contextPath} already exists — edit it directly rather than regenerating it.`,
+    );
+  }
+
+  ensureContainerReadme(host, containerDir, !!options.project);
+  ensureArtifactSchemaEntry(host, 'bounded-contexts', []);
+
+  const content = [
+    '---',
+    `name: ${options.name}`,
+    'aliases: []',
+    'not_confused_with: []',
+    '---',
+    '',
+    "<!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->",
+    '',
+  ].join('\n');
+  host.write(contextPath, content);
+
+  await formatFiles(host);
+}

--- a/packages/nx-agent/src/generators/bounded-context/schema.d.ts
+++ b/packages/nx-agent/src/generators/bounded-context/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  name: string;
+  project?: string;
+}

--- a/packages/nx-agent/src/generators/bounded-context/schema.json
+++ b/packages/nx-agent/src/generators/bounded-context/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentBoundedContext",
+  "title": "Add a bounded context",
+  "description": "Creates one file for a bounded context under project-docs/bounded-contexts/, with structured frontmatter (aliases, disambiguation) and a free-text boundary description. Bootstraps the bounded-contexts/README.md convention doc on first use.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The canonical name of the bounded context (e.g. \"Collision Reporting\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What is the bounded context called?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this bounded context to a specific project's project-docs/bounded-contexts/ instead of the workspace root — prefer this whenever the context already has a natural code home (most often a domain library other projects depend on); only use the workspace root when it genuinely doesn't have one."
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/domain-model/README.template.md
+++ b/packages/nx-agent/src/generators/domain-model/README.template.md
@@ -1,0 +1,26 @@
+# Domain models
+
+The actual design — aggregates, entities, value objects, invariants — built from the vocabulary and
+boundaries this project has already established.{{SHARED_CONTEXT_NOTE}} One file per model, so
+listing this folder (cheap — just filenames) is enough to see what's been designed before adding to
+it.
+
+Add a model with `nx g @abgov/nx-agent:domain-model <name> --project-docs-ancestors <path> ...` —
+don't hand-author files here, so the frontmatter shape stays consistent. Each file:
+
+    ---
+    name: Collision Report Lifecycle
+    project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]
+    ---
+
+    A CollisionReport aggregate, keyed by its report id, moving through Intake -> Triage ->
+    Closed. Triage requires an assigned reviewer; Closed requires a resolution code.
+
+- `name` — the canonical name, matching the filename.
+- `project-docs-ancestors` — the bounded context this model belongs to and the domain terms it's
+  composed from. Set with `--project-docs-ancestors <path>` at creation time, not by hand — see
+  `nx g @abgov/nx-agent:project-docs-lineage`'s own guidance for the full reference convention.
+
+The body is free text — the actual design. Keep it current: when the model changes (a new
+invariant, a renamed aggregate), update its file rather than letting the answer live only in the
+code that happens to implement it today.

--- a/packages/nx-agent/src/generators/domain-model/domain-model.spec.ts
+++ b/packages/nx-agent/src/generators/domain-model/domain-model.spec.ts
@@ -1,0 +1,154 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
+import generator from './domain-model';
+
+describe('nx-agent domain-model generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('creates the model file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { name: 'Collision Report Lifecycle' });
+
+    const content = host
+      .read('project-docs/domain-models/collision-report-lifecycle.md')
+      .toString();
+    expect(content).toContain('name: Collision Report Lifecycle');
+    expect(content).toContain('project-docs-ancestors: []');
+  });
+
+  it('resolves --project-docs-ancestors paths into the canonical reference and writes them', async () => {
+    host.write(
+      'project-docs/bounded-contexts/collision-reporting.md',
+      ['---', 'name: Collision Reporting', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      ['---', 'term: Collision Report', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      name: 'Collision Report Lifecycle',
+      projectDocsAncestors: [
+        'project-docs/bounded-contexts/collision-reporting.md',
+        'project-docs/domain-terms/collision-report.md',
+      ],
+    });
+
+    const content = host
+      .read('project-docs/domain-models/collision-report-lifecycle.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]',
+    );
+  });
+
+  it('throws and makes no changes when a --project-docs-ancestors path does not resolve', async () => {
+    await expect(
+      generator(host, {
+        name: 'Collision Report Lifecycle',
+        projectDocsAncestors: ['project-docs/bounded-contexts/nope.md'],
+      }),
+    ).rejects.toThrow(/not found/);
+
+    expect(
+      host.exists(
+        'project-docs/domain-models/collision-report-lifecycle.md',
+      ),
+    ).toBe(false);
+    expect(host.exists('project-docs/domain-models/README.md')).toBe(false);
+  });
+
+  it('throws and makes no changes when the model file already exists', async () => {
+    await generator(host, { name: 'Collision Report Lifecycle' });
+    const before = host
+      .read('project-docs/domain-models/collision-report-lifecycle.md')
+      .toString();
+
+    await expect(
+      generator(host, { name: 'Collision Report Lifecycle' }),
+    ).rejects.toThrow(/already exists/);
+
+    expect(
+      host
+        .read('project-docs/domain-models/collision-report-lifecycle.md')
+        .toString(),
+    ).toBe(before);
+  });
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { name: 'Collision Report Lifecycle' });
+
+    const readme = host
+      .read('project-docs/domain-models/README.md')
+      .toString();
+    expect(readme).toContain('# Domain models');
+    expect(readme).toContain('nx g @abgov/nx-agent:domain-model');
+  });
+
+  it('scopes the model file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      name: 'Collision Report Lifecycle',
+      project: 'domain-lib',
+    });
+
+    expect(
+      host.exists(
+        'libs/domain-lib/project-docs/domain-models/collision-report-lifecycle.md',
+      ),
+    ).toBe(true);
+    expect(
+      host.exists(
+        'project-docs/domain-models/collision-report-lifecycle.md',
+      ),
+    ).toBe(false);
+  });
+
+  it('adds the shared-context note to the README only when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      name: 'Collision Report Lifecycle',
+      project: 'domain-lib',
+    });
+
+    const scopedReadme = host
+      .read('libs/domain-lib/project-docs/domain-models/README.md')
+      .toString();
+    expect(scopedReadme).toContain(
+      'shared by every project that depends on this library',
+    );
+
+    await generator(host, { name: 'Case Lifecycle' });
+
+    const rootReadme = host
+      .read('project-docs/domain-models/README.md')
+      .toString();
+    expect(rootReadme).not.toContain(
+      'shared by every project that depends on this library',
+    );
+  });
+
+  it('registers its own artifact-schema entry expecting bounded-contexts/domain-terms ancestors', async () => {
+    await generator(host, { name: 'Collision Report Lifecycle' });
+
+    expect(readArtifactSchema(host)).toEqual({
+      'domain-models': {
+        expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
+      },
+    });
+  });
+});

--- a/packages/nx-agent/src/generators/domain-model/domain-model.ts
+++ b/packages/nx-agent/src/generators/domain-model/domain-model.ts
@@ -12,7 +12,7 @@ import { ensureReadme } from '../../utils/readme';
 import { resolveRefFromPath } from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
-const DOMAIN_TERMS_SUBDIR = 'project-docs/domain-terms';
+const DOMAIN_MODELS_SUBDIR = 'project-docs/domain-models';
 const README_TEMPLATE_PATH = join(__dirname, 'README.template.md');
 
 function resolveTargetRoot(host: Tree, project?: string): string {
@@ -20,15 +20,15 @@ function resolveTargetRoot(host: Tree, project?: string): string {
 }
 
 // The container has no standalone value on its own (its README only exists to
-// explain the convention for the term about to be added), so this is an
-// internal step composed by domain-term rather than its own generator.
+// explain the convention for the model about to be added), so this is an
+// internal step composed by domain-model rather than its own generator.
 function ensureContainerReadme(
   host: Tree,
   containerDir: string,
   scoped: boolean,
 ): void {
   const sharedNote = scoped
-    ? ' This is shared by every project that depends on this library — keep the vocabulary consistent across the service and its frontends rather than letting each drift toward its own terms.'
+    ? ' This is shared by every project that depends on this library — keep the design consistent across the service and its consumers rather than letting each drift toward its own interpretation.'
     : '';
   const content = readFileSync(README_TEMPLATE_PATH, 'utf-8')
     .split('{{SHARED_CONTEXT_NOTE}}')
@@ -38,19 +38,16 @@ function ensureContainerReadme(
 
 export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
-  const containerDir = joinPathFragments(targetRoot, DOMAIN_TERMS_SUBDIR);
-  const slug = names(options.term).fileName;
-  const termPath = joinPathFragments(containerDir, `${slug}.md`);
+  const containerDir = joinPathFragments(targetRoot, DOMAIN_MODELS_SUBDIR);
+  const slug = names(options.name).fileName;
+  const modelPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently
-  // clobbering or duplicating a term — unlike the "never overwrite, skip
-  // silently" posture used for one-shot config like .secretlintrc.json,
-  // re-adding an existing term is almost always a mistake, not an
-  // idempotent re-run. Checked before ensureContainerReadme so a failing
-  // run has no side effects.
-  if (host.exists(termPath)) {
+  // clobbering or duplicating a model — same posture as domain-term. Checked
+  // before any write so a failing run has no side effects.
+  if (host.exists(modelPath)) {
     throw new Error(
-      `[nx-agent] ${termPath} already exists — edit it directly rather than regenerating it.`,
+      `[nx-agent] ${modelPath} already exists — edit it directly rather than regenerating it.`,
     );
   }
 
@@ -62,20 +59,21 @@ export default async function (host: Tree, options: Schema) {
   );
 
   ensureContainerReadme(host, containerDir, !!options.project);
-  ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
+  ensureArtifactSchemaEntry(host, 'domain-models', [
+    'bounded-contexts',
+    'domain-terms',
+  ]);
 
   const content = [
     '---',
-    `term: ${options.term}`,
-    'aliases: []',
-    'not_confused_with: []',
+    `name: ${options.name}`,
     `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
     '---',
     '',
-    "<!-- Definition: describe this term in the domain's own language. -->",
+    '<!-- Design: describe the aggregates, entities, value objects, and invariants here. -->',
     '',
   ].join('\n');
-  host.write(termPath, content);
+  host.write(modelPath, content);
 
   await formatFiles(host);
 }

--- a/packages/nx-agent/src/generators/domain-model/schema.d.ts
+++ b/packages/nx-agent/src/generators/domain-model/schema.d.ts
@@ -1,0 +1,5 @@
+export interface Schema {
+  name: string;
+  project?: string;
+  projectDocsAncestors?: string[];
+}

--- a/packages/nx-agent/src/generators/domain-model/schema.json
+++ b/packages/nx-agent/src/generators/domain-model/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentDomainModel",
+  "title": "Add a domain model",
+  "description": "Creates one file for a domain model under project-docs/domain-models/, with a project-docs-ancestors frontmatter list and a free-text design body (aggregates, entities, invariants). Bootstraps the domain-models/README.md convention doc on first use.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The canonical name of the domain model (e.g. \"Collision Report Lifecycle\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What is the domain model called?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this domain model to a specific project's project-docs/domain-models/ instead of the workspace root — prefer this whenever the model already has a natural code home (most often a domain library other projects depend on); only use the workspace root when it genuinely doesn't have one."
+    },
+    "projectDocsAncestors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing project-docs/ artifacts this model derives from — normally the bounded context it belongs to plus the domain terms it's composed from (e.g. project-docs/bounded-contexts/collision-reporting.md). Each path must already exist; a backward reference only makes sense pointing at something already established."
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/domain-term/domain-term.spec.ts
+++ b/packages/nx-agent/src/generators/domain-term/domain-term.spec.ts
@@ -1,5 +1,6 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
 import generator from './domain-term';
 
 describe('nx-agent domain-term generator', () => {
@@ -143,5 +144,13 @@ describe('nx-agent domain-term generator', () => {
 
     const readme = host.read('project-docs/domain-terms/README.md').toString();
     expect(readme).toContain('listing this folder');
+  });
+
+  it('registers its own artifact-schema entry expecting a bounded-contexts ancestor', async () => {
+    await generator(host, { term: 'Case' });
+
+    expect(readArtifactSchema(host)).toEqual({
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
   });
 });

--- a/packages/nx-agent/src/generators/domain-term/schema.json
+++ b/packages/nx-agent/src/generators/domain-term/schema.json
@@ -13,7 +13,7 @@
     },
     "project": {
       "type": "string",
-      "description": "Scope this term to a specific project's project-docs/domain-terms/ instead of the workspace root — use when a bounded context spans a domain library and its consuming apps."
+      "description": "Scope this term to a specific project's project-docs/domain-terms/ instead of the workspace root — prefer this whenever the term already has a natural code home (most often a domain library other projects depend on); only use the workspace root when it genuinely doesn't have one."
     },
     "projectDocsAncestors": {
       "type": "array",

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -1,17 +1,36 @@
 **Project-docs lineage.** When a file (code, test, or another `project-docs/` artifact) is built on
-top of something else in `project-docs/` — a domain term, a bounded context, a requirement, any
-artifact kind that folder holds — say so with a `project-docs-ancestors` reference, so that relationship
-is recorded rather than left implicit. Same directive, two forms: a frontmatter list on a doc
-artifact, or a comment near the top of a code/test file. Value shape is `<type>[:<id>][#fragment]`,
-comma-separated for more than one (there's no single-"parent" constraint — deriving from several
-unrelated artifacts at once is normal). `type` is the literal `project-docs/` subfolder name, no
-plural-to-singular guessing; `id` is the filename minus extension for a collection artifact (many
-instances, one file each, inside a type-named folder), and omitted entirely for a singular one (a
-type with exactly one file, directly under `project-docs/`, no subfolder) — e.g. `domain-terms:case`
-for a term, `architecture-overview` alone for a one-off doc. Only ever reference something that
-already exists — this is a backward reference, and deriving from a thing that doesn't exist yet
-isn't a real case. `nx g @abgov/nx-agent:domain-term --project-docs-ancestors <path>` resolves and writes
-this for you (from an existing artifact's path, not a hand-typed `type:id` string) rather than
-requiring you to know the format; other artifact-producing generators should do the same. Run
+top of something else in `project-docs/` — a domain term, a bounded context, a domain model, any
+artifact kind that folder holds — say so with a `project-docs-ancestors` reference, so that
+relationship is recorded rather than left implicit. Same directive, two forms: a frontmatter list on
+a doc artifact, or a comment near the top of a code/test file. Value shape is
+`<type>[:<id>][#fragment]`, comma-separated for more than one (there's no single-"parent"
+constraint — deriving from several unrelated artifacts at once is normal). `type` is the literal
+`project-docs/` subfolder name, no plural-to-singular guessing; `id` is the filename minus extension
+for a collection artifact (many instances, one file each, inside a type-named folder), and omitted
+entirely for a singular one (a type with exactly one file, directly under `project-docs/`, no
+subfolder) — e.g. `domain-terms:case` for a term, `architecture-overview` alone for a one-off doc.
+Only ever reference something that already exists — this is a backward reference, and deriving from
+a thing that doesn't exist yet isn't a real case. `nx g @abgov/nx-agent:domain-term`,
+`:bounded-context`, and `:domain-model` each resolve a `--project-docs-ancestors <path>` for you
+(from an existing artifact's path, not a hand-typed `type:id` string) rather than requiring you to
+know the format; other artifact-producing generators should do the same. Run
 `nx g @abgov/nx-agent:project-docs-lineage` to build the full graph and catch a broken reference —
 not yet wired into the pre-commit hook, so run it yourself after adding or changing a reference.
+
+**Where an artifact belongs**, one level below the format above: a bounded context, domain model, or
+domain term can be scoped to a specific project (`--project <p>`) instead of the workspace root, and
+"shared across several projects" is not the same question as "workspace root or not." Prefer scoping
+to the project that already owns the concept in code — most often a domain library several
+apps/services depend on — since that's where someone touching the domain logic will actually look,
+and the project-qualified reference form (`<project>/type:id`) already lets every consumer point at
+it precisely. Reserve the workspace root for a concept genuinely without a single owning project (a
+cross-cutting decision, or a workspace where domain code hasn't been organized into libraries yet) —
+not as a default just because something is widely used.
+
+**Expected ancestors.** An artifact-producing generator can declare, in
+`project-docs/artifact-schema.json`, what ancestor type its own kind normally expects — e.g. a domain
+term expecting a bounded context — by writing its own entry there on first use
+(`{ "<type>": { "expectedAncestorTypes": ["<type>", ...] } }`). `project-docs-lineage` reads this file
+generically, with no knowledge of any specific type baked in, and reports — never fails, since this
+is a convention nudge rather than a hard rule — an artifact of a scoped type with no matching
+ancestor as "unscoped."

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -26,6 +26,7 @@ describe('nx-agent project-docs-lineage generator', () => {
     expect(lineage.registry['domain-terms:collision-report']).toBeDefined();
     expect(lineage.violations.brokenRefs).toEqual([]);
     expect(lineage.violations.orphans).toEqual([]);
+    expect(lineage.violations.unscoped).toEqual([]);
   });
 
   it('throws and lists every broken reference when one is found', async () => {
@@ -47,5 +48,64 @@ describe('nx-agent project-docs-lineage generator', () => {
 
     const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
     expect(lineage.violations.orphans).toEqual(['domain-terms:unused']);
+  });
+
+  it('reports an unscoped artifact without throwing, when artifact-schema.json expects an ancestor', async () => {
+    host.write(
+      'project-docs/artifact-schema.json',
+      JSON.stringify({
+        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+      }),
+    );
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      ['---', 'term: Collision Report', '---'].join('\n'),
+    );
+
+    await expect(generator(host)).resolves.toBeUndefined();
+
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.unscoped).toEqual([
+      'domain-terms:collision-report',
+    ]);
+  });
+
+  it('does not flag an artifact that has the expected ancestor type', async () => {
+    host.write(
+      'project-docs/artifact-schema.json',
+      JSON.stringify({
+        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+      }),
+    );
+    host.write(
+      'project-docs/bounded-contexts/collision-reporting.md',
+      ['---', 'name: Collision Reporting', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      [
+        '---',
+        'term: Collision Report',
+        'project-docs-ancestors: [bounded-contexts:collision-reporting]',
+        '---',
+      ].join('\n'),
+    );
+
+    await generator(host);
+
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.unscoped).toEqual([]);
+  });
+
+  it('behaves exactly as today when artifact-schema.json is absent', async () => {
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      ['---', 'term: Collision Report', '---'].join('\n'),
+    );
+
+    await generator(host);
+
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.unscoped).toEqual([]);
   });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -1,4 +1,5 @@
 import { Tree } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
 import { ensureGitignoreEntries } from '../../utils/gitignore';
 import {
   buildIndex,
@@ -17,11 +18,18 @@ export default async function (host: Tree) {
 
   const registry = buildRegistry(host);
   const index = buildIndex(host);
-  const violations = computeViolations(registry, index);
+  const artifactSchema = readArtifactSchema(host);
+  const violations = computeViolations(registry, index, artifactSchema);
 
   for (const orphan of violations.orphans) {
     // eslint-disable-next-line no-console
     console.log(`[nx-agent] orphan (nothing derives from it yet): ${orphan}`);
+  }
+  for (const unscoped of violations.unscoped) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[nx-agent] unscoped (missing an expected ancestor type): ${unscoped}`,
+    );
   }
   for (const broken of violations.brokenRefs) {
     // eslint-disable-next-line no-console

--- a/packages/nx-agent/src/utils/artifact-schema.spec.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.spec.ts
@@ -1,0 +1,87 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree } from '@nx/devkit';
+import { ensureArtifactSchemaEntry, readArtifactSchema } from './artifact-schema';
+
+describe('readArtifactSchema', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('returns an empty object when the file does not exist', () => {
+    expect(readArtifactSchema(host)).toEqual({});
+  });
+
+  it('reads an existing schema file', () => {
+    host.write(
+      'project-docs/artifact-schema.json',
+      JSON.stringify({
+        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+      }),
+    );
+
+    expect(readArtifactSchema(host)).toEqual({
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
+  });
+});
+
+describe('ensureArtifactSchemaEntry', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('creates the file fresh with the given entry', () => {
+    ensureArtifactSchemaEntry(host, 'bounded-contexts', []);
+
+    expect(readArtifactSchema(host)).toEqual({
+      'bounded-contexts': { expectedAncestorTypes: [] },
+    });
+  });
+
+  it('merges a second type in without disturbing the first', () => {
+    ensureArtifactSchemaEntry(host, 'bounded-contexts', []);
+    ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
+
+    expect(readArtifactSchema(host)).toEqual({
+      'bounded-contexts': { expectedAncestorTypes: [] },
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
+  });
+
+  it('overwrites its own entry on re-run without touching others', () => {
+    ensureArtifactSchemaEntry(host, 'bounded-contexts', []);
+    ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
+
+    ensureArtifactSchemaEntry(host, 'domain-terms', [
+      'bounded-contexts',
+      'something-else',
+    ]);
+
+    expect(readArtifactSchema(host)).toEqual({
+      'bounded-contexts': { expectedAncestorTypes: [] },
+      'domain-terms': {
+        expectedAncestorTypes: ['bounded-contexts', 'something-else'],
+      },
+    });
+  });
+
+  it('preserves a hand-added entry for a type nx-agent knows nothing about', () => {
+    host.write(
+      'project-docs/artifact-schema.json',
+      JSON.stringify({
+        requirements: { expectedAncestorTypes: ['bounded-contexts'] },
+      }),
+    );
+
+    ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
+
+    expect(readArtifactSchema(host)).toEqual({
+      requirements: { expectedAncestorTypes: ['bounded-contexts'] },
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
+  });
+});

--- a/packages/nx-agent/src/utils/artifact-schema.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.ts
@@ -1,0 +1,34 @@
+import { Tree, readJson, writeJson } from '@nx/devkit';
+
+const ARTIFACT_SCHEMA_PATH = 'project-docs/artifact-schema.json';
+
+// What ancestor types a given artifact `type` is expected to have — e.g.
+// domain-terms expects a bounded-contexts ancestor. This is data the
+// workspace owns, not logic nx-agent owns: project-docs-lineage only ever
+// reads it generically (no per-type branches), so a hand-invented artifact
+// kind with its own entry here gets the same soft check for free.
+export interface ArtifactTypeSchema {
+  expectedAncestorTypes: string[];
+}
+
+export type ArtifactSchema = Record<string, ArtifactTypeSchema>;
+
+export function readArtifactSchema(host: Tree): ArtifactSchema {
+  if (!host.exists(ARTIFACT_SCHEMA_PATH)) {
+    return {};
+  }
+  return readJson<ArtifactSchema>(host, ARTIFACT_SCHEMA_PATH);
+}
+
+// Merge-only: sets/overwrites only the calling generator's own `type` key,
+// leaving every other entry — including a hand-added one for a custom
+// artifact kind nx-agent knows nothing about — untouched.
+export function ensureArtifactSchemaEntry(
+  host: Tree,
+  type: string,
+  expectedAncestorTypes: string[],
+): void {
+  const schema = readArtifactSchema(host);
+  schema[type] = { expectedAncestorTypes };
+  writeJson(host, ARTIFACT_SCHEMA_PATH, schema);
+}

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -271,6 +271,69 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     expect(registry.size).toBe(0);
   });
+
+  it('defaults to no unscoped violations when no schema is passed', () => {
+    host.write(
+      'project-docs/domain-terms/a.md',
+      ['---', 'term: A', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+
+    expect(violations.unscoped).toEqual([]);
+  });
+
+  it('flags an artifact missing an expected ancestor type as unscoped', () => {
+    host.write(
+      'project-docs/domain-terms/a.md',
+      ['---', 'term: A', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(buildRegistry(host), buildIndex(host), {
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
+
+    expect(violations.unscoped).toEqual(['domain-terms:a']);
+  });
+
+  it('does not flag an artifact that has one of the expected ancestor types', () => {
+    host.write(
+      'project-docs/bounded-contexts/b.md',
+      ['---', 'name: B', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-terms/a.md',
+      [
+        '---',
+        'term: A',
+        'project-docs-ancestors: [bounded-contexts:b]',
+        '---',
+      ].join('\n'),
+    );
+
+    const violations = computeViolations(buildRegistry(host), buildIndex(host), {
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
+
+    expect(violations.unscoped).toEqual([]);
+  });
+
+  it('does not check a type with no schema entry, or one with an empty expectation', () => {
+    host.write(
+      'project-docs/domain-terms/a.md',
+      ['---', 'term: A', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/bounded-contexts/b.md',
+      ['---', 'name: B', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(buildRegistry(host), buildIndex(host), {
+      'bounded-contexts': { expectedAncestorTypes: [] },
+    });
+
+    expect(violations.unscoped).toEqual([]);
+  });
 });
 
 describe('getAncestors', () => {

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -1,4 +1,5 @@
 import { Tree, getProjects } from '@nx/devkit';
+import { ArtifactSchema } from './artifact-schema';
 
 // project-docs-ancestors convention: <type>[:<id>][#fragment], optionally
 // qualified with a project name (<project>/<type>...). `type` is the literal
@@ -286,11 +287,17 @@ export function buildIndex(host: Tree): Index {
 export interface Violations {
   brokenRefs: { ref: string; referencedFrom: string }[];
   orphans: string[];
+  unscoped: string[];
 }
 
+// `artifactSchema` is plain data the workspace owns (see utils/artifact-schema.ts)
+// mapping an artifact `type` to the ancestor types it's expected to have — this
+// function never mentions a concrete type name, so a new artifact kind gets the
+// same soft check for free the moment its own generator registers an entry.
 export function computeViolations(
   registry: Registry,
   index: Index,
+  artifactSchema: ArtifactSchema = {},
 ): Violations {
   const brokenRefs: Violations['brokenRefs'] = [];
   for (const [key, entries] of index) {
@@ -303,7 +310,23 @@ export function computeViolations(
 
   const orphans = [...registry.keys()].filter((key) => !index.has(key));
 
-  return { brokenRefs, orphans };
+  const unscoped: string[] = [];
+  for (const [key, entry] of registry) {
+    const parsedKey = parseAncestorRef(key);
+    const expected = parsedKey && artifactSchema[parsedKey.type]?.expectedAncestorTypes;
+    if (!expected || expected.length === 0) {
+      continue;
+    }
+    const ancestorTypes = entry.ancestorRefs
+      .map((raw) => parseAncestorRef(raw)?.type)
+      .filter((type): type is string => !!type);
+    const satisfied = expected.some((type) => ancestorTypes.includes(type));
+    if (!satisfied) {
+      unscoped.push(key);
+    }
+  }
+
+  return { brokenRefs, orphans, unscoped };
 }
 
 // The two retrieval directions, deliberately not symmetric in cost. Forward

--- a/packages/nx-agent/src/utils/readme.ts
+++ b/packages/nx-agent/src/utils/readme.ts
@@ -1,0 +1,12 @@
+import { Tree, joinPathFragments } from '@nx/devkit';
+
+// Write-if-missing only — a README a team may have already started editing
+// is never overwritten. Callers own their own template content (and any
+// substitution into it); this just owns the "does one already exist" check.
+export function ensureReadme(host: Tree, dir: string, content: string): void {
+  const readmePath = joinPathFragments(dir, 'README.md');
+  if (host.exists(readmePath)) {
+    return;
+  }
+  host.write(readmePath, content);
+}


### PR DESCRIPTION
## Summary
- Adds `bounded-context` and `domain-model` generators (`project-docs/bounded-contexts/`, `project-docs/domain-models/`), matching `domain-term`'s existing shape: collection artifacts, project-scopable via `--project`, `domain-model` resolving `--project-docs-ancestors` the same way `domain-term` does.
- Introduces `project-docs/artifact-schema.json` so `project-docs-lineage` can softly flag an artifact missing an ancestor its kind expects (e.g. a domain term with no bounded-context ancestor) — without hardcoding any type name into the lineage generator. Each artifact-producing generator self-registers its own expected-ancestor-types entry; `computeViolations` reads the schema generically as a third, non-throwing `unscoped` category alongside the existing `brokenRefs`/`orphans`.
- Adds explicit "shared ≠ workspace root" guidance: prefer scoping an artifact to the project that already owns the concept in code (usually a domain library), reserving the workspace root for a concept genuinely without one.

## Test plan
- [x] `nx lint,test,build nx-agent` — 111 tests pass, lint/build clean
- [x] Manual end-to-end run against this repo: generated a bounded context, a domain term deriving from it, a domain model deriving from both, and an unscoped domain term; ran `project-docs-lineage` and confirmed `violations.unscoped` correctly flagged only the unscoped term, with zero broken refs; scratch artifacts removed before commit