### PR TITLE
feat(nx-agent): tag descendant entries with their own artifact type

### DIFF
--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -17,7 +17,7 @@ export default async function (host: Tree) {
   ensureGitignoreEntries(host, ['.nx-agent/']);
 
   const registry = buildRegistry(host);
-  const index = buildIndex(host);
+  const index = buildIndex(host, registry);
   const artifactSchema = readArtifactSchema(host);
   const violations = computeViolations(registry, index, artifactSchema);
 

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -614,6 +614,39 @@ describe('getDescendants', () => {
     );
   });
 
+  it("tags a descendant with its own artifact type when it's itself a registered artifact", () => {
+    host.write(
+      'project-docs/domain-terms/b.md',
+      ['---', 'term: B', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/bounded-contexts/c.md',
+      [
+        '---',
+        'name: C',
+        'project-docs-ancestors: [domain-terms:b]',
+        '---',
+      ].join('\n'),
+    );
+
+    const [entry] = getDescendants(host, 'domain-terms:b');
+
+    expect(entry.file).toBe('project-docs/bounded-contexts/c.md');
+    expect(entry.type).toBe('bounded-contexts');
+  });
+
+  it('leaves type undefined for a plain source file referencing an artifact in a comment', () => {
+    host.write(
+      'apps/a/src/main.ts',
+      '// project-docs-ancestors: domain-terms:collision-report\nexport {};',
+    );
+
+    const [entry] = getDescendants(host, 'domain-terms:collision-report');
+
+    expect(entry.file).toBe('apps/a/src/main.ts');
+    expect(entry.type).toBeUndefined();
+  });
+
   it('defaults to direct referrers only (depth 1)', () => {
     host.write(
       'project-docs/domain-terms/b.md',

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -155,9 +155,25 @@ export type Registry = Map<string, RegistryEntry>;
 
 export interface DescendantEntry {
   file: string;
+  // The descendant's own artifact type — only present when `file` is itself
+  // a registered project-docs artifact (a plain source file that merely
+  // references one in a comment has no type of its own).
+  type?: string;
 }
 
 export type Index = Map<string, DescendantEntry[]>;
+
+// Reverse of a Registry's own path -> key direction, shared by buildIndex
+// (to type each descendant that's itself a registered artifact) and
+// getDescendants' depth > 1 walk (to hop from a referrer's file back to the
+// key something else might reference it by).
+function buildPathToKeyMap(registry: Registry): Map<string, string> {
+  const pathToKey = new Map<string, string>();
+  for (const [key, entry] of registry) {
+    pathToKey.set(entry.path, key);
+  }
+  return pathToKey;
+}
 
 const REF_SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.md'];
 const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.nx']);
@@ -251,9 +267,15 @@ function registerArtifact(
 }
 
 // Every project-docs-ancestors reference found anywhere in the workspace's
-// source files, inverted into "referenced by" per target key.
-export function buildIndex(host: Tree): Index {
+// source files, inverted into "referenced by" per target key. Accepts an
+// already-built registry to avoid re-walking project-docs/ when the caller
+// has one on hand (e.g. project-docs-lineage); builds one otherwise.
+export function buildIndex(
+  host: Tree,
+  registry: Registry = buildRegistry(host),
+): Index {
   const index: Index = new Map();
+  const pathToKey = buildPathToKeyMap(registry);
 
   for (const file of walk(host, '')) {
     if (!REF_SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext))) {
@@ -265,6 +287,11 @@ export function buildIndex(host: Tree): Index {
       ? extractFrontmatterAncestorRefs(content)
       : extractCommentAncestorRefs(content);
 
+    const descendantKey = pathToKey.get(file);
+    const type = descendantKey
+      ? (parseAncestorRef(descendantKey)?.type ?? undefined)
+      : undefined;
+
     for (const raw of rawRefs) {
       const parsed = parseAncestorRef(raw);
       if (!parsed) {
@@ -272,7 +299,7 @@ export function buildIndex(host: Tree): Index {
       }
       const key = refKey(parsed);
       const entries = index.get(key) ?? [];
-      entries.push({ file });
+      entries.push({ file, type });
       index.set(key, entries);
     }
   }
@@ -416,7 +443,8 @@ export function getDescendants(
   key: string,
   depth = 1,
 ): DescendantEntry[] {
-  const index = buildIndex(host);
+  const registry = buildRegistry(host);
+  const index = buildIndex(host, registry);
   const direct = index.get(key) ?? [];
   if (depth <= 1) {
     return direct;
@@ -426,11 +454,7 @@ export function getDescendants(
   // (has its own key something else could reference) — a plain source file
   // is always a leaf in this direction, since nothing can target it (every
   // reference resolves under project-docs/, never to an arbitrary path).
-  const registry = buildRegistry(host);
-  const pathToKey = new Map<string, string>();
-  for (const [k, entry] of registry) {
-    pathToKey.set(entry.path, k);
-  }
+  const pathToKey = buildPathToKeyMap(registry);
 
   const visited = new Map<string, DescendantEntry>();
   let frontier = direct;


### PR DESCRIPTION
## Summary

`DescendantEntry` only carried a file path (`{ file: string }`), so a caller wanting just the domain-term (vs. bounded-context) descendants of an artifact had no clean way to filter — the type info existed in the registry but wasn't surfaced on the returned entries, and reconstructing it required re-deriving the path→registry-key mapping that `buildIndex`/`getDescendants` already build internally.

This closes the gap that `getAncestors` didn't have (its `AncestorRef` already carries `type`, so callers can filter with a one-line `.filter()` today) — `getDescendants`'s return value now carries the same information.

- `DescendantEntry` gains an optional `type` field — populated when the descendant is itself a registered project-docs artifact, `undefined` for a plain source file that only references one in a comment (a `.ts` file has no artifact type of its own).
- `buildIndex(host, registry?)` now accepts an already-built `Registry`, avoiding a second `project-docs/` walk in callers that already have one on hand (`project-docs-lineage` does).
- `getDescendants` and `buildIndex` now share one `buildPathToKeyMap` helper for the path→key reverse lookup, instead of each building their own copy.

This is a real consumer need, not speculative: `domain-model` artifacts have two distinct expected ancestor types (`bounded-contexts` and `domain-terms`), so "give me just the bounded-context ancestor/descendant" is an actual query shape.

## Test plan

- [x] New tests: a descendant that's itself a registered artifact gets tagged with its type; a plain source-file referrer's `type` stays `undefined`.
- [x] All existing `buildIndex`/`getDescendants` tests pass unchanged (they assert on `.file`, not exact object equality, so the additive field doesn't break them).
- [x] `npx nx run-many -t lint,test,build -p nx-agent` — all green (118 tests).