### PR TITLE
feat(nx-adsp,nx-agent): wire axe-core accessibility checks into generated frontend e2e projects

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -221,6 +221,10 @@ npx nx g @abgov/nx-adsp:react-app my-app --env dev --tenant my-tenant
 | `accessToken` | `-at` | No       | Access token for non-interactive retrieval of ADSP configuration               |
 | `proxy`       | —     | No       | Nginx proxy rule(s): `{ location, proxyPass }` or an array of such objects     |
 
+The generated Playwright e2e project includes an axe-core accessibility check (`a11y.spec.ts`),
+scoped to WCAG 2.1 A/AA, that runs automatically as part of the `e2e` target — no separate command
+needed. `angular-app` and `vue-app` include the same check.
+
 ---
 
 ### angular-app

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -161,6 +161,10 @@ npx nx g @abgov/nx-adsp:react-app my-app --env dev --tenant my-tenant
 | `accessToken` | `-at` | No       | Access token for non-interactive retrieval of ADSP configuration                                                                                                                   |
 | `proxy`       | —     | No       | Nginx proxy rule(s) as `{ location, proxyPass }` or an array of such objects                                                                                                       |
 
+The generated Playwright e2e project includes an axe-core accessibility check (`a11y.spec.ts`),
+scoped to WCAG 2.1 A/AA, that runs automatically as part of the `e2e` target — no separate command
+needed. `angular-app` and `vue-app` include the same check.
+
 ---
 
 ### `angular-app`

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -67,6 +67,10 @@ describe('angular app generator', () => {
       ? 'apps/test-e2e/playwright.config.mts'
       : 'apps/test-e2e/playwright.config.ts';
     expect(appTree.read(cfg).toString()).toContain('process.env.BASE_URL');
+    // Accessibility check (axe-core, WCAG 2.1 A/AA) rides along in the same e2e project.
+    expect(appTree.exists('apps/test-e2e/src/a11y.spec.ts')).toBeTruthy();
+    const pkgJson = JSON.parse(appTree.read('package.json').toString());
+    expect(pkgJson.devDependencies['@axe-core/playwright']).toBeTruthy();
   }, 120000);
 
   it('AGENTS.md points at the current design system docs', async () => {

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
+  addAxeAccessibilityCheck,
   addJestCoverageConfig,
   addSemgrepTarget,
   guardPlaywrightWebServer,
@@ -133,6 +134,7 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
   // Let the Playwright e2e target the deployed URL (BASE_URL) in CI instead of
   // always starting a local dev server — see the nx-oc pipeline's e2e jobs.
   guardPlaywrightWebServer(host, `${normalizedOptions.projectRoot}-e2e`);
+  addAxeAccessibilityCheck(host, `${normalizedOptions.projectRoot}-e2e`);
 
   addDependenciesToPackageJson(
     host,
@@ -149,7 +151,9 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
       'keycloak-js': '^23.0.7',
       'zone.js': '~0.15.0',
     },
-    {},
+    {
+      '@axe-core/playwright': '^4.12.1',
+    },
   );
 
   const addedProxy = addFiles(host, normalizedOptions);

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -58,6 +58,10 @@ describe('React App Generator', () => {
       ? 'apps/test-e2e/playwright.config.mts'
       : 'apps/test-e2e/playwright.config.ts';
     expect(host.read(cfg).toString()).toContain('process.env.BASE_URL');
+    // Accessibility check (axe-core, WCAG 2.1 A/AA) rides along in the same e2e project.
+    expect(host.exists('apps/test-e2e/src/a11y.spec.ts')).toBeTruthy();
+    const pkgJson = JSON.parse(host.read('package.json').toString());
+    expect(pkgJson.devDependencies['@axe-core/playwright']).toBeTruthy();
   }, 30000);
 
   it('AGENTS.md points at the current design system docs', async () => {

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
+  addAxeAccessibilityCheck,
   addEslintQualityRules,
   addJestCoverageConfig,
   addSemgrepTarget,
@@ -144,6 +145,7 @@ export default async function (host: Tree, options: Schema) {
   // Let the Playwright e2e target the deployed URL (BASE_URL) in CI instead of
   // always starting a local dev server — see the nx-oc pipeline's e2e jobs.
   guardPlaywrightWebServer(host, `${normalizedOptions.projectRoot}-e2e`);
+  addAxeAccessibilityCheck(host, `${normalizedOptions.projectRoot}-e2e`);
 
   addDependenciesToPackageJson(
     host,
@@ -157,6 +159,7 @@ export default async function (host: Tree, options: Schema) {
       'react-router-dom': '6.30.3',
     },
     {
+      '@axe-core/playwright': '^4.12.1',
       'html-webpack-plugin': '~5.5.0',
       'redux-mock-store': '~1.5.4',
       'eslint-plugin-security': '^3.0.0',

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -83,6 +83,10 @@ describe('Vue App Generator', () => {
       ? 'apps/test-e2e/playwright.config.mts'
       : 'apps/test-e2e/playwright.config.ts';
     expect(host.read(cfg).toString()).toContain('process.env.BASE_URL');
+    // Accessibility check (axe-core, WCAG 2.1 A/AA) rides along in the same e2e project.
+    expect(host.exists('apps/test-e2e/src/a11y.spec.ts')).toBeTruthy();
+    const pkgJson = JSON.parse(host.read('package.json').toString());
+    expect(pkgJson.devDependencies['@axe-core/playwright']).toBeTruthy();
   }, 30000);
 
   it('AGENTS.md points at the current design system docs', async () => {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -11,6 +11,7 @@ import {
 } from '../../utils/keycloak-admin';
 import { PLUGIN_VERSION } from '../../utils/plugin-version';
 import {
+  addAxeAccessibilityCheck,
   addJestCoverageConfig,
   addSemgrepTarget,
   guardPlaywrightWebServer,
@@ -127,6 +128,7 @@ export default async function (host: Tree, options: Schema) {
   // Let the Playwright e2e target the deployed URL (BASE_URL) in CI instead of
   // always starting a local dev server — see the nx-oc pipeline's e2e jobs.
   guardPlaywrightWebServer(host, `${normalizedOptions.projectRoot}-e2e`);
+  addAxeAccessibilityCheck(host, `${normalizedOptions.projectRoot}-e2e`);
 
   // Ensure the shared GoA wrapper library exists (idempotent — created once per
   // workspace, refreshed on later runs). Apps import it instead of each carrying
@@ -145,6 +147,7 @@ export default async function (host: Tree, options: Schema) {
       'vue-router': '^4.0.0',
     },
     {
+      '@axe-core/playwright': '^4.12.1',
       'eslint-plugin-security': '^3.0.0',
       'eslint-plugin-no-secrets': '^2.0.0',
     },

--- a/packages/nx-adsp/src/utils/quality.spec.ts
+++ b/packages/nx-adsp/src/utils/quality.spec.ts
@@ -1,6 +1,10 @@
 import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { addJestCoverageConfig, fixExpressServiceE2eProject } from './quality';
+import {
+  addAxeAccessibilityCheck,
+  addJestCoverageConfig,
+  fixExpressServiceE2eProject,
+} from './quality';
 
 function makeConfig(coverageDirectoryLine: string): string {
   return [
@@ -217,5 +221,35 @@ module.exports = async function () {
       fixExpressServiceE2eProject(tree, 'apps/none-e2e', 3333),
     ).not.toThrow();
     expect(tree.exists('apps/none-e2e/jest.config.cts')).toBe(false);
+  });
+});
+
+describe('addAxeAccessibilityCheck', () => {
+  let tree: Tree;
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('writes an a11y spec scoped to WCAG 2.1 A/AA', () => {
+    addAxeAccessibilityCheck(tree, 'apps/my-app-e2e');
+
+    const specPath = 'apps/my-app-e2e/src/a11y.spec.ts';
+    expect(tree.exists(specPath)).toBe(true);
+    const spec = tree.read(specPath).toString();
+    expect(spec).toContain("import AxeBuilder from '@axe-core/playwright'");
+    expect(spec).toContain("['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']");
+    expect(spec).toContain('.withTags(WCAG_TAGS).analyze()');
+    expect(spec).toContain("await page.goto('/')");
+    expect(spec).toContain('expect(summary, summary.join');
+  });
+
+  it('is idempotent — a second call does not clobber a manually-edited file', () => {
+    addAxeAccessibilityCheck(tree, 'apps/my-app-e2e');
+    const specPath = 'apps/my-app-e2e/src/a11y.spec.ts';
+    tree.write(specPath, '// manually edited\n');
+
+    addAxeAccessibilityCheck(tree, 'apps/my-app-e2e');
+
+    expect(tree.read(specPath).toString()).toBe('// manually edited\n');
   });
 });

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -152,6 +152,47 @@ export function guardPlaywrightWebServer(
   }
 }
 
+const AXE_SPEC_CONTENT = `import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// Scoped to WCAG 2.1 A/AA — the standard compliance baseline — rather than
+// axe-core's full default ruleset, which also includes "best-practice" rules
+// (e.g. requiring a landmark region, requiring exactly one <h1>) that aren't
+// tied to any WCAG success criterion and are legitimately opinionated. A pass
+// here means the WCAG 2.1 A/AA baseline, not full accessibility conformance.
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+test('has no WCAG 2.1 A/AA accessibility violations', async ({ page }) => {
+  await page.goto('/');
+
+  const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze();
+
+  const summary = results.violations.map(
+    (v) =>
+      \`[\${v.impact}] \${v.id}: \${v.help} (\${v.nodes.length} node(s)) \${v.helpUrl}\`,
+  );
+  expect(summary, summary.join('\\n')).toEqual([]);
+});
+`;
+
+/**
+ * Writes a Playwright + axe-core accessibility spec into the generated e2e
+ * project, scoped to WCAG 2.1 A/AA (see AXE_SPEC_CONTENT's own comment for
+ * why not axe's full default ruleset). Runs automatically as part of the
+ * project's normal `e2e` target — no separate command to remember.
+ *
+ * Idempotent: a no-op if the spec already exists, so a manual edit survives
+ * re-running the generator, matching guardPlaywrightWebServer's style above.
+ */
+export function addAxeAccessibilityCheck(
+  host: Tree,
+  e2eProjectRoot: string,
+): void {
+  const specPath = `${e2eProjectRoot}/src/a11y.spec.ts`;
+  if (host.exists(specPath)) return;
+  host.write(specPath, AXE_SPEC_CONTENT);
+}
+
 /**
  * Fixes two bugs that surface when e2e testing is added to express-service,
  * confirmed by actually running the generated `e2e` target rather than just

--- a/packages/nx-agent/src/generators/init/guidance/verifying-your-work/accessibility-checks.md
+++ b/packages/nx-agent/src/generators/init/guidance/verifying-your-work/accessibility-checks.md
@@ -1,0 +1,9 @@
+**Accessibility checks.** `react-app`/`angular-app`/`vue-app` (`@abgov/nx-adsp`) each wire an
+axe-core accessibility check (`a11y.spec.ts`) into the generated Playwright e2e project. It runs
+automatically as part of the normal `e2e` target — locally and in CI — so there's no separate
+command to remember, and no reason to skip or delete it when running the existing e2e suite. It's
+scoped to WCAG 2.1 A/AA, not axe's full default ruleset — a pass means the app clears that
+compliance baseline, not that it's fully accessible; don't treat a green check as license to skip a
+real review when one's warranted. When it fails, read each violation's `helpUrl` (printed in the
+failure output) for the rule's specific remediation rather than guessing a fix from the violation ID
+alone.

--- a/packages/nx-agent/src/generators/init/init.spec.ts
+++ b/packages/nx-agent/src/generators/init/init.spec.ts
@@ -249,7 +249,7 @@ describe('nx-agent init generator', () => {
     );
   });
 
-  it('assembles all six groups with all twenty-two items in the correct order', async () => {
+  it('assembles all six groups with all twenty-three items in the correct order', async () => {
     await generator(host, {});
 
     const agentsMd = host.read('AGENTS.md').toString();
@@ -271,6 +271,7 @@ describe('nx-agent init generator', () => {
       'Choosing a dependency',
       'Pre-commit checks',
       'Style, formatting, and complexity tooling',
+      'Accessibility checks',
       'Atomic, conventional commits',
       'GitHub Flow',
       'Linear history',

--- a/packages/nx-agent/src/generators/init/init.ts
+++ b/packages/nx-agent/src/generators/init/init.ts
@@ -87,7 +87,11 @@ const GUIDANCE_GROUPS: GuidanceGroup[] = [
   {
     title: 'Verifying your work',
     folder: 'verifying-your-work',
-    items: ['pre-commit-checks', 'style-formatting-and-complexity-tooling'],
+    items: [
+      'pre-commit-checks',
+      'style-formatting-and-complexity-tooling',
+      'accessibility-checks',
+    ],
   },
   {
     title: 'Version control practices',


### PR DESCRIPTION
## Summary

`react-app`, `angular-app`, and `vue-app` now write a WCAG 2.1 A/AA-scoped axe-core check (`a11y.spec.ts`) into their generated Playwright e2e project — riding along on the existing `e2e` target, no separate command to remember or wire up.

- New `addAxeAccessibilityCheck(host, e2eProjectRoot)` in `packages/nx-adsp/src/utils/quality.ts`, called from all three frontend generators right next to the existing `guardPlaywrightWebServer`. `@axe-core/playwright` is added as a devDependency of the *consuming* workspace (not nx-adsp itself), matching how framework packages are handled today.
- **Scoped to `['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']`**, not axe-core's full default ruleset — the full ruleset also includes "best-practice" rules (e.g. requiring a landmark region, requiring exactly one `<h1>`) that aren't tied to any WCAG success criterion. A pass means the app clears the WCAG 2.1 A/AA baseline, not full accessibility conformance — stated explicitly in both the generated spec's own comment and the new guidance doc.
- New nx-agent guidance (`verifying-your-work/accessibility-checks.md`) so an agent knows the check exists, runs automatically, and should read each violation's `helpUrl` for the actual fix rather than guessing from the rule ID.
- README/docs updated for `react-app` (noting `angular-app`/`vue-app` share it).

## Verification

Generated real apps of all three types via local plugin tarballs against a mock ADSP server (mirroring `nx-adsp-e2e`'s own test harness), then served and axe-checked them live:

- **react-app / vue-app**: served for real, ran a throwaway axe check against the actual rendered page. **0 WCAG 2.1 A/AA violations** for both. The full default ruleset (including best-practice rules) found exactly 1 non-WCAG violation (`region`, best-practice-only) — confirming the WCAG-tag-scoping decision avoids exactly this class of noise.
- **angular-app**: static template read plus confirmation that `@abgov/angular-components` depends on the same underlying `@abgov/web-components` package already live-verified for react/vue. Its full live boot was blocked by an unrelated Keycloak silent-SSO (`check-sso`) iframe handshake that a lightweight HTTP mock can't complete — a limitation of the scratch verification harness, not of the shipped code (which doesn't touch Keycloak at all). Confirmed via the same converging evidence that axe has no WCAG-tagged rule for duplicate/missing `<h1>` elements, so this scoping choice sidesteps the one template question (a possible duplicate `<h1>` on Angular's home route) regardless.

## Test plan

- [x] `quality.spec.ts`: new `addAxeAccessibilityCheck` tests — writes the expected WCAG-scoped spec, idempotent against a manual edit.
- [x] `react-app.spec.ts` / `angular-app.spec.ts` / `vue-app.spec.ts`: extended the existing Playwright-e2e-scaffolding test to assert `a11y.spec.ts` exists and `@axe-core/playwright` is in the generated `package.json`.
- [x] `init.spec.ts`: updated the full-guidance-assembly test for the new 23rd item.
- [x] `npx nx run-many -t lint,test,build -p nx-adsp,nx-agent` — all green (nx-adsp: 88 tests; nx-agent: 116 tests).