### PR TITLE
fix(nx-agent): require all expected ancestor types, not any, for unscoped

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -297,9 +297,12 @@ own entry here on first use, declaring what ancestor type its kind normally expe
 ```
 
 `project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
-a hand-added entry for a custom artifact kind gets the same check for free. An artifact whose type has
-an entry here but no ancestor of an expected type is reported (not thrown, since this is a convention
-nudge rather than a hard rule) as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
+a hand-added entry for a custom artifact kind gets the same check for free. `expectedAncestorTypes` is
+an all-of list, not any-of: `domain-models` above requires an ancestor of _both_ `bounded-contexts`
+and `domain-terms`, not either — a model with only one is still missing part of the vocabulary it
+should be built from. An artifact whose type has an entry here but is missing an ancestor of one of
+the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
+as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 
 ### Programmatic access
 

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -266,9 +266,12 @@ own entry here on first use, declaring what ancestor type its kind normally expe
 ```
 
 `project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
-a hand-added entry for a custom artifact kind gets the same check for free. An artifact whose type has
-an entry here but no ancestor of an expected type is reported (not thrown, since this is a convention
-nudge rather than a hard rule) as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
+a hand-added entry for a custom artifact kind gets the same check for free. `expectedAncestorTypes` is
+an all-of list, not any-of: `domain-models` above requires an ancestor of _both_ `bounded-contexts`
+and `domain-terms`, not either — a model with only one is still missing part of the vocabulary it
+should be built from. An artifact whose type has an entry here but is missing an ancestor of one of
+the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
+as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 
 ### Programmatic access
 

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -28,9 +28,11 @@ cross-cutting decision, or a workspace where domain code hasn't been organized i
 not as a default just because something is widely used.
 
 **Expected ancestors.** An artifact-producing generator can declare, in
-`project-docs/artifact-schema.json`, what ancestor type its own kind normally expects — e.g. a domain
-term expecting a bounded context — by writing its own entry there on first use
-(`{ "<type>": { "expectedAncestorTypes": ["<type>", ...] } }`). `project-docs-lineage` reads this file
-generically, with no knowledge of any specific type baked in, and reports — never fails, since this
-is a convention nudge rather than a hard rule — an artifact of a scoped type with no matching
-ancestor as "unscoped."
+`project-docs/artifact-schema.json`, what ancestor type(s) its own kind normally expects — e.g. a
+domain term expecting a bounded context — by writing its own entry there on first use
+(`{ "<type>": { "expectedAncestorTypes": ["<type>", ...] } }`). That list is all-of, not any-of: a
+domain model expecting both a bounded context and a domain term is still missing part of its
+vocabulary with only one of the two. `project-docs-lineage` reads this file generically, with no
+knowledge of any specific type baked in, and reports — never fails, since this is a convention nudge
+rather than a hard rule — an artifact of a scoped type missing one of its expected ancestors as
+"unscoped."

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -289,9 +289,13 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: A', '---'].join('\n'),
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host), {
-      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
-    });
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+      },
+    );
 
     expect(violations.unscoped).toEqual(['domain-terms:a']);
   });
@@ -311,9 +315,13 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host), {
-      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
-    });
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+      },
+    );
 
     expect(violations.unscoped).toEqual([]);
   });
@@ -328,9 +336,73 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'name: B', '---'].join('\n'),
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host), {
-      'bounded-contexts': { expectedAncestorTypes: [] },
-    });
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'bounded-contexts': { expectedAncestorTypes: [] },
+      },
+    );
+
+    expect(violations.unscoped).toEqual([]);
+  });
+
+  it('flags an artifact with only some of several expected ancestor types (all-of, not any-of)', () => {
+    host.write(
+      'project-docs/bounded-contexts/b.md',
+      ['---', 'name: B', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-models/m.md',
+      [
+        '---',
+        'name: M',
+        'project-docs-ancestors: [bounded-contexts:b]',
+        '---',
+      ].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'domain-models': {
+          expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
+        },
+      },
+    );
+
+    expect(violations.unscoped).toEqual(['domain-models:m']);
+  });
+
+  it('does not flag an artifact that has all of several expected ancestor types', () => {
+    host.write(
+      'project-docs/bounded-contexts/b.md',
+      ['---', 'name: B', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-terms/a.md',
+      ['---', 'term: A', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-models/m.md',
+      [
+        '---',
+        'name: M',
+        'project-docs-ancestors: [bounded-contexts:b, domain-terms:a]',
+        '---',
+      ].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'domain-models': {
+          expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
+        },
+      },
+    );
 
     expect(violations.unscoped).toEqual([]);
   });
@@ -415,7 +487,12 @@ describe('getAncestors', () => {
     );
 
     expect(getAncestors(host, 'apps/test/src/main.ts')).toEqual([
-      { project: undefined, type: 'domain-terms', id: 'b', fragment: undefined },
+      {
+        project: undefined,
+        type: 'domain-terms',
+        id: 'b',
+        fragment: undefined,
+      },
     ]);
   });
 
@@ -429,7 +506,10 @@ describe('getAncestors', () => {
         '---',
       ].join('\n'),
     );
-    host.write('project-docs/bounded-contexts/c.md', ['---', 'name: C', '---'].join('\n'));
+    host.write(
+      'project-docs/bounded-contexts/c.md',
+      ['---', 'name: C', '---'].join('\n'),
+    );
     host.write(
       'apps/test/src/main.ts',
       '// project-docs-ancestors: domain-terms:b\nexport {};',
@@ -452,7 +532,12 @@ describe('getAncestors', () => {
     );
     host.write(
       'project-docs/bounded-contexts/c.md',
-      ['---', 'name: C', 'project-docs-ancestors: [domain-terms:b]', '---'].join('\n'),
+      [
+        '---',
+        'name: C',
+        'project-docs-ancestors: [domain-terms:b]',
+        '---',
+      ].join('\n'),
     );
     host.write(
       'apps/test/src/main.ts',
@@ -460,9 +545,7 @@ describe('getAncestors', () => {
     );
 
     expect(
-      getAncestors(host, 'apps/test/src/main.ts', Infinity)
-        .map(refKey)
-        .sort(),
+      getAncestors(host, 'apps/test/src/main.ts', Infinity).map(refKey).sort(),
     ).toEqual(['bounded-contexts:c', 'domain-terms:b']);
   });
 });
@@ -499,10 +582,18 @@ describe('getDescendants', () => {
   });
 
   it('defaults to direct referrers only (depth 1)', () => {
-    host.write('project-docs/domain-terms/b.md', ['---', 'term: B', '---'].join('\n'));
+    host.write(
+      'project-docs/domain-terms/b.md',
+      ['---', 'term: B', '---'].join('\n'),
+    );
     host.write(
       'project-docs/bounded-contexts/c.md',
-      ['---', 'name: C', 'project-docs-ancestors: [domain-terms:b]', '---'].join('\n'),
+      [
+        '---',
+        'name: C',
+        'project-docs-ancestors: [domain-terms:b]',
+        '---',
+      ].join('\n'),
     );
     host.write(
       'apps/test/src/main.ts',
@@ -515,10 +606,18 @@ describe('getDescendants', () => {
   });
 
   it('walks multiple hops when depth > 1, following referrers that are themselves registered artifacts', () => {
-    host.write('project-docs/domain-terms/b.md', ['---', 'term: B', '---'].join('\n'));
+    host.write(
+      'project-docs/domain-terms/b.md',
+      ['---', 'term: B', '---'].join('\n'),
+    );
     host.write(
       'project-docs/bounded-contexts/c.md',
-      ['---', 'name: C', 'project-docs-ancestors: [domain-terms:b]', '---'].join('\n'),
+      [
+        '---',
+        'name: C',
+        'project-docs-ancestors: [domain-terms:b]',
+        '---',
+      ].join('\n'),
     );
     host.write(
       'apps/test/src/main.ts',
@@ -535,11 +634,21 @@ describe('getDescendants', () => {
   it('terminates on a cycle when depth is Infinity, without duplicates', () => {
     host.write(
       'project-docs/domain-terms/b.md',
-      ['---', 'term: B', 'project-docs-ancestors: [bounded-contexts:c]', '---'].join('\n'),
+      [
+        '---',
+        'term: B',
+        'project-docs-ancestors: [bounded-contexts:c]',
+        '---',
+      ].join('\n'),
     );
     host.write(
       'project-docs/bounded-contexts/c.md',
-      ['---', 'name: C', 'project-docs-ancestors: [domain-terms:b]', '---'].join('\n'),
+      [
+        '---',
+        'name: C',
+        'project-docs-ancestors: [domain-terms:b]',
+        '---',
+      ].join('\n'),
     );
 
     expect(

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -294,6 +294,10 @@ export interface Violations {
 // mapping an artifact `type` to the ancestor types it's expected to have — this
 // function never mentions a concrete type name, so a new artifact kind gets the
 // same soft check for free the moment its own generator registers an entry.
+// `expectedAncestorTypes` is an all-of list, not any-of: e.g. domain-models
+// expects both a bounded-contexts and a domain-terms ancestor, not either —
+// a model with only the former is still missing the vocabulary it should be
+// built from, so it's still worth flagging.
 export function computeViolations(
   registry: Registry,
   index: Index,
@@ -313,14 +317,15 @@ export function computeViolations(
   const unscoped: string[] = [];
   for (const [key, entry] of registry) {
     const parsedKey = parseAncestorRef(key);
-    const expected = parsedKey && artifactSchema[parsedKey.type]?.expectedAncestorTypes;
+    const expected =
+      parsedKey && artifactSchema[parsedKey.type]?.expectedAncestorTypes;
     if (!expected || expected.length === 0) {
       continue;
     }
     const ancestorTypes = entry.ancestorRefs
       .map((raw) => parseAncestorRef(raw)?.type)
       .filter((type): type is string => !!type);
-    const satisfied = expected.some((type) => ancestorTypes.includes(type));
+    const satisfied = expected.every((type) => ancestorTypes.includes(type));
     if (!satisfied) {
       unscoped.push(key);
     }


### PR DESCRIPTION
## Summary
- `computeViolations` checked `artifactSchema`'s `expectedAncestorTypes` with `.some()`, so an artifact was considered "scoped" if it had an ancestor of *any* listed type. That's wrong for `domain-models`, which expects both `bounded-contexts` and `domain-terms` — a model with only a bounded-context ancestor and none of its constituent terms was silently treated as fully scoped.
- Switches to `.every()`: an artifact is flagged `unscoped` unless it has an ancestor of *every* type its kind expects. No behavior change for `domain-terms` (single expected type, so any/all were equivalent there already).
- Updated the doc/guidance wording that described `expectedAncestorTypes` to state the all-of semantics explicitly, and added tests covering the multi-type case in both directions (missing one → flagged; has both → not flagged).

## Test plan
- [x] `nx lint,test,build nx-agent` — 113 tests pass, lint/build clean