### PR TITLE
fix(nx-oc): verify required gh scopes across sandbox, setup-secrets, and setup-runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,12 @@ Key wiring to preserve when editing:
   prompt; it's lowercased and stored under `generators['@abgov/nx-oc:sandbox']` in `nx.json`.
 - **Auth**: the deploy reads `gh auth token` for both the image push and the pull secret (no PAT
   stored), so the **active** `gh` account must have `write:packages` on the registry org — the
-  preflight checks `gh auth status` but not the scope/identity.
+  preflight parses `gh auth status`'s own output to check the _active_ account's scopes
+  specifically (not just that some account is logged in) and fails fast with the exact
+  `gh auth refresh -s write:packages` fix if it's missing. It also warns (non-fatal) if
+  `delete:packages` is missing — needed only by `sandbox-teardown`'s best-effort GHCR package
+  deletion, which already tolerates failing silently. It can't check registry-org access
+  itself, though — that still only surfaces as a push/import auth error.
 - The generator unit tests assert the target/manifest shape; the executor tests mock `child_process`
   `execSync` and assert the command sequence/preflight/retry.
 

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -126,7 +126,7 @@ describe('sandbox executor', () => {
 
   it('fails fast when gh is installed but not authenticated (before the build)', async () => {
     execSync.mockImplementation((cmd: string) => {
-      if (cmd === 'gh auth status') throw new Error('not logged in');
+      if (cmd === 'gh auth status 2>&1') throw new Error('not logged in');
       return Buffer.from('');
     });
     const result = await runExecutor(baseOptions, context());
@@ -134,6 +134,84 @@ describe('sandbox executor', () => {
     // gh checked up front — no build/push happened
     expect(commands().some((c) => c.includes('nx build test'))).toBe(false);
     expect(commands().some((c) => c.includes('podman build'))).toBe(false);
+  });
+
+  it('fails fast, before the build, when the active gh account is missing write:packages', async () => {
+    const status = `github.com
+  ✓ Logged in to github.com account someone (keyring)
+  - Active account: true
+  - Git operations protocol: https
+  - Token: gho_************************************
+  - Token scopes: 'gist', 'read:org', 'repo'
+`;
+    execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth status 2>&1') return Buffer.from(status);
+      return Buffer.from('');
+    });
+    const result = await runExecutor(baseOptions, context());
+    expect(result.success).toBe(false);
+    expect(commands().some((c) => c.includes('nx build test'))).toBe(false);
+    expect(commands().some((c) => c.includes('podman build'))).toBe(false);
+  });
+
+  it('proceeds when the active gh account has write:packages, even if another logged-in account does not', async () => {
+    const status = `github.com
+  ✓ Logged in to github.com account other-account (keyring)
+  - Active account: false
+  - Token scopes: 'gist', 'read:org', 'repo'
+
+  ✓ Logged in to github.com account active-account (keyring)
+  - Active account: true
+  - Token scopes: 'delete:packages', 'gist', 'read:org', 'repo', 'write:packages'
+`;
+    execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth status 2>&1') return Buffer.from(status);
+      return Buffer.from('');
+    });
+    const result = await runExecutor(baseOptions, context());
+    expect(result.success).toBe(true);
+    expect(commands().some((c) => c.includes('podman build'))).toBe(true);
+  });
+
+  it('warns (without failing) when the active gh account has write:packages but not delete:packages', async () => {
+    const status = `github.com
+  ✓ Logged in to github.com account active-account (keyring)
+  - Active account: true
+  - Token scopes: 'gist', 'read:org', 'repo', 'write:packages'
+`;
+    execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth status 2>&1') return Buffer.from(status);
+      return Buffer.from('');
+    });
+    const warnSpy = jest
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+    const result = await runExecutor(baseOptions, context());
+    expect(result.success).toBe(true);
+    expect(commands().some((c) => c.includes('podman build'))).toBe(true);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('delete:packages'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn when the active gh account has both write:packages and delete:packages', async () => {
+    const status = `github.com
+  ✓ Logged in to github.com account active-account (keyring)
+  - Active account: true
+  - Token scopes: 'delete:packages', 'gist', 'read:org', 'repo', 'write:packages'
+`;
+    execSync.mockImplementation((cmd: string) => {
+      if (cmd === 'gh auth status 2>&1') return Buffer.from(status);
+      return Buffer.from('');
+    });
+    const warnSpy = jest
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+    const result = await runExecutor(baseOptions, context());
+    expect(result.success).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 
   it('retries oc import-image on the tag-reconcile race', async () => {

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -1,6 +1,7 @@
 import { ExecutorContext, logger } from '@nx/devkit';
 import { execSync } from 'child_process';
 import { detectApplicationType } from '../../utils/app-type';
+import { activeAccountScopes } from '../../utils/gh-utils';
 import { ensureOcLogin } from '../../utils/oc-utils';
 import { SandboxExecutorSchema } from './schema';
 
@@ -16,16 +17,50 @@ function requireTool(tool: string, hint: string): void {
   }
 }
 
+// write:packages is mandatory — the push + pull-secret steps below can't work
+// at all without it. delete:packages is only needed by the (best-effort,
+// `|| true`'d) GHCR package deletion in the sandbox-teardown target this
+// generator also wires up — that call already tolerates failing silently, so
+// its absence is worth a warning here rather than a hard failure now.
+const REQUIRED_GH_SCOPE = 'write:packages';
+const RECOMMENDED_GH_SCOPE = 'delete:packages';
+
 // The pull secret + registry login read the gh session token, so gh must be
-// installed AND authenticated. Checked up front so a missing/expired login
-// fails before the slow build rather than at the push/import step.
+// installed, authenticated, AND the *active* account's token must actually
+// carry write:packages — `gh auth status` succeeding only confirms *an*
+// account is logged in, not that it has the scope the push/pull-secret steps
+// below need, so that's checked explicitly too, up front, before the slow
+// build rather than at the push/import step where the failure is a bare
+// registry auth error with no mention of scope at all.
 function requireGhAuth(): void {
   requireTool('gh', 'Install the GitHub CLI (https://cli.github.com).');
+
+  let status: string;
   try {
-    execSync('gh auth status', { stdio: 'ignore', shell: '/bin/bash' });
+    status = execSync('gh auth status 2>&1', {
+      shell: '/bin/bash',
+    }).toString();
   } catch {
     throw new Error(
       'gh is installed but not authenticated. Run `gh auth login` as an account with write:packages on the registry org (check/switch with `gh auth status` / `gh auth switch`).',
+    );
+  }
+
+  const scopes = activeAccountScopes(status);
+  if (!scopes) return;
+
+  if (!scopes.includes(REQUIRED_GH_SCOPE)) {
+    throw new Error(
+      `The active gh account is missing the '${REQUIRED_GH_SCOPE}' scope needed to push the image and create the pull secret. ` +
+        `Run \`gh auth refresh -h github.com -s ${REQUIRED_GH_SCOPE}\` to add it to the current login, or \`gh auth switch\` first ` +
+        `if a different, already-scoped account should be active.`,
+    );
+  }
+  if (!scopes.includes(RECOMMENDED_GH_SCOPE)) {
+    logger.warn(
+      `[nx-oc] The active gh account is missing the '${RECOMMENDED_GH_SCOPE}' scope. Deploying will still work, but ` +
+        `\`sandbox-teardown\`'s GHCR package deletion is best-effort and will silently no-op without it, leaving the ` +
+        `image behind. Run \`gh auth refresh -h github.com -s ${RECOMMENDED_GH_SCOPE}\` to add it now.`,
     );
   }
 }

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -75,10 +75,18 @@ oc get pods -n <%= sandboxProject %> -l name=<%= projectName %>
 
 ## Known issues & workarounds
 
-- **`podman push` / import fails with an auth error** — the *active* `gh`
-  account lacks `write:packages` (or access to the org). Preflight only confirms
-  *an* account is logged in, not its scope. Check `gh auth status`; switch with
-  `gh auth switch -u <account>`, then re-run with `--skipBuild`.
+- **Preflight fails with `missing the 'write:packages' scope`** — the *active*
+  `gh` account is logged in but its token doesn't carry `write:packages` (or it
+  lacks access to the org). Run `gh auth refresh -h github.com -s write:packages`
+  to add the scope to the current login, or `gh auth switch -u <account>` first
+  if a different, already-scoped account should be active — then re-run.
+  If the push/import still fails with an auth error *after* preflight passes,
+  the account also needs actual access to the registry org, not just the scope.
+- **Preflight warns about `delete:packages`** — not fatal; deploy proceeds. It
+  means `sandbox-teardown`'s GHCR package deletion (best-effort) will silently
+  no-op without it, leaving the image behind. Run
+  `gh auth refresh -h github.com -s delete:packages` before tearing down if
+  you want that cleanup to actually happen.
 - **Pod `FailedCreate` "exceeded quota"** — the namespace CPU quota is full.
   Free room: `oc get deploy -n <%= sandboxProject %>` then delete stale apps
   (`oc delete all,configmap,is -l app=<old-app>,deployment-mode=sandbox -n <%= sandboxProject %>`), and re-run.

--- a/packages/nx-oc/src/generators/setup-runner/setup-runner.ts
+++ b/packages/nx-oc/src/generators/setup-runner/setup-runner.ts
@@ -46,7 +46,8 @@ export default async function (host: Tree, options: Schema) {
   }
 
   try {
-    checkGhCli();
+    // repo scope is what gh variable set needs to write RUN_E2E below.
+    checkGhCli('repo');
   } catch (e) {
     console.log(e instanceof Error ? e.message : String(e));
     return;

--- a/packages/nx-oc/src/generators/setup-secrets/setup-secrets.ts
+++ b/packages/nx-oc/src/generators/setup-secrets/setup-secrets.ts
@@ -38,7 +38,8 @@ export default async function (host: Tree, options: Schema) {
   }
 
   try {
-    checkGhCli();
+    // repo scope is what gh secret set needs to write Actions secrets below.
+    checkGhCli('repo');
   } catch (e) {
     console.log(e instanceof Error ? e.message : String(e));
     return;

--- a/packages/nx-oc/src/utils/gh-utils.spec.ts
+++ b/packages/nx-oc/src/utils/gh-utils.spec.ts
@@ -1,25 +1,77 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import { mocked } from 'jest-mock';
-import { checkGhCli, setGhSecret } from './gh-utils';
+import { activeAccountScopes, checkGhCli, setGhSecret } from './gh-utils';
 
 jest.mock('child_process');
 const mockedExecFileSync = mocked(execFileSync);
+const mockedExecSync = mocked(execSync);
+
+const ACTIVE_WITH_REPO = `github.com
+  ✓ Logged in to github.com account someone (keyring)
+  - Active account: true
+  - Token scopes: 'gist', 'read:org', 'repo'
+`;
+
+const ACTIVE_WITHOUT_REPO = `github.com
+  ✓ Logged in to github.com account someone (keyring)
+  - Active account: true
+  - Token scopes: 'gist', 'read:org'
+`;
+
+describe('activeAccountScopes', () => {
+  it("extracts the active account's scopes, ignoring an inactive account's", () => {
+    const status = `github.com
+  ✓ Logged in to github.com account other (keyring)
+  - Active account: false
+  - Token scopes: 'workflow'
+
+  ✓ Logged in to github.com account active (keyring)
+  - Active account: true
+  - Token scopes: 'repo', 'write:packages'
+`;
+    expect(activeAccountScopes(status)).toEqual(['repo', 'write:packages']);
+  });
+
+  it('returns undefined when no active account block can be found', () => {
+    expect(activeAccountScopes('')).toBeUndefined();
+  });
+});
 
 describe('checkGhCli', () => {
-  beforeEach(() => mockedExecFileSync.mockReset());
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+    mockedExecSync.mockReset();
+  });
 
-  it('does not throw when gh is authenticated', () => {
-    mockedExecFileSync.mockReturnValue(Buffer.from('Logged in to github.com'));
+  it('does not throw when gh is authenticated and no scope is required', () => {
+    mockedExecSync.mockReturnValue(Buffer.from('Logged in to github.com'));
     expect(() => checkGhCli()).not.toThrow();
   });
 
   it('throws a clear error when gh CLI is unavailable or unauthenticated', () => {
-    mockedExecFileSync.mockImplementation(() => {
+    mockedExecSync.mockImplementation(() => {
       throw new Error('gh: command not found');
     });
     expect(() => checkGhCli()).toThrow(
       'gh CLI is not installed or not authenticated',
     );
+  });
+
+  it('does not throw when the active account has the required scope', () => {
+    mockedExecSync.mockReturnValue(Buffer.from(ACTIVE_WITH_REPO));
+    expect(() => checkGhCli('repo')).not.toThrow();
+  });
+
+  it('throws an actionable error when the active account is missing the required scope', () => {
+    mockedExecSync.mockReturnValue(Buffer.from(ACTIVE_WITHOUT_REPO));
+    expect(() => checkGhCli('repo')).toThrow(
+      /missing the 'repo' scope[\s\S]*gh auth refresh -h github.com -s repo/,
+    );
+  });
+
+  it('does not throw when scopes cannot be determined at all (fails open)', () => {
+    mockedExecSync.mockReturnValue(Buffer.from(''));
+    expect(() => checkGhCli('repo')).not.toThrow();
   });
 });
 

--- a/packages/nx-oc/src/utils/gh-utils.ts
+++ b/packages/nx-oc/src/utils/gh-utils.ts
@@ -1,11 +1,50 @@
-import { execFileSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 
-export function checkGhCli(): void {
+// `gh auth status` lists every logged-in account in its own block, each
+// starting with "✓ Logged in to ..." and containing its own "Active
+// account:"/"Token scopes:" lines — only the block with "Active account:
+// true" is the one whose scopes actually apply to the gh commands the rest
+// of a caller makes. Returns undefined if no block (or no scopes line
+// within it) can be found, so callers can tell "couldn't tell" apart from
+// "found it, and the scope is missing" (and fail open on the former).
+export function activeAccountScopes(
+  statusOutput: string,
+): string[] | undefined {
+  const blocks = statusOutput.split(/(?=✓ Logged in to)/);
+  const active = blocks.find((block) => block.includes('Active account: true'));
+  const match = active?.match(/Token scopes:\s*(.+)/);
+  if (!match) return undefined;
+  return match[1]
+    .split(',')
+    .map((s) => s.trim().replace(/^'|'$/g, ''))
+    .filter(Boolean);
+}
+
+// Checked up front by every generator/executor that shells out to `gh`, so a
+// missing login (or missing scope, when `requiredScope` is given) fails with
+// an actionable message before the real work starts, rather than surfacing
+// later as a bare `gh`/registry auth error that says nothing about why.
+// `gh auth status` succeeding only confirms *an* account is logged in, not
+// that it has any particular scope — hence the separate check below.
+export function checkGhCli(requiredScope?: string): void {
+  let status: string;
   try {
-    execFileSync('gh', ['auth', 'status'], { stdio: 'pipe' });
+    // 2>&1: which stream gh auth status's account details land on has
+    // differed across gh CLI versions — merging both is the version-safe way
+    // to capture it regardless.
+    status = execSync('gh auth status 2>&1', { shell: '/bin/bash' }).toString();
   } catch {
     throw new Error(
       'gh CLI is not installed or not authenticated. Run `gh auth login` then re-try.',
+    );
+  }
+
+  if (!requiredScope) return;
+  const scopes = activeAccountScopes(status);
+  if (scopes && !scopes.includes(requiredScope)) {
+    throw new Error(
+      `The active gh account is missing the '${requiredScope}' scope. Run \`gh auth refresh -h github.com -s ${requiredScope}\` ` +
+        `to add it to the current login, or \`gh auth switch\` first if a different, already-scoped account should be active.`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Root cause of the "coding agent isn't guiding me to log in with the required scopes" issue: the sandbox executor's preflight only ran `gh auth status`, which confirms *an* account is logged in but says nothing about its scopes. An account authenticated without `write:packages` passed preflight cleanly and only failed much later, at the podman push/pull-secret step, with a bare registry auth error that never mentions scope at all — so there was nothing in the actual failure output (for a human *or* an agent troubleshooting it) pointing at the real cause. This was previously only documented as a post-hoc "known issue" in the generated `SANDBOX.md` runbook, i.e. tribal knowledge you needed to already have.

**Sandbox** — preflight now parses `gh auth status`'s own output once, finds the *active* account's block specifically, and checks it against the full set of scopes actually used across `sandbox` and `sandbox-teardown`:

- **`write:packages`** (push + pull secret) — **mandatory**. Fails fast with the exact fix (`gh auth refresh -h github.com -s write:packages`) before the build starts if missing.
- **`delete:packages`** (`sandbox-teardown`'s best-effort GHCR package deletion, already `|| true`'d) — **warns only**. Deploy still proceeds, but the warning names the exact command to add it, instead of the deletion silently no-op'ing later with no signal that it didn't happen.
- If scopes can't be determined at all (unexpected `gh auth status` shape), it fails open on both.

**The same blind spot existed in two other generators**, both via the shared `checkGhCli()` in `gh-utils.ts`:

- `setup-secrets` (`gh secret set` for `OPENSHIFT_SERVER`/`OPENSHIFT_TOKEN`) — needs `repo`.
- `setup-runner` (`gh variable set` for `RUN_E2E`) — needs `repo`.

`checkGhCli()` now takes an optional required scope and does the same active-account check; the scope-parsing logic (`activeAccountScopes`) moved into `gh-utils.ts` as a shared export instead of being duplicated in the sandbox executor, so both generators got the fix with one line each (`checkGhCli('repo')`).

Updated `SANDBOX.md`'s generated runbook and `AGENTS.md`'s own "Auth" note to describe the new behavior.

## Verification

- Verified the parsing logic against my own real `gh auth status` output (two real logged-in accounts, one active) — correctly identifies the active account's scopes and ignores the inactive one's.
- New tests: sandbox — fails fast before the build when missing `write:packages`; proceeds when it has it even if another logged-in account doesn't; warns (without failing) when missing only `delete:packages`; no warning when both are present. `gh-utils` — `activeAccountScopes` isolates the active account's scopes correctly; `checkGhCli` throws/doesn't throw appropriately for the authenticated/unauthenticated/missing-scope/undetermined-scope cases.
- `npx nx run-many -t lint,test,build -p nx-oc,nx-adsp` — all green (nx-oc: 132 tests, +7 since the original preflight-only fix).