### PR TITLE
chore(deps): bump @abgov/adsp-cli to ^1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abgov/adsp-cli": "^1.5.2",
+        "@abgov/adsp-cli": "^1.6.0",
         "@angular/core": "21.2.17",
         "@nx/devkit": "23.0.1",
         "json-schema-to-typescript": "^13.0.1",
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@abgov/adsp-cli": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.5.2.tgz",
-      "integrity": "sha512-O2VyNZBoCcSr+D82YsszKSg7M0kKAuj3SiJ2Hii+5XYhyqbk6bD0cPFFPDUKtwBiNvffgfCalGUDg9Lj0qbkUA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.6.0.tgz",
+      "integrity": "sha512-jBh3t5aPGJ3EVc9E5UW9fJQsLKL2ExmEfmwIZaHSzCdkiNmy6NzXxH0rACjFSChStVVGRszQx3UV8neAKQKoiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "private": true,
   "dependencies": {
-    "@abgov/adsp-cli": "^1.5.2",
+    "@abgov/adsp-cli": "^1.6.0",
     "@angular/core": "21.2.17",
     "@nx/devkit": "23.0.1",
     "json-schema-to-typescript": "^13.0.1",

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -265,7 +265,7 @@ have a tenant yet? That picker also offers a **+ Create a new tenant** choice â€
 `tenant-service-admin`, and (unless `tenant-service-admin`) that doesn't already own a tenant (one
 per admin email). Picking it prompts for a name and waits for the new realm to finish provisioning
 before continuing the login as that tenant. Requires `@abgov/adsp-cli` ^1.4.0+ (this plugin pins
-^1.5.2 or later).
+^1.6.0 or later).
 
 ## Agent consultation
 

--- a/packages/nx-oc/package.json
+++ b/packages/nx-oc/package.json
@@ -14,7 +14,7 @@
     "tslib": "^2.0.0"
   },
   "dependencies": {
-    "@abgov/adsp-cli": "^1.5.2",
+    "@abgov/adsp-cli": "^1.6.0",
     "axios": "^1.16.0",
     "enquirer": "^2.3.6",
     "yaml": "~2.9.0"


### PR DESCRIPTION
## Summary

`@abgov/adsp-cli` 1.6.0 improves the tenant picker UX for large tenant lists — confirmed via the upstream changelog at `GovAlta/adsp-monorepo`:

> **Features**
> - **adsp-cli:** improve tenant picker UX for large tenant lists

Bumped `^1.5.2` → `^1.6.0` in both places it's pinned (root `package.json` and `packages/nx-oc/package.json`, the only real dependency on it), updated the package README's "this plugin pins X or later" note to match, and regenerated `package-lock.json` via `npm install`.

## Test plan
- [x] Checked npm's registry + the upstream changelog before bumping — confirms the described tenant-picker improvement, no unexpected breaking changes
- [x] `package-lock.json` diff is scoped to exactly this bump (4 lines changed) — no other dependencies shifted
- [x] `npm audit` — no new vulnerabilities trace to `@abgov/adsp-cli`'s own dependency tree
- [x] `nx lint,test,build nx-oc,nx-adsp` — 122 + 81 tests pass, lint/build clean