### PR TITLE
feat(nx-adsp): add init generator for nx-adsp's own workspace-root setup

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -26,6 +26,8 @@ The plugin provides generators for Node/Express services, React, Angular, and Vu
 npm i -D @abgov/nx-adsp
 ```
 
+Always run `nx g @abgov/nx-adsp:init` right after installing — see [`init`](#init) below.
+
 ## Prerequisites
 
 Some generators require additional peer dependencies:
@@ -44,6 +46,28 @@ Some generators require additional peer dependencies:
 | `react-form`, `react-task-list` | existing React project in the workspace |
 
 ## Generators
+
+### init
+
+Sets up nx-adsp's own workspace-root concerns: registers the ADSP SDK MCP server
+(`@abgov/adsp-sdk-mcp-server`) in `.mcp.json`, and shared VS Code settings. Every app/service
+generator below already runs this as one of its own steps — always run it directly right after
+installing the plugin, too, so grounded ADSP platform knowledge (tenant/realm/role model,
+`@abgov/adsp-service-sdk` reference) is available immediately, not only once you've scaffolded
+your first app. That gap matters for a decision made _before_ any app exists — a design pass, for
+instance — which a scaffolding-generator side effect can never reach in time.
+
+```bash
+npx nx g @abgov/nx-adsp:init
+```
+
+No options. Idempotent — merges into existing `.mcp.json`/`.vscode/settings.json` without
+clobbering another server, a customized `adsp-sdk` entry, or unrelated settings; safe to re-run.
+Project-scoped MCP servers only load at session start, so reconnect (or restart) your MCP client
+after running this before relying on the new tools — the generator's own output says so as a
+reminder.
+
+---
 
 ### express-service
 

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -37,7 +37,14 @@ npx create-nx-workspace my-workspace
 # 2. Install the plugin and any required peer dependencies
 npm i -D @abgov/nx-adsp @nx/express
 
-# 3. Generate a quickstart (interactive prompts fill missing options)
+# 3. Set up nx-adsp's own workspace-root concerns (ADSP SDK MCP server, VS Code
+#    settings) — always run this right after installing the plugin. Every
+#    app/service generator below also runs it as one of its own steps, but
+#    running it here means grounded ADSP platform knowledge is available
+#    immediately, not only once you've scaffolded your first app.
+npx nx g @abgov/nx-adsp:init
+
+# 4. Generate a quickstart (interactive prompts fill missing options)
 npx nx g @abgov/nx-adsp:express-service my-service --env dev --tenant my-tenant
 ```
 
@@ -90,6 +97,28 @@ See [`@abgov/nx-oc`](https://www.npmjs.com/package/@abgov/nx-oc) for the sandbox
 deploy details.
 
 ## Generators
+
+### `init`
+
+Sets up nx-adsp's own workspace-root concerns: registers the ADSP SDK MCP server
+(`@abgov/adsp-sdk-mcp-server`) in `.mcp.json`, and shared VS Code settings. Every app/service
+generator below already runs this as one of its own steps — always run it directly right after
+installing the plugin, too, so grounded ADSP platform knowledge (tenant/realm/role model,
+`@abgov/adsp-service-sdk` reference) is available immediately, not only once you've scaffolded
+your first app. That gap matters for a decision made _before_ any app exists — a design pass, for
+instance — which a scaffolding-generator side effect can never reach in time.
+
+```bash
+npx nx g @abgov/nx-adsp:init
+```
+
+No options. Idempotent — merges into existing `.mcp.json`/`.vscode/settings.json` without
+clobbering another server, a customized `adsp-sdk` entry, or unrelated settings; safe to re-run.
+Project-scoped MCP servers only load at session start, so reconnect (or restart) your MCP client
+after running this before relying on the new tools — the generator's own output says so as a
+reminder.
+
+---
 
 ### `express-service`
 

--- a/packages/nx-adsp/generators.json
+++ b/packages/nx-adsp/generators.json
@@ -3,6 +3,11 @@
   "name": "nx-adsp",
   "version": "0.0.1",
   "generators": {
+    "init": {
+      "factory": "./src/generators/init/init",
+      "schema": "./src/generators/init/schema.json",
+      "description": "Sets up nx-adsp's own workspace-root concerns (ADSP SDK MCP server, shared VS Code settings). Run once per workspace, right after installing @abgov/nx-adsp."
+    },
     "express-service": {
       "factory": "./src/generators/express-service/express-service",
       "schema": "./src/generators/express-service/schema.json",

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -47,6 +47,13 @@ describe('angular app generator', () => {
     expect(appTree.exists('apps/test/nginx.conf')).toBeTruthy();
   }, 120000);
 
+  it("runs nx-adsp's own workspace-root setup (ADSP SDK MCP server + VS Code settings)", async () => {
+    await angularApp(appTree, options);
+
+    expect(appTree.exists('.mcp.json')).toBeTruthy();
+    expect(appTree.exists('.vscode/settings.json')).toBeTruthy();
+  }, 120000);
+
   it('scaffolds a Playwright e2e project (consistent across frontends)', async () => {
     await angularApp(appTree, options);
     expect(appTree.exists('apps/test-e2e/project.json')).toBeTruthy();

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -13,9 +13,9 @@ import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
   addJestCoverageConfig,
   addSemgrepTarget,
-  addVsCodeSettings,
   guardPlaywrightWebServer,
 } from '../../utils/quality';
+import initGenerator from '../init/init';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -155,7 +155,10 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
   const addedProxy = addFiles(host, normalizedOptions);
 
   addJestCoverageConfig(host, normalizedOptions.projectRoot);
-  addVsCodeSettings(host);
+  // nx-adsp's own workspace-root setup (ADSP SDK MCP server + shared VS Code
+  // settings), run as one step here in case `nx-adsp:init` hasn't been run
+  // standalone yet.
+  await initGenerator(host);
 
   // @nx/angular generates app.ts/html/css/spec.ts (new naming) and nx-welcome.ts;
   // our templates use app.component.* and don't use nx-welcome.

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -20,12 +20,11 @@ import { consultAgent } from '../../utils/agent';
 import { ensureServiceClient } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
-  addAdspMcpServer,
   addEslintQualityRules,
   addJestCoverageConfig,
   addSemgrepTarget,
-  addVsCodeSettings,
 } from '../../utils/quality';
+import initGenerator from '../init/init';
 import { Schema, NormalizedSchema } from './schema';
 
 async function normalizeOptions(
@@ -132,9 +131,10 @@ export default async function (host: Tree, options: Schema) {
     '**/*.test.ts',
   ]);
   addJestCoverageConfig(host, normalizedOptions.projectRoot);
-  addVsCodeSettings(host);
-  // Equip coding agents with grounded ADSP docs + Node SDK reference lookup.
-  addAdspMcpServer(host);
+  // Equips coding agents with grounded ADSP docs + Node SDK reference lookup,
+  // and shared VS Code settings — nx-adsp's own workspace-root setup, run as
+  // one step here in case `nx-adsp:init` hasn't been run standalone yet.
+  await initGenerator(host);
 
   const projectConfig = readProjectConfiguration(
     host,

--- a/packages/nx-adsp/src/generators/init/init.spec.ts
+++ b/packages/nx-adsp/src/generators/init/init.spec.ts
@@ -1,0 +1,70 @@
+import { readJson, Tree, writeJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import generator from './init';
+
+describe('nx-adsp init generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('wires the ADSP SDK MCP server into the workspace .mcp.json, standalone', async () => {
+    await generator(host);
+
+    expect(host.exists('.mcp.json')).toBeTruthy();
+    const mcp = readJson(host, '.mcp.json');
+    expect(mcp.mcpServers['adsp-sdk']).toEqual({
+      command: 'npx',
+      args: ['-y', '@abgov/adsp-sdk-mcp-server'],
+    });
+  });
+
+  it('merges .mcp.json without clobbering other servers or a customized entry', async () => {
+    writeJson(host, '.mcp.json', {
+      mcpServers: {
+        other: { command: 'other-cmd', args: [] },
+        'adsp-sdk': { command: 'node', args: ['/local/build/main.js'] },
+      },
+    });
+
+    await generator(host);
+
+    const mcp = readJson(host, '.mcp.json');
+    expect(mcp.mcpServers.other).toEqual({ command: 'other-cmd', args: [] });
+    expect(mcp.mcpServers['adsp-sdk']).toEqual({
+      command: 'node',
+      args: ['/local/build/main.js'],
+    });
+  });
+
+  it('reminds that a session reconnect is needed before the MCP server is usable', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await generator(host);
+
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('reconnect');
+    logSpy.mockRestore();
+  });
+
+  it('writes shared VS Code settings, standalone', async () => {
+    await generator(host);
+
+    expect(host.exists('.vscode/settings.json')).toBeTruthy();
+    const settings = readJson(host, '.vscode/settings.json');
+    expect(settings['editor.formatOnSave']).toBe(true);
+    expect(settings['editor.defaultFormatter']).toBe('esbenp.prettier-vscode');
+  });
+
+  it('merges into existing VS Code settings without dropping unrelated ones', async () => {
+    writeJson(host, '.vscode/settings.json', {
+      'files.exclude': { '**/.git': true },
+    });
+
+    await generator(host);
+
+    const settings = readJson(host, '.vscode/settings.json');
+    expect(settings['files.exclude']).toEqual({ '**/.git': true });
+    expect(settings['editor.formatOnSave']).toBe(true);
+  });
+});

--- a/packages/nx-adsp/src/generators/init/init.ts
+++ b/packages/nx-adsp/src/generators/init/init.ts
@@ -1,0 +1,17 @@
+import { Tree, formatFiles } from '@nx/devkit';
+import { addAdspMcpServer, addVsCodeSettings } from '../../utils/quality';
+
+// Every app/service generator (express-service, react-app, angular-app,
+// vue-app) calls this as one of its own steps — it's also the standalone
+// entry point for the same workspace-root setup. That setup previously only
+// ever arrived as a side effect of scaffolding a specific app, which meant
+// grounded ADSP platform knowledge (tenant/realm/role model, SDK reference)
+// was never available for a decision made before any app exists — a
+// Design-stage pass, for instance. A single, prescriptive, re-runnable entry
+// point — same shape as @abgov/nx-agent:init — rather than a generator per
+// workspace-root concern.
+export default async function (host: Tree) {
+  addAdspMcpServer(host);
+  addVsCodeSettings(host);
+  await formatFiles(host);
+}

--- a/packages/nx-adsp/src/generators/init/schema.d.ts
+++ b/packages/nx-adsp/src/generators/init/schema.d.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Schema {}

--- a/packages/nx-adsp/src/generators/init/schema.json
+++ b/packages/nx-adsp/src/generators/init/schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAdspInit",
+  "title": "nx-adsp workspace setup",
+  "description": "Sets up nx-adsp's own workspace-root concerns: registers the @abgov/adsp-sdk-mcp-server MCP server in .mcp.json, and shared VS Code settings. Run once per workspace, right after installing @abgov/nx-adsp — every app/service generator (express-service, react-app, angular-app, vue-app) already calls this as one of its own steps, but running it standalone lets grounded ADSP platform knowledge be available before any app exists, e.g. during a design pass. Idempotent — safe to re-run, never clobbers a customized entry.",
+  "type": "object",
+  "properties": {},
+  "required": [],
+  "additionalProperties": false
+}

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -36,6 +36,14 @@ describe('React App Generator', () => {
     expect(host.exists('apps/test/nginx.conf')).toBeTruthy();
   }, 30000);
 
+  it("runs nx-adsp's own workspace-root setup (ADSP SDK MCP server + VS Code settings)", async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    expect(host.exists('.mcp.json')).toBeTruthy();
+    expect(host.exists('.vscode/settings.json')).toBeTruthy();
+  }, 30000);
+
   it('scaffolds a Playwright e2e project (consistent across frontends)', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, options);

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -14,9 +14,9 @@ import {
   addEslintQualityRules,
   addJestCoverageConfig,
   addSemgrepTarget,
-  addVsCodeSettings,
   guardPlaywrightWebServer,
 } from '../../utils/quality';
+import initGenerator from '../init/init';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -175,7 +175,10 @@ export default async function (host: Tree, options: Schema) {
     '**/*.test.tsx',
   ]);
   addJestCoverageConfig(host, normalizedOptions.projectRoot);
-  addVsCodeSettings(host);
+  // nx-adsp's own workspace-root setup (ADSP SDK MCP server + shared VS Code
+  // settings), run as one step here in case `nx-adsp:init` hasn't been run
+  // standalone yet.
+  await initGenerator(host);
 
   const config = readProjectConfiguration(host, options.name);
 

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -56,6 +56,13 @@ describe('Vue App Generator', () => {
     expect(config.targets.build.options.outputPath).toBe('dist/apps/test');
   }, 30000);
 
+  it("runs nx-adsp's own workspace-root setup (ADSP SDK MCP server + VS Code settings)", async () => {
+    await generator(host, options);
+
+    expect(host.exists('.mcp.json')).toBeTruthy();
+    expect(host.exists('.vscode/settings.json')).toBeTruthy();
+  }, 30000);
+
   it('records the resolved env/tenant as project tags for the sandbox generator', async () => {
     await generator(host, options);
     const config = readProjectConfiguration(host, 'test');

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -13,9 +13,9 @@ import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
   addJestCoverageConfig,
   addSemgrepTarget,
-  addVsCodeSettings,
   guardPlaywrightWebServer,
 } from '../../utils/quality';
+import initGenerator from '../init/init';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -173,7 +173,10 @@ export default async function (host: Tree, options: Schema) {
   const addedProxy = addFiles(host, normalizedOptions);
 
   addJestCoverageConfig(host, normalizedOptions.projectRoot);
-  addVsCodeSettings(host);
+  // nx-adsp's own workspace-root setup (ADSP SDK MCP server + shared VS Code
+  // settings), run as one step here in case `nx-adsp:init` hasn't been run
+  // standalone yet.
+  await initGenerator(host);
 
   const config = readProjectConfiguration(host, options.name);
 

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -170,6 +170,12 @@ export function addVsCodeSettings(host: Tree): void {
  * It's a stdio knowledge server (no credentials, run via npx), so wiring is just
  * config. Merges into an existing `.mcp.json` and never clobbers a user-customized
  * `adsp-sdk` entry, so it's safe to re-run and to run for every generated service.
+ *
+ * The reconnect reminder lives here, not in each caller — project-scoped MCP
+ * servers load at session start, so a file write mid-session (whether from
+ * an app/service generator or the standalone `init` generator) leaves the
+ * entry configured but inert until the client reconnects, and every caller
+ * needs to say so, not just one.
  */
 export function addAdspMcpServer(host: Tree): void {
   const mcpPath = '.mcp.json';
@@ -186,4 +192,10 @@ export function addAdspMcpServer(host: Tree): void {
   } else {
     writeJson(host, mcpPath, { mcpServers: { 'adsp-sdk': server } });
   }
+
+  console.log(
+    '\n✓ .mcp.json configures the ADSP SDK MCP server (adsp-sdk).\n' +
+      '  Project-scoped MCP servers load at session start, not on a mid-session file\n' +
+      '  change — reconnect (or restart) your MCP client now before relying on it.\n',
+  );
 }


### PR DESCRIPTION
## Summary

Per `NX-ADSP-MCP-PROVISIONING-TIMING-GAP.md`: `.mcp.json` (ADSP SDK MCP server) and `.vscode/settings.json` were only ever written as side effects of app/service generators, with no way to provision them on their own. That meant grounded ADSP platform knowledge (tenant/realm/role model, `@abgov/adsp-service-sdk` reference) was unavailable for any decision made before an app exists — e.g. during a design pass, which benefits from exactly this grounding as much as implementation does, just earlier.

Originally scoped narrower (a single-purpose `adsp-mcp` generator), but `addVsCodeSettings` turned out to have the exact same shape and problem — called from every one of `express-service`/`react-app`/`angular-app`/`vue-app`, also with no standalone entry point. That's not a population of one, so this is `init` instead: a single, prescriptive, re-runnable entry point for nx-adsp's own workspace-root concerns, mirroring `@abgov/nx-agent:init` exactly, rather than a generator per concern.

- Each app/service generator now calls `init` as a single step instead of the two separate utility functions it called before.
- React/Angular/Vue app generators previously never registered the ADSP MCP server at all (only `express-service` did) — they now do too, via the same shared step, since platform grounding is just as relevant to a frontend decision as a backend one.
- `README.md`/`docs/nx-adsp.md`'s Quick Start now runs `nx-adsp:init` as an explicit step right after installing the plugin.
- Moves the "reconnect before relying on this" reminder into `addAdspMcpServer` itself rather than each caller, since project-scoped MCP servers only load at session start and every caller needs to say so.

Note: `feat/nx-agent-init-mcp-guidance` (PR #351, already open, not mine) separately addresses the *behavioral* half of this same report. This PR is the *capability* half, intentionally on its own branch/PR.

## Test plan
- [x] `nx lint,test,build nx-adsp` (+ its `nx-oc` dependency) — 81 tests pass, lint/build clean
- [x] Manual end-to-end run against this repo: `nx g @abgov/nx-adsp:init` standalone — confirmed `.mcp.json` created and `.vscode/settings.json` merged correctly (existing `cSpell.words`/`editor.formatOnSave` preserved), reconnect reminder printed; re-ran to confirm idempotency (no diff); reverted scratch changes to this repo's own files before committing