### PR TITLE
feat(nx-adsp): print coverage results to the terminal on every test run

### DIFF
--- a/packages/nx-adsp/src/utils/quality.spec.ts
+++ b/packages/nx-adsp/src/utils/quality.spec.ts
@@ -38,11 +38,13 @@ describe('addJestCoverageConfig', () => {
 
     expect(out).toContain("coverageDirectory: 'test-output/jest/coverage',");
     expect(out).toContain('collectCoverage: true,');
+    expect(out).toContain("coverageReporters: ['html', 'text'],");
     expect(out).toContain('lines: 60,');
     expect(out).not.toContain(',,');
     // The result must be a valid object literal.
     const cfg = evalConfigObject(out);
     expect(cfg.collectCoverage).toBe(true);
+    expect(cfg.coverageReporters).toEqual(['html', 'text']);
     expect(
       (cfg.coverageThreshold as { global: { lines: number } }).global.lines,
     ).toBe(60);

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -59,9 +59,19 @@ export default [
 }
 
 /**
- * Adds collectCoverage and a 60% line coverage threshold to the project's
- * jest.config.cts. The threshold is inactive until the first test file is
- * added (passWithNoTests exits before coverage is checked).
+ * Adds collectCoverage, a 60% line coverage threshold, and terminal-visible
+ * coverage reporters to the project's jest.config.cts. The threshold is
+ * inactive until the first test file is added (passWithNoTests exits before
+ * coverage is checked).
+ *
+ * @nx/jest's shared preset sets `coverageReporters: ['html']` — a report
+ * written to disk, with nothing printed to the terminal even when coverage
+ * runs. That's a real gap for a coding agent, whose main feedback loop *is*
+ * the terminal: a threshold failure alone only says the aggregate number
+ * dropped, not which files or lines are under it. `text` is set directly in
+ * this project's own jest.config.cts (overriding the preset's list for this
+ * project only, without touching the shared preset every other project
+ * inherits) so every `nx test` run prints the full per-file breakdown.
  */
 export function addJestCoverageConfig(host: Tree, projectRoot: string): void {
   const jestPath = `${projectRoot}/jest.config.cts`;
@@ -74,7 +84,7 @@ export function addJestCoverageConfig(host: Tree, projectRoot: string): void {
   // properties after it verbatim would produce an invalid object literal.
   const modified = existing.replace(
     /([ \t]*coverageDirectory:[^\n]*?),?\n/,
-    `$1,\n  collectCoverage: true,\n  coverageThreshold: {\n    global: {\n      lines: 60,\n    },\n  },\n`,
+    `$1,\n  collectCoverage: true,\n  coverageReporters: ['html', 'text'],\n  coverageThreshold: {\n    global: {\n      lines: 60,\n    },\n  },\n`,
   );
   if (modified !== existing) {
     host.write(jestPath, modified);


### PR DESCRIPTION
## Summary

`@nx/jest`'s shared preset sets `coverageReporters: ['html']` — a report written to disk, nothing printed to stdout even when coverage runs. That's a real gap for a coding agent, whose feedback loop *is* the terminal: a threshold failure alone (`addJestCoverageConfig` already enforces 60% lines) only says the aggregate number dropped, not which files or lines are under it.

Sets `coverageReporters: ['html', 'text']` directly in the generated app's own `jest.config.cts`, alongside the existing `collectCoverage`/`coverageThreshold` insertion — overrides the preset for that project only, without touching the shared `jest.preset.js` every other project (including nx-tools' own packages) inherits.

## Test plan
- [x] `nx lint,test,build nx-adsp` (+ its `nx-oc` dependency) — 81 tests pass, lint/build clean
- [x] Verified against real Jest output, not just the generator's own regex-insertion unit test: ran Jest with the exact resulting config against deliberately low-coverage code — the per-file table (with uncovered line numbers) now prints on every run, both when the threshold passes (previously completely silent) and fails (previously only a one-line threshold message)