### PR TITLE
feat(nx-adsp,nx-oc): differentiate liveness from readiness, check DB connectivity

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -192,6 +192,13 @@ describe('Express Service Generator', () => {
     const database = host.read('apps/test/src/database.ts').toString();
     expect(database).toContain('drizzle-orm/node-postgres');
     expect(database).toContain('closeDatabase');
+    expect(database).toContain('isDatabaseReady');
+
+    // Readiness (DB-checked) is wired up separately from liveness — a DB
+    // outage should hold traffic, not restart a pod that can't fix it.
+    const mainTs = host.read('apps/test/src/main.ts').toString();
+    expect(mainTs).toContain('isDatabaseReady');
+    expect(mainTs).toContain("app.get('/health/ready'");
 
     // webpack emits a second bundle (migrate.js) for the deploy init container.
     const webpackConfig = host.read('apps/test/webpack.config.js').toString();
@@ -233,6 +240,11 @@ describe('Express Service Generator', () => {
 
     const database = host.read('apps/test/src/database.ts').toString();
     expect(database).toContain('mongoose');
+    expect(database).toContain('isDatabaseReady');
+
+    const mainTs = host.read('apps/test/src/main.ts').toString();
+    expect(mainTs).toContain('isDatabaseReady');
+    expect(mainTs).toContain("app.get('/health/ready'");
 
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['dev-db']).toBeTruthy();
@@ -248,6 +260,12 @@ describe('Express Service Generator', () => {
     expect(host.exists('apps/test/src/db/schema.ts')).toBeFalsy();
     expect(host.exists('apps/test/src/database.ts')).toBeFalsy();
     expect(host.exists('apps/test/scripts/dev-db.sh')).toBeFalsy();
+
+    // No database to check readiness against — don't emit a route that
+    // would always report ready regardless of anything real.
+    const mainTs = host.read('apps/test/src/main.ts').toString();
+    expect(mainTs).not.toContain('/health/ready');
+    expect(mainTs).not.toContain('isDatabaseReady');
 
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['dev-db']).toBeFalsy();

--- a/packages/nx-adsp/src/generators/express-service/files-mongo/src/database.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-mongo/src/database.ts__tmpl__
@@ -9,3 +9,13 @@ export async function connectDatabase(): Promise<void> {
 export async function disconnectDatabase(): Promise<void> {
   await mongoose.disconnect();
 }
+
+// A real ping, not just `readyState === 1` — the connection can report
+// "connected" while actually stale. Used by /health/ready, not by `main.ts`
+// directly.
+export async function isDatabaseReady(): Promise<void> {
+  if (!mongoose.connection.db) {
+    throw new Error('Database connection not established.');
+  }
+  await mongoose.connection.db.admin().ping();
+}

--- a/packages/nx-adsp/src/generators/express-service/files-postgres/src/database.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files-postgres/src/database.ts__tmpl__
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
@@ -12,3 +13,10 @@ const pool = new Pool({ connectionString: environment.DATABASE_URL });
 export const db = drizzle(pool, { schema });
 
 export const closeDatabase = (): Promise<void> => pool.end();
+
+// A trivial round-trip query, not just a pool-state check — proves the
+// database is actually reachable and answering, the same reason `pg_isready`
+// exists. Used by /health/ready, not by `main.ts` directly.
+export const isDatabaseReady = async (): Promise<void> => {
+  await db.execute(sql`SELECT 1`);
+};

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -68,6 +68,17 @@ need project-scoped MCP enabled. The server runs via `npx` and needs no credenti
 | `src/database.ts` | Mongoose connection helpers — `connectDatabase()` and `disconnectDatabase()` |
 <% } %>
 
+## Health and readiness checks
+
+`/health` and (<% if (database !== 'none') { %>already, since this service has a database<% } else { %>if this service later gains a database or another required dependency<% } %>) `/health/ready` are two different questions, mapped to the two different OpenShift probes for a reason — conflating them into one endpoint means an outage in a downstream dependency gets treated as "restart this pod," which does not fix the outage and just adds a restart loop on top of it:
+
+- **`/health` — liveness: is the process itself up.** Stays dependency-free on purpose. Don't add a check here for anything this service depends on but doesn't own.
+<% if (database !== 'none') { %>
+- **`/health/ready` — readiness: can this pod actually serve requests right now.** Already checks the database (`isDatabaseReady()` in `src/database.ts`) — a real round-trip query, not just a pool-state flag. **Extend this handler, not `/health`, for any other resource this service can't function without** — another required downstream API, a message broker, a required ADSP capability beyond what `healthCheck()` already covers — following the same reasoning: a dependency being down should hold traffic (503, readiness), not trigger a pod restart (liveness) that can't fix a problem outside this pod.
+<% } else { %>
+- If this service later gains a database or another hard dependency, add a `/health/ready` route that checks it (see `@abgov/nx-adsp:express-service --database postgres|mongo` for the shipped pattern) and point the deployment's `readinessProbe` at it instead of `/health` — don't check dependencies from the liveness route.
+<% } %>
+
 ## SDK capabilities
 
 `initializeService()` returns `capabilities`:

--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -7,9 +7,9 @@ import helmet from 'helmet';
 import passport from 'passport';
 import { Strategy as AnonymousStrategy } from 'passport-anonymous';
 <% if (database === 'postgres') { %>
-import { closeDatabase } from './database';
+import { closeDatabase, isDatabaseReady } from './database';
 <% } else if (database === 'mongo') { %>
-import { connectDatabase, disconnectDatabase } from './database';
+import { connectDatabase, disconnectDatabase, isDatabaseReady } from './database';
 <% } %>
 import { environment } from './environment';
 import { exampleEventDefinition } from './events';
@@ -54,10 +54,34 @@ async function initializeApp() {
   passport.use('tenant', tenantStrategy);
   app.use(passport.initialize());
 
+  // Liveness — is the process itself up. Deliberately stays dependency-free
+  // (platform reachability, not this app's own resources) so an outage in a
+  // downstream dependency doesn't get treated as "restart this pod," which
+  // wouldn't fix the outage and would just cause a needless restart loop.
   app.get('/health', async (_req, res) => {
     const platform = await healthCheck();
     res.json({ ...platform });
   });
+<% if (database !== 'none') { %>
+  // Readiness — can this pod actually serve requests right now. Checks the
+  // database because this service can't do anything useful without it; 503
+  // tells the platform to hold traffic rather than route it somewhere that
+  // will 500. Extend this handler (not /health above) for any other resource
+  // this service can't function without — another required downstream API,
+  // a message broker, etc. — following the same "hold traffic, don't
+  // restart" reasoning; see AGENTS.md's "Health and readiness checks".
+  app.get('/health/ready', async (_req, res) => {
+    try {
+      await isDatabaseReady();
+      res.json({ ready: true });
+    } catch (err) {
+      res.status(503).json({
+        ready: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+<% } %>
 
   // Generated once from the routers' registry.registerPath() calls (see
   // routes/example.ts) — every router imported above has already registered
@@ -85,6 +109,9 @@ async function initializeApp() {
       _links: {
         self: { href: new URL(req.originalUrl, rootUrl).href },
         health: { href: new URL('/health', rootUrl).href },
+<% if (database !== 'none') { %>
+        ready: { href: new URL('/health/ready', rootUrl).href },
+<% } %>
         api: { href: new URL('/<%= projectName %>/v1', rootUrl).href },
         docs: { href: new URL('/swagger/docs/v1', rootUrl).href },
       },

--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -158,6 +158,9 @@ describe('Deployment Generator', () => {
     const manifest = host.read('.openshift/test/test.yml').toString();
     expect(manifest).toContain('readinessProbe');
     expect(manifest).toContain('livenessProbe');
+    // No database configured — readiness falls back to the plain liveness
+    // endpoint rather than pointing at a /health/ready that doesn't exist.
+    expect(manifest).not.toContain('/health/ready');
     // The service authenticates with ADSP using a confidential client secret,
     // injected from the ${APP_NAME}-secrets Secret.
     expect(manifest).toContain('CLIENT_SECRET');
@@ -227,6 +230,9 @@ describe('Deployment Generator', () => {
     expect(manifest).toContain('DATABASE_URL');
     expect(manifest).toContain('initContainers');
     expect(manifest).toContain('migrate.js');
+    // Readiness (not liveness) points at the DB-checked endpoint — a DB
+    // outage should hold traffic, not restart a pod that can't fix it.
+    expect(manifest).toContain('path: /health/ready');
   });
 
   it('includes MONGODB_URI secretKeyRef without init container for mongo node deployment', async () => {
@@ -255,6 +261,7 @@ describe('Deployment Generator', () => {
     const manifest = host.read('.openshift/test/test.yml').toString();
     expect(manifest).toContain('MONGODB_URI');
     expect(manifest).not.toContain('initContainers');
+    expect(manifest).toContain('path: /health/ready');
   });
 
   it('throws an actionable error when the app type cannot be detected', async () => {

--- a/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
@@ -187,7 +187,11 @@ objects:
                   memory: 50Mi
               readinessProbe:
                 httpGet:
+<% if (database === 'postgres' || database === 'mongo') { %>
+                  path: /health/ready
+<% } else { %>
                   path: /health
+<% } %>
                   port: 3333
                 initialDelaySeconds: 10
                 periodSeconds: 10


### PR DESCRIPTION
## Summary
- `express-service`'s generated `/health` was used for both the `readinessProbe` and `livenessProbe`, and never checked this service's own database — a DB outage would go unnoticed by the platform (traffic kept routing to an instance that can't serve real requests) and, since liveness shares the same endpoint, could also trigger needless pod restarts that can't fix an outage outside the pod.
- Adds `/health/ready` (postgres and mongo) backed by a real round-trip check (`SELECT 1` / `admin().ping()`), not a pool-state flag. `/health` stays dependency-free for liveness.
- The deployment manifest's `readinessProbe` now points at `/health/ready` when a database is configured (`nx-oc`'s `deployment`/`sandbox` generators share this template); no dead route is added when there isn't one.
- `AGENTS.md` gains a "Health and readiness checks" section, and `main.ts` itself carries a comment at the exact point someone would extend it, instructing that any other hard dependency (a required downstream API, a message broker) belongs on `/health/ready`, never `/health`, for the same "hold traffic, don't restart" reason.

## Test plan
- [x] `nx-adsp` unit tests updated (postgres, mongo, and no-database cases, including the negative case — no `/health/ready` route when there's no database)
- [x] `nx-oc` deployment generator tests updated (readiness path assertions for postgres, mongo, and no-database)
- [x] `nx test`, `nx lint`, `nx build` green for both `nx-adsp` and `nx-oc`
- [x] The new `isDatabaseReady()` implementations (Drizzle `sql` query, Mongoose `admin().ping()`) independently type-checked against the real installed `drizzle-orm`/`mongoose` type definitions in a throwaway scratch project, not just string-matched by the generator's own unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)