### PR TITLE
feat(nx-agent): add MCP-server guidance to init's AGENTS.md

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -86,7 +86,8 @@ Currently sets up:
    - **Version control practices** — atomic Conventional Commits, GitHub Flow, linear history.
    - **Conventions and consistency** — ubiquitous language (domain vocabulary, and the
      `domain-term` generator below), matching this project's own established patterns (including
-     `project-docs/`, if present), and following framework/library idioms.
+     `project-docs/`, if present), following framework/library idioms, and checking a connected
+     MCP server before recalling a platform/design-system API from memory.
    - **Code quality** — scope discipline, comments (why, not what), reuse before reinventing
      (existing generators and workspace ESLint rules over bespoke code), error handling, TODO
      transparency (including deliberately-accepted findings), test quality.

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -64,7 +64,8 @@ Currently sets up:
      style/format/complexity tooling a project already has configured.
    - **Version control practices** — atomic Conventional Commits, GitHub Flow, linear history.
    - **Conventions and consistency** — ubiquitous language (domain vocabulary), matching this
-     project's own established patterns, and following framework/library idioms.
+     project's own established patterns, following framework/library idioms, and checking a
+     connected MCP server before recalling a platform/design-system API from memory.
    - **Code quality** — scope discipline, comments (why, not what), reuse before reinventing,
      error handling, TODO transparency, test quality.
 

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/mcp-servers.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/mcp-servers.md
@@ -1,0 +1,15 @@
+**MCP servers.** Check `.mcp.json` for a project-scoped MCP server, when one's configured and
+connected, before recalling a platform's or design system's API/component inventory from memory —
+same training-data-staleness risk as the library case above, just reached through a different
+mechanism. Two things routinely go wrong with these, not just one. First: they're typically only
+added as a side effect of a specific scaffolding generator (a platform-integration server arriving
+bundled with a backend-service generator, a design-system server with a frontend one) rather than
+being available whenever the knowledge would actually help — a design decision made before that
+generator ever runs gets none of it. Don't just wait for that side effect: check whether the
+relevant plugin has an `init` generator — the established convention for a plugin's own
+workspace-root setup, run once and safe to re-run — and run it as soon as the need is identified
+(e.g. during Design), rather than waiting for a scaffolding generator to bundle it later. Second:
+even once `.mcp.json` exists, a server configured or changed mid-session isn't picked up
+automatically — say so explicitly and prompt for a reconnect before relying on it, rather than
+silently proceeding as if it's already connected. Verify with a tool search rather than assuming
+either the file's presence or a prior approval means the server is actually live right now.

--- a/packages/nx-agent/src/generators/init/init.spec.ts
+++ b/packages/nx-agent/src/generators/init/init.spec.ts
@@ -249,7 +249,7 @@ describe('nx-agent init generator', () => {
     );
   });
 
-  it('assembles all six groups with all twenty-one items in the correct order', async () => {
+  it('assembles all six groups with all twenty-two items in the correct order', async () => {
     await generator(host, {});
 
     const agentsMd = host.read('AGENTS.md').toString();
@@ -278,6 +278,7 @@ describe('nx-agent init generator', () => {
       'Project conventions',
       'Project-docs lineage',
       'Framework and library idioms',
+      'MCP servers',
       'Scope discipline',
       'Comments: why, not what',
       'Reuse before reinventing',

--- a/packages/nx-agent/src/generators/init/init.ts
+++ b/packages/nx-agent/src/generators/init/init.ts
@@ -102,6 +102,7 @@ const GUIDANCE_GROUPS: GuidanceGroup[] = [
       'project-conventions',
       'project-docs-lineage',
       'framework-and-library-idioms',
+      'mcp-servers',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Adds a new **Conventions and consistency** guidance item to `nx-agent:init`'s generated `AGENTS.md`: check `.mcp.json` for a project-scoped MCP server before recalling a platform's or design system's API/component inventory from memory, same training-data-staleness principle as the existing framework/library-idioms item, just reached through a different mechanism.
- Deliberately generic, not tied to any specific server — the same shape recurs for any MCP-providing generator (a platform-integration server bundled with a backend-service generator today, a design-system server with a frontend one presumably later), so this belongs once in the shared guidance rather than being duplicated per server as each one arrives.
- Flags two things that routinely go wrong with these, and now tells the agent what to *do* about both, not just names them:
  - They're typically only provisioned as a scaffolding side effect (too late for an earlier-stage design decision). The guidance now says to check whether the relevant plugin has an `init` generator — the established convention for a plugin's own workspace-root setup — and run it as soon as the need is identified, rather than waiting.
  - Even once `.mcp.json` exists, a server added or changed mid-session isn't picked up without a reconnect — say so explicitly rather than silently assuming it's live.
- `README.md` and `docs/nx-agent/nx-agent.md`'s "Conventions and consistency" summaries updated to match.

## How this was found
While implementing a Discovery→Design→Develop workflow by hand in a sandbox workspace against real `@abgov/nx-agent`/`@abgov/nx-adsp` generators: a domain-modeling decision (an authorization model) was left as an explicit, marked placeholder specifically because no platform MCP server was provisioned yet at that point in the workflow. Even once one arrived later (as a side effect of scaffolding a backend service), it was never actually connected in that same session — confirmed via a tool search returning nothing — since project-scoped MCP servers load at session start, not on a mid-session file change.

The companion capability gap (no standalone way to provision an MCP server independent of scaffolding a full app) is addressed separately in `feat/adsp-mcp-standalone-generator` (PR #352), which added `@abgov/nx-adsp:init` — intentionally on its own branch/PR, independent of this one. This PR's guidance stays generic (not naming `nx-adsp:init` specifically) so any plugin with the same shape is discoverable the same way.

## Test plan
- [x] `nx test nx-agent` — 116/116 passing
- [x] `nx lint nx-agent` — clean
- [x] `nx build nx-agent` — clean