### PR TITLE
fix(nx-oc): let sandbox and deployment coexist instead of colliding on one manifest

### DIFF
--- a/docs/nx-oc/nx-oc.md
+++ b/docs/nx-oc/nx-oc.md
@@ -118,6 +118,15 @@ npx nx g @abgov/nx-oc:deployment my-app --appType node --env dev
 
 Run the generator once per environment per application. For a typical three-environment setup, run it three times with `--env dev`, `--env test`, and `--env prod`.
 
+`deployment` writes `.openshift/<project>/<project>.yml`; [`sandbox`](#sandbox) writes
+`.openshift/<project>/<project>.sandbox.yml` alongside it and shares the same
+`.openshift/<project>/Dockerfile` (identical either way). A project can have both — a real
+CI-driven pipeline deployment and a sandbox for local experimentation — at the same time;
+running one never touches the other's manifest. Every object either renders also carries a
+`deployment-mode: pipeline`/`sandbox` label (alongside the existing `app` label), so the
+`teardown-<env>` and `sandbox-teardown` targets' label-selector deletes can never remove the
+other mode's resources even if they ever land in the same namespace.
+
 The database connection secret must be created manually in each environment project before the first deploy:
 
 ```bash
@@ -164,8 +173,8 @@ The generator adds `sandbox` and `sandbox-teardown` targets to the project and c
 ```
 .openshift/
   ├─ my-app/
-  │   ├─ Dockerfile          ← built locally by the sandbox target
-  │   └─ my-app.yml          ← sandbox deployment manifest
+  │   ├─ Dockerfile          ← built locally by the sandbox target (shared with `deployment`)
+  │   └─ my-app.sandbox.yml  ← sandbox deployment manifest (coexists with `deployment`'s my-app.yml)
   └─ sandbox/
       └─ sandbox-postgres.yml  ← shared DB (written once, reused by all apps)
 ```

--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -192,7 +192,7 @@ describe('nx-adsp e2e', () => {
       );
       checkFilesExist(
         `.openshift/${svc}/Dockerfile`,
-        `.openshift/${svc}/${svc}.yml`,
+        `.openshift/${svc}/${svc}.sandbox.yml`,
       );
       // The in-cluster BuildConfig manifest is gone.
       expect(
@@ -225,7 +225,7 @@ describe('nx-adsp e2e', () => {
       );
       checkFilesExist(
         `.openshift/${app}/Dockerfile`,
-        `.openshift/${app}/${app}.yml`,
+        `.openshift/${app}/${app}.sandbox.yml`,
       );
       expect(
         existsSync(join(tmpProjPath(), `.openshift/${app}/sandbox-build.yml`)),

--- a/packages/nx-oc/README.md
+++ b/packages/nx-oc/README.md
@@ -93,6 +93,15 @@ npx nx g @abgov/nx-oc:deployment my-app --appType node --env dev
 
 Run the generator once per environment per application. For a typical three-environment setup, run it three times with `--env dev`, `--env test`, and `--env prod`.
 
+`deployment` writes `.openshift/<project>/<project>.yml`; [`sandbox`](#sandbox-deployment-local-build)
+writes `.openshift/<project>/<project>.sandbox.yml` alongside it and shares the same
+`.openshift/<project>/Dockerfile` (identical either way). A project can have both — a
+real CI-driven pipeline deployment and a sandbox for local experimentation — at the same
+time; running one never touches the other's manifest. Every object either renders also
+carries a `deployment-mode: pipeline`/`sandbox` label (alongside the existing `app` label),
+so the `teardown-<env>` and `sandbox-teardown` targets' label-selector deletes can never
+remove the other mode's resources even if they ever land in the same namespace.
+
 ---
 
 ## Executor: `apply`

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -67,6 +67,11 @@ describe('sandbox executor', () => {
       true,
     );
     expect(has('oc create secret docker-registry ghcr-pull')).toBe(true);
+    expect(
+      has(
+        'oc process -f .openshift/test/test.sandbox.yml -p PROJECT=test-sandbox',
+      ),
+    ).toBe(true);
     expect(has('oc rollout restart deployment/test -n test-sandbox')).toBe(
       true,
     );

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -318,7 +318,7 @@ export default async function runExecutor(
 
     run(
       'Apply manifest',
-      `oc process -f .openshift/${projectName}/${projectName}.yml -p PROJECT=${sandboxProject} | oc apply -f -`,
+      `oc process -f .openshift/${projectName}/${projectName}.sandbox.yml -p PROJECT=${sandboxProject} | oc apply -f -`,
       cwd,
     );
     run(

--- a/packages/nx-oc/src/generators/deployment/deployment.spec.ts
+++ b/packages/nx-oc/src/generators/deployment/deployment.spec.ts
@@ -314,4 +314,43 @@ describe('Deployment Generator', () => {
     const config = readProjectConfiguration(host, 'test');
     expect(config.targets['apply-envs']).toBeFalsy();
   });
+
+  it('coexists with an existing sandbox deployment for the same project', async () => {
+    // sandbox writes its manifest to <project>.sandbox.yml (see sandbox.spec.ts),
+    // so deployment writing the pipeline-shaped <project>.yml alongside it must
+    // not disturb the sandbox manifest.
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await pipeline(host, {
+      pipeline: 'test',
+      registry: 'ghcr.io/test-org',
+      type: 'jenkins',
+      infra: 'test-infra',
+      envs: 'test-dev',
+    });
+
+    addProjectConfiguration(host, 'test', {
+      root: 'apps/test',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          options: { compiler: 'tsc', target: 'node' },
+        },
+      },
+    });
+    host.write(
+      '.openshift/test/test.sandbox.yml',
+      'kind: Template\nlabels:\n  deployment-mode: sandbox\n',
+    );
+
+    await generator(host, { ...options, appType: 'node' });
+
+    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
+    expect(host.exists('.openshift/test/test.sandbox.yml')).toBeTruthy();
+    expect(host.read('.openshift/test/test.sandbox.yml').toString()).toContain(
+      'deployment-mode: sandbox',
+    );
+    const manifest = host.read('.openshift/test/test.yml').toString();
+    expect(manifest).toContain('deployment-mode: pipeline');
+  });
 });

--- a/packages/nx-oc/src/generators/deployment/dotnet-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/dotnet-files/__projectName__.yml__tmpl__
@@ -4,6 +4,7 @@ metadata:
   name: <%= projectName %>
 labels:
   app: <%= projectName %>
+  deployment-mode: <%= sandbox ? 'sandbox' : 'pipeline' %>
 parameters:
 <% if (!sandbox) { %>
   - name: INFRA_PROJECT

--- a/packages/nx-oc/src/generators/deployment/frontend-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/frontend-files/__projectName__.yml__tmpl__
@@ -4,6 +4,7 @@ metadata:
   name: <%= projectName %>
 labels:
   app: <%= projectName %>
+  deployment-mode: <%= sandbox ? 'sandbox' : 'pipeline' %>
 parameters:
 <% if (!sandbox) { %>
   - name: INFRA_PROJECT

--- a/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
@@ -4,6 +4,7 @@ metadata:
   name: <%= projectName %>
 labels:
   app: <%= projectName %>
+  deployment-mode: <%= sandbox ? 'sandbox' : 'pipeline' %>
 parameters:
 <% if (!sandbox) { %>
   - name: INFRA_PROJECT

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -61,7 +61,7 @@ podman push "$REF"
 oc tag "$REF" <%= projectName %>:sandbox --reference-policy=local -n "$NS"
 until oc import-image <%= projectName %>:sandbox --confirm -n "$NS"; do sleep 3; done
 # (3) apply the manifest and roll out
-oc process -f .openshift/<%= projectName %>/<%= projectName %>.yml -p PROJECT="$NS" | oc apply -f -
+oc process -f .openshift/<%= projectName %>/<%= projectName %>.sandbox.yml -p PROJECT="$NS" | oc apply -f -
 oc rollout restart deployment/<%= projectName %> -n "$NS"
 oc rollout status  deployment/<%= projectName %> -n "$NS" --timeout=180s
 ```
@@ -81,7 +81,7 @@ oc get pods -n <%= sandboxProject %> -l name=<%= projectName %>
   `gh auth switch -u <account>`, then re-run with `--skipBuild`.
 - **Pod `FailedCreate` "exceeded quota"** — the namespace CPU quota is full.
   Free room: `oc get deploy -n <%= sandboxProject %>` then delete stale apps
-  (`oc delete all,configmap,is -l app=<old-app> -n <%= sandboxProject %>`), and re-run.
+  (`oc delete all,configmap,is -l app=<old-app>,deployment-mode=sandbox -n <%= sandboxProject %>`), and re-run.
 - **Pod `CrashLoopBackOff`** — `oc logs -n <%= sandboxProject %> <pod> -c <%= projectName %>`.<% if (appType === 'node' && database && database !== 'none') { %>
   For the DB migration, also check the init container:
   `oc logs -n <%= sandboxProject %> <pod> -c <%= projectName %>-migrate`.<% } %>

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -64,12 +64,17 @@ describe('Sandbox Generator', () => {
 
     await generator(host, options);
 
-    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
-    const manifest = host.read('.openshift/test/test.yml').toString();
+    // The manifest gets its own filename (rather than <project>.yml) so it can
+    // coexist with a `deployment`-generated pipeline manifest for the same
+    // project instead of one overwriting the other.
+    expect(host.exists('.openshift/test/test.sandbox.yml')).toBeTruthy();
+    expect(host.exists('.openshift/test/test.yml')).toBeFalsy();
+    const manifest = host.read('.openshift/test/test.sandbox.yml').toString();
     expect(manifest).toContain('imagePullPolicy: Always');
     expect(manifest).not.toContain('ImageStream');
     expect(manifest).not.toContain('DEPLOY_TAG');
     expect(manifest).toContain('sandbox');
+    expect(manifest).toContain('deployment-mode: sandbox');
   });
 
   it('errors (does not prompt) when the registry cannot be resolved non-interactively', async () => {
@@ -98,8 +103,8 @@ describe('Sandbox Generator', () => {
 
     await generator(host, options);
 
-    expect(host.exists('.openshift/test/test.yml')).toBeTruthy();
-    const manifest = host.read('.openshift/test/test.yml').toString();
+    expect(host.exists('.openshift/test/test.sandbox.yml')).toBeTruthy();
+    const manifest = host.read('.openshift/test/test.sandbox.yml').toString();
     expect(manifest).toContain('imagePullPolicy: Always');
     expect(manifest).not.toContain('ImageStream');
   });
@@ -199,7 +204,9 @@ describe('Sandbox Generator', () => {
     expect(cmds.some((c) => c.includes('oc delete'))).toBeTruthy();
     expect(cmds.some((c) => c.includes('--ignore-not-found'))).toBeTruthy();
     expect(cmds.some((c) => c.includes('test-sandbox'))).toBeTruthy();
-    expect(cmds.some((c) => c.includes('-l app=test'))).toBeTruthy();
+    expect(
+      cmds.some((c) => c.includes('-l app=test,deployment-mode=sandbox')),
+    ).toBeTruthy();
     expect(cmds.some((c) => c.includes('all,configmap'))).toBeTruthy();
     // Teardown also removes the sandbox package (best-effort).
     expect(
@@ -220,7 +227,9 @@ describe('Sandbox Generator', () => {
       .toString();
     expect(dbManifest).toContain('sandbox-postgres-creds');
 
-    const appManifest = host.read('.openshift/test/test.yml').toString();
+    const appManifest = host
+      .read('.openshift/test/test.sandbox.yml')
+      .toString();
     expect(appManifest).toContain('sandbox-postgres-creds');
     expect(appManifest).toContain('$(POSTGRES_PASSWORD)');
 
@@ -243,7 +252,9 @@ describe('Sandbox Generator', () => {
       .toString();
     expect(dbManifest).toContain('sandbox-mongodb-creds');
 
-    const appManifest = host.read('.openshift/test/test.yml').toString();
+    const appManifest = host
+      .read('.openshift/test/test.sandbox.yml')
+      .toString();
     expect(appManifest).toContain('sandbox-mongodb-creds');
     expect(appManifest).toContain('$(MONGO_PASSWORD)');
 

--- a/packages/nx-oc/src/generators/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.ts
@@ -173,11 +173,21 @@ function addManifestFiles(host: Tree, options: NormalizedSchema) {
     ocInfraProject: options.sandboxProject,
     tmpl: '',
   };
+  const projectDir = `./.openshift/${options.projectName}`;
   generateFiles(
     host,
     path.join(__dirname, `../deployment/${options.appType}-files`),
-    `./.openshift/${options.projectName}`,
+    projectDir,
     templateOptions,
+  );
+  // The Dockerfile is byte-identical either way and stays shared, but the
+  // manifest content genuinely differs (image source, DB secret, no
+  // ImageStream trigger) — give it a distinct name so a project can carry
+  // both a sandbox manifest and a `deployment`-generated pipeline manifest
+  // side by side instead of one overwriting the other.
+  host.rename(
+    `${projectDir}/${options.projectName}.yml`,
+    `${projectDir}/${options.projectName}.sandbox.yml`,
   );
 }
 
@@ -243,7 +253,10 @@ function addSandboxTarget(host: Tree, options: NormalizedSchema) {
       executor: 'nx:run-commands',
       options: {
         commands: [
-          `oc delete all,configmap,is -l app=${projectName} -n ${sandboxProject} --ignore-not-found`,
+          // Scoped by deployment-mode too, not just app, so this can never
+          // delete a pipeline-shaped deployment for the same project that
+          // happens to land in the same namespace.
+          `oc delete all,configmap,is -l app=${projectName},deployment-mode=sandbox -n ${sandboxProject} --ignore-not-found`,
           `oc delete imagestream ${projectName} -n ${sandboxProject} --ignore-not-found`,
           // Remove the sandbox package (needs delete:packages). Best-effort:
           // sandbox packages are the unlinked ones and can also be pruned org-wide

--- a/packages/nx-oc/src/generators/teardown/teardown.spec.ts
+++ b/packages/nx-oc/src/generators/teardown/teardown.spec.ts
@@ -97,7 +97,9 @@ describe('Teardown Generator', () => {
 
     const config = readProjectConfiguration(host, 'test');
     const cmds: string[] = config.targets['teardown-dev'].options.commands;
-    expect(cmds.some((c) => c.includes('-l app=test'))).toBeTruthy();
+    expect(
+      cmds.some((c) => c.includes('-l app=test,deployment-mode=pipeline')),
+    ).toBeTruthy();
     expect(cmds.some((c) => c.includes('all,configmap'))).toBeTruthy();
   });
 });

--- a/packages/nx-oc/src/generators/teardown/teardown.ts
+++ b/packages/nx-oc/src/generators/teardown/teardown.ts
@@ -59,7 +59,10 @@ export default async function (host: Tree, options: Schema) {
       executor: 'nx:run-commands',
       options: {
         commands: [
-          `oc delete all,configmap -l app=${projectName} -n ${envProject} --ignore-not-found`,
+          // Scoped by deployment-mode too, not just app, so this can never
+          // delete a sandbox deployment for the same project that happens to
+          // land in the same namespace.
+          `oc delete all,configmap -l app=${projectName},deployment-mode=pipeline -n ${envProject} --ignore-not-found`,
         ],
       },
     },


### PR DESCRIPTION
## Summary

`sandbox` and `deployment` used to render the exact same shared template (`deployment/${appType}-files`) to the exact same destination (`.openshift/<project>/<project>.yml`) — differing only in whether it's shaped for a local sandbox deploy or the real multi-environment pipeline. Whichever generator ran second silently overwrote the other's manifest, and a project could never have both a real CI pipeline and a sandbox for experimentation at the same time — even though that's a legitimate combination (e.g. experimenting locally against a service that's already deployed via CI).

Rather than gating this with a throw (the original approach in this PR), the two no longer need to collide at all:

- The Dockerfile output is byte-identical in both modes (no `sandbox` branching exists in any of the three `Dockerfile__tmpl__` templates), so it stays fully shared at `.openshift/<project>/Dockerfile`.
- Only the manifest genuinely differs (image source, DB secret names, presence of the ImageStream + image-trigger annotation for the pipeline mode) — `sandbox` now writes it to `<project>.sandbox.yml` instead of `<project>.yml`, so both can exist side by side. `deployment`'s sandbox-collision guard is removed since there's nothing left to collide with.
- Every rendered object also gets a `deployment-mode: pipeline`/`sandbox` label alongside the existing `app` label, and the `teardown-<env>` / `sandbox-teardown` targets' label-selector deletes are scoped to match (`-l app=<project>,deployment-mode=...`) — so one mode's teardown can never remove the other's resources, even in the (unsupported but not actively prevented) case where they land in the same namespace.
- `SANDBOX.md`'s generated runbook and README/docs are updated to match.

## Test plan

- [x] `deployment.spec.ts`: new coexistence test — an existing sandbox manifest at `<project>.sandbox.yml` is untouched after running `deployment`, and the new pipeline manifest carries `deployment-mode: pipeline`.
- [x] `sandbox.spec.ts`: manifest now written to `<project>.sandbox.yml` (not `<project>.yml`), carries `deployment-mode: sandbox`, and `sandbox-teardown`'s delete command is scoped to `deployment-mode=sandbox`.
- [x] `teardown.spec.ts`: `teardown-<env>`'s delete command is scoped to `deployment-mode=pipeline`.
- [x] Sandbox executor spec: `oc process` now reads `<project>.sandbox.yml`.
- [x] `npx nx affected -t lint,test,build --base=origin/main` — all green (nx-oc: 123 tests; nx-adsp: 86 tests).