### PR TITLE
fix(nx-adsp): fix express-service's e2e-project bugs, wire it up by default

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -99,6 +99,31 @@ describe('Express Service Generator', () => {
     expect(agents).toContain('search_sdk_reference');
   }, 60000);
 
+  it('scaffolds a Jest e2e project with the port default fixed to match environment.ts', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    const e2eRoot = 'apps/test-e2e';
+    expect(host.exists(`${e2eRoot}/jest.config.cts`)).toBeTruthy();
+
+    // @nx/node:e2e-project's own template hardcodes a fallback port of 3000;
+    // nx-adsp's own environment.ts.__tmpl__ defaults PORT to 3333. Which of
+    // @nx/node's two jest.config.cts shapes (ts-jest vs. @swc/jest — see
+    // fixExpressServiceE2eProject's own tests for that variance) this
+    // workspace produces isn't deterministic here, but the port fix applies
+    // to both identically.
+    for (const file of ['global-setup.ts', 'global-teardown.ts']) {
+      const content = host.read(`${e2eRoot}/src/support/${file}`).toString();
+      expect(content).not.toContain(': 3000');
+      expect(content).toContain(': 3333');
+    }
+    const testSetup = host
+      .read(`${e2eRoot}/src/support/test-setup.ts`)
+      .toString();
+    expect(testSetup).not.toContain("?? '3000'");
+    expect(testSetup).toContain("?? '3333'");
+  }, 60000);
+
   it('merges .mcp.json without clobbering other servers or a customized entry', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     writeJson(host, '.mcp.json', {

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -23,9 +23,15 @@ import {
   addEslintQualityRules,
   addJestCoverageConfig,
   addSemgrepTarget,
+  fixExpressServiceE2eProject,
 } from '../../utils/quality';
 import initGenerator from '../init/init';
 import { Schema, NormalizedSchema } from './schema';
+
+// Must match environment.ts.__tmpl__'s own `PORT: num({ default: ... })` —
+// there's no --port option to source this from yet, so it's a second literal
+// kept in sync by convention rather than a single shared value.
+const DEFAULT_PORT = 3333;
 
 async function normalizeOptions(
   host: Tree,
@@ -80,15 +86,30 @@ export default async function (host: Tree, options: Schema) {
 
   const normalizedOptions = await normalizeOptions(host, options);
 
-  await initExpress(host, {
+  // @nx/express's own Schema type doesn't declare e2eTestRunner, even though
+  // its implementation forwards it straight through to @nx/node's own
+  // applicationGenerator (which does). Assigning to an inferred-type const
+  // first, rather than passing the object literal directly, sidesteps
+  // TypeScript's excess-property check on a type that's simply incomplete.
+  const initExpressOptions = {
     ...options,
     skipFormat: true,
     skipPackageJson: false,
     linter: Linter.EsLint,
     unitTestRunner: 'jest',
+    e2eTestRunner: 'jest',
     js: false,
     directory: normalizedOptions.projectRoot,
-  });
+  };
+  await initExpress(host, initExpressOptions);
+
+  // @nx/node:e2e-project's own generated output has two bugs of its own —
+  // see fixExpressServiceE2eProject's doc comment for how each was confirmed.
+  fixExpressServiceE2eProject(
+    host,
+    `${normalizedOptions.projectRoot}-e2e`,
+    DEFAULT_PORT,
+  );
 
   addDependenciesToPackageJson(
     host,

--- a/packages/nx-adsp/src/utils/quality.spec.ts
+++ b/packages/nx-adsp/src/utils/quality.spec.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { addJestCoverageConfig } from './quality';
+import { addJestCoverageConfig, fixExpressServiceE2eProject } from './quality';
 
 function makeConfig(coverageDirectoryLine: string): string {
   return [
@@ -65,5 +65,155 @@ describe('addJestCoverageConfig', () => {
   it('is a no-op when there is no jest config', () => {
     expect(() => addJestCoverageConfig(tree, 'apps/none')).not.toThrow();
     expect(tree.exists('apps/none/jest.config.cts')).toBe(false);
+  });
+});
+
+describe('fixExpressServiceE2eProject', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  // Byte-for-byte what @nx/node:e2e-project actually writes when the
+  // workspace has @swc/jest available — confirmed via a real `nx e2e` run,
+  // which failed to parse with exactly this shape.
+  const SWC_JEST_CONFIG = `/* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config for the spec files
+const swcJestConfig = JSON.parse(
+  readFileSync(\`\${__dirname}/.spec.swcrc\`, 'utf-8'),
+);
+
+// Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+swcJestConfig.swcrc = false;
+
+export default {
+  displayName: '@org/test-service-e2e',
+  preset: '../jest.preset.js',
+  globalSetup: '<rootDir>/src/support/global-setup.ts',
+  globalTeardown: '<rootDir>/src/support/global-teardown.ts',
+  setupFiles: ['<rootDir>/src/support/test-setup.ts'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: 'test-output/jest/coverage',
+};
+`;
+
+  // What @nx/node:e2e-project writes when the workspace uses ts-jest instead
+  // (this repo's own case) — already valid CommonJS, nothing to fix.
+  const TS_JEST_CONFIG = `module.exports = {
+  displayName: 'test-e2e',
+  preset: '../../jest.preset.js',
+  globalSetup: '<rootDir>/src/support/global-setup.ts',
+  globalTeardown: '<rootDir>/src/support/global-teardown.ts',
+  setupFiles: ['<rootDir>/src/support/test-setup.ts'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\\\.[tj]s$': ['ts-jest', {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../coverage/test-e2e',
+};
+`;
+
+  const GLOBAL_SETUP = `import { waitForPortOpen } from '@nx/node/utils';
+
+/* eslint-disable */
+var __TEARDOWN_MESSAGE__: string;
+
+module.exports = async function () {
+  console.log('\\nSetting up...\\n');
+
+  const host = process.env.HOST ?? 'localhost';
+  const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+  await waitForPortOpen(port, { host });
+
+  globalThis.__TEARDOWN_MESSAGE__ = '\\nTearing down...\\n';
+};
+`;
+
+  const GLOBAL_TEARDOWN = `import { killPort } from '@nx/node/utils';
+/* eslint-disable */
+
+module.exports = async function () {
+  const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+  await killPort(port);
+  console.log(globalThis.__TEARDOWN_MESSAGE__);
+};
+`;
+
+  const TEST_SETUP = `/* eslint-disable */
+import axios from 'axios';
+
+module.exports = async function () {
+  const host = process.env.HOST ?? 'localhost';
+  const port = process.env.PORT ?? '3000';
+  axios.defaults.baseURL = \`http://\${host}:\${port}\`;
+};
+`;
+
+  function writeE2eProject(root: string, jestConfig: string): void {
+    tree.write(`${root}/jest.config.cts`, jestConfig);
+    tree.write(`${root}/src/support/global-setup.ts`, GLOBAL_SETUP);
+    tree.write(`${root}/src/support/global-teardown.ts`, GLOBAL_TEARDOWN);
+    tree.write(`${root}/src/support/test-setup.ts`, TEST_SETUP);
+  }
+
+  it('rewrites the @swc/jest variant of jest.config.cts to CommonJS', () => {
+    writeE2eProject('apps/svc-e2e', SWC_JEST_CONFIG);
+
+    fixExpressServiceE2eProject(tree, 'apps/svc-e2e', 3333);
+
+    const out = tree.read('apps/svc-e2e/jest.config.cts').toString();
+    expect(out).not.toContain('export default');
+    expect(out).not.toMatch(/^import /m);
+    expect(out).toContain('module.exports = {');
+    expect(out).toContain("const { readFileSync } = require('fs');");
+  });
+
+  it('leaves the ts-jest variant of jest.config.cts untouched (already valid CommonJS)', () => {
+    writeE2eProject('apps/svc-e2e', TS_JEST_CONFIG);
+
+    fixExpressServiceE2eProject(tree, 'apps/svc-e2e', 3333);
+
+    expect(tree.read('apps/svc-e2e/jest.config.cts').toString()).toBe(
+      TS_JEST_CONFIG,
+    );
+  });
+
+  it('fixes the hardcoded port default in all three support files', () => {
+    writeE2eProject('apps/svc-e2e', TS_JEST_CONFIG);
+
+    fixExpressServiceE2eProject(tree, 'apps/svc-e2e', 3333);
+
+    const setup = tree
+      .read('apps/svc-e2e/src/support/global-setup.ts')
+      .toString();
+    expect(setup).toContain(
+      'process.env.PORT ? Number(process.env.PORT) : 3333',
+    );
+    const teardown = tree
+      .read('apps/svc-e2e/src/support/global-teardown.ts')
+      .toString();
+    expect(teardown).toContain(
+      'process.env.PORT ? Number(process.env.PORT) : 3333',
+    );
+    const testSetup = tree
+      .read('apps/svc-e2e/src/support/test-setup.ts')
+      .toString();
+    expect(testSetup).toContain("process.env.PORT ?? '3333'");
+  });
+
+  it('is a no-op when there is no e2e project at that root', () => {
+    expect(() =>
+      fixExpressServiceE2eProject(tree, 'apps/none-e2e', 3333),
+    ).not.toThrow();
+    expect(tree.exists('apps/none-e2e/jest.config.cts')).toBe(false);
   });
 });

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -142,6 +142,107 @@ export function guardPlaywrightWebServer(
   }
 }
 
+/**
+ * Fixes two bugs that surface when e2e testing is added to express-service,
+ * confirmed by actually running the generated `e2e` target rather than just
+ * inspecting the templates. The two have different owners — kept together
+ * here only because both need fixing at the same call site, not because
+ * they share a cause:
+ *
+ * 1. UPSTREAM BUG, not nx-adsp's — lives entirely inside `@nx/node`'s own
+ *    `e2e-project` generator (triggered here via `e2eTestRunner: 'jest'` on
+ *    the express application generator). Nothing about nx-adsp's own code
+ *    causes it, and it would reproduce in a plain `@nx/node`/`@nx/express`
+ *    workspace with no nx-adsp involved at all. Kept as a local workaround
+ *    anyway since nx-adsp doesn't control Nx's release cadence and a safe
+ *    no-op against already-correct output (see below) costs nothing if
+ *    upstream fixes it later — worth reporting to `nrwl/nx` regardless.
+ *
+ *    `@nx/node:e2e-project` writes one of two shapes for `jest.config.cts`
+ *    depending on whether `@swc/jest` is present in the workspace — not
+ *    necessarily for this project itself; a Vue/React app elsewhere in a
+ *    multi-app workspace pulling in `@swc/core` for its own build is enough
+ *    to flip it. The `@swc/jest` shape is `export default {...}` with a
+ *    top-level `import` — ESM syntax in a `.cts` file, which Node/ts-jest/SWC
+ *    always treat as CommonJS regardless of the workspace's own
+ *    `package.json` "type". Jest's own config loader (unlike its `transform`
+ *    pipeline, which only applies to *test* files) can't reconcile the two,
+ *    so the config fails to parse before a single test runs — every target
+ *    that reads it breaks outright with `SyntaxError: Cannot use import
+ *    statement outside a module`. Rewritten to `const {...} = require(...)`
+ *    / `module.exports = {...}`, matching both the pattern the service's own
+ *    `jest.config.cts` already uses correctly and the ts-jest shape
+ *    `@nx/node` writes when `@swc/jest` isn't present — which needs no fix,
+ *    so the two replaces below are safe no-ops against it.
+ *
+ *    (`src/support/*.ts` also import at the top level, but — verified by
+ *    running the target — those are plain `.ts` files that DO go through
+ *    the config's `transform` pipeline, so they don't need this fix; only
+ *    the config file itself, read before that pipeline exists, does.)
+ *
+ * 2. OUR OWN BUG, not Nx's — a convention mismatch entirely on nx-adsp's
+ *    side, not a defect in the upstream generator. `@nx/node:e2e-project`'s
+ *    fallback port of `3000` is a reasonable generic default with no
+ *    knowledge of any particular caller; it's only wrong here because
+ *    nx-adsp's own `environment.ts.__tmpl__` defaults `PORT` to `3333`
+ *    instead (matching `@nx/express`'s own scaffolded `main.ts` before
+ *    nx-adsp replaces it), and until this fix nothing reconciled the two.
+ *    There's no upstream fix to wait for — reconciling nx-adsp's own port
+ *    convention with whatever generates the e2e project is squarely
+ *    nx-adsp's job. Confirmed via a real run:
+ *    the express app logs `Listening at http://localhost:3333`, while
+ *    `global-setup.ts` waits on `3000` and never sees it open — the target
+ *    hangs, then fails with `Jest: Got error running globalSetup ...
+ *    reason: [AggregateError]`, no port number anywhere in the message.
+ */
+export function fixExpressServiceE2eProject(
+  host: Tree,
+  e2eProjectRoot: string,
+  port: number,
+): void {
+  const jestConfigPath = `${e2eProjectRoot}/jest.config.cts`;
+  if (host.exists(jestConfigPath)) {
+    const cfg = host
+      .read(jestConfigPath)
+      .toString()
+      .replace(
+        /^import \{([^}]+)\} from '([^']+)';$/m,
+        "const {$1} = require('$2');",
+      )
+      .replace(/^export default \{/m, 'module.exports = {');
+    host.write(jestConfigPath, cfg);
+  }
+
+  for (const file of ['global-setup.ts', 'global-teardown.ts']) {
+    const path = `${e2eProjectRoot}/src/support/${file}`;
+    if (!host.exists(path)) continue;
+    host.write(
+      path,
+      host
+        .read(path)
+        .toString()
+        .replace(
+          /process\.env\.PORT \? Number\(process\.env\.PORT\) : 3000/,
+          `process.env.PORT ? Number(process.env.PORT) : ${port}`,
+        ),
+    );
+  }
+
+  const testSetupPath = `${e2eProjectRoot}/src/support/test-setup.ts`;
+  if (host.exists(testSetupPath)) {
+    host.write(
+      testSetupPath,
+      host
+        .read(testSetupPath)
+        .toString()
+        .replace(
+          /process\.env\.PORT \?\? '3000'/,
+          `process.env.PORT ?? '${port}'`,
+        ),
+    );
+  }
+}
+
 export function addVsCodeSettings(host: Tree): void {
   const settingsPath = '.vscode/settings.json';
   const settings = {


### PR DESCRIPTION
## Summary

Per `NX-ADSP-E2E-PORT-DEFAULT-MISMATCH-BUG.md` and `NX-ADSP-E2E-PROJECT-CTS-ESM-SYNTAX-BUG.md`: backend services got zero e2e scaffolding — frontends (`react-app`/`vue-app`/`angular-app`) already auto-scaffold Playwright e2e via `e2eTestRunner`, but `express-service` passed nothing, so anyone adding e2e to a service had to manually run the generic `e2e-project` recipe and immediately hit two bugs with **different owners**:

1. **Upstream bug, not nx-adsp's.** `@nx/node:e2e-project` writes `jest.config.cts` as `export default {...}` with a top-level `import` when `@swc/jest` is present in the workspace — not necessarily for this project; a Vue/React app elsewhere in the same multi-app workspace pulling in `@swc/core` is enough to flip it. ESM syntax in a `.cts` file always parses as CommonJS, so the config fails outright with `SyntaxError: Cannot use import statement outside a module`. This lives entirely inside `@nx/node`'s own generator and would reproduce in a plain `@nx/node`/`@nx/express` workspace with no nx-adsp involved at all. Kept as a local workaround here anyway — nx-adsp doesn't control Nx's release cadence, and it's a verified no-op against the `ts-jest` shape `@nx/node` writes when `@swc/jest` isn't present (this repo's own case) — but it's worth reporting to `nrwl/nx` separately; **not** done as part of this change.
2. **Our own bug, not Nx's.** The same generator hardcodes a fallback port of `3000` in `global-setup`/`global-teardown`/`test-setup`, while nx-adsp's own `environment.ts.__tmpl__` defaults `PORT` to `3333`. Nothing reconciles the two, so the app listens on `3333` while `global-setup` waits on `3000` forever, surfacing only as `Jest: Got error running globalSetup ... reason: [AggregateError]` — no port number anywhere in the message. There's no upstream fix to wait for here; reconciling nx-adsp's own port convention is squarely nx-adsp's job.

Both confirmed via a real `nx e2e` run in a scratch workspace (not just inspecting templates) — reproduced each failure exactly as described, then fixed and re-ran end to end (setup → real HTTP request → teardown) to confirm.

- `express-service` now passes `e2eTestRunner: 'jest'` (matching frontend parity) and runs a new `fixExpressServiceE2eProject` post-processing step, mirroring the existing `guardPlaywrightWebServer` pattern already used for frontends.
- Worth noting: I could **not** reproduce the ESM syntax bug in this repo's own test environment (it uses `ts-jest`, which `@nx/node:e2e-project` correctly detects and generates a valid CommonJS config for) — only in a scratch workspace with `@swc/jest` installed. The fix handles both shapes safely (a no-op against the already-valid ts-jest variant), and the unit tests cover both directly with the real captured content from each.

## Test plan
- [x] `nx lint,test,build nx-adsp` (+ its `nx-oc` dependency) — 86 tests pass (5 new), lint/build clean
- [x] Manual end-to-end repro in a scratch workspace: generated a real `@nx/express` app with `e2eTestRunner: jest`, confirmed both bugs exactly as reported (`SyntaxError: Cannot use import statement outside a module`, then `Jest: Got error running globalSetup ... [AggregateError]` with the app actually listening on 3333 while global-setup waited on 3000), applied the same fixes by hand, and confirmed the `e2e` target runs the full pipeline (setup → test → teardown) without any infrastructure failure