### PR TITLE
test(nx-oc): cover deployment's silent no-op when pipeline hasn't run

### DIFF
--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -285,4 +285,33 @@ describe('Deployment Generator', () => {
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['apply-envs']).toBeFalsy();
   });
+
+  it('does nothing, without throwing, when pipeline has not been run yet', async () => {
+    // deploymentGenerator is composed, unconditionally, into the end of every
+    // nx-adsp app/service scaffolder (express-service, react-app, ...). A
+    // fresh workspace scaffolding its first app has almost certainly not run
+    // `pipeline` yet — this must resolve cleanly rather than throw, or
+    // scaffolding the app itself would fail for an unrelated,
+    // deployment-only reason.
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          options: { compiler: 'tsc', target: 'node' },
+        },
+      },
+    });
+
+    await expect(
+      generator(host, { ...options, appType: 'node' }),
+    ).resolves.toBeUndefined();
+
+    expect(host.exists('.openshift/test/test.yml')).toBeFalsy();
+    const config = readProjectConfiguration(host, 'test');
+    expect(config.targets['apply-envs']).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Summary
- `deployment` checks for `.openshift/environments.yml` (written by `pipeline`) and, if missing, logs a message and returns without throwing — this branch had no test coverage at all.
- That silence is deliberate, not a bug: `deploymentGenerator` is composed unconditionally into the end of every nx-adsp app/service scaffolder (`express-service`, `react-app`, `angular-app`, `dotnet-service`, `vue-app`), and a fresh workspace scaffolding its first app has almost certainly not run `pipeline` yet. Throwing here would fail the entire scaffolding command for an unrelated, deployment-only reason.
- Adds a test asserting the generator resolves cleanly and generates nothing in that state, so this doesn't get "fixed" into a regression later without someone realizing why it's silent.

## Test plan
- [x] `nx lint,test,build nx-oc,nx-adsp` — 122 + 73 tests pass, lint/build clean (nx-adsp is affected since it depends on nx-oc)