### PR TITLE
feat(nx-agent): add open-question/blocker generators, --resolves, and resolution status

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -144,6 +144,7 @@ term: Case
 aliases: []
 not_confused_with: []
 project-docs-ancestors: []
+resolves: []
 ---
 
 <!-- Definition: describe this term in the domain's own language. -->
@@ -154,6 +155,9 @@ project-docs-ancestors: []
 - `not_confused_with` — similar-sounding terms this one is deliberately distinct from, and why.
 - `project-docs-ancestors` — other `project-docs/` artifacts this term derives from (see
   `project-docs-lineage` below) — set via `--project-docs-ancestors`, never by hand.
+- `resolves` — which of those ancestors (typically an `open-question`/`blocker`) this term
+  specifically _resolves_, not just builds on — set via `--resolves`, a distinct flag from
+  `--project-docs-ancestors` even though the same ref also lands there.
 
 One file per term rather than a single flat glossary, so frontmatter (a per-file construct in
 every tool that uses the term) is meaningful, and so listing the folder — cheap, just filenames —
@@ -166,11 +170,12 @@ glossary" generator; `domain-term` composes it as an internal step.
 
 ### `domain-term` options
 
-| Option                 | Default                  | Description                                                                                                                                                                                                |
-| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `term`                 | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                                                                        |
-| `project`              | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — prefer this whenever the term already has a natural code home (usually a domain library), not just workspace root by default |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                                                                        |
+| Option                 | Default                  | Description                                                                                                                                                                                                        |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `term`                 | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                                                                                |
+| `project`              | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — prefer this whenever the term already has a natural code home (usually a domain library), not just workspace root by default         |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                                                                                |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this term resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 ```bash
 npx nx g @abgov/nx-agent:domain-term Case --project=domain-lib
@@ -199,6 +204,8 @@ Creates `project-docs/bounded-contexts/collision-reporting.md`:
 name: Collision Reporting
 aliases: []
 not_confused_with: []
+project-docs-ancestors: []
+resolves: []
 ---
 
 <!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->
@@ -206,10 +213,12 @@ not_confused_with: []
 
 ### `bounded-context` options
 
-| Option    | Default                  | Description                                                                                                                                                                                                          |
-| --------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`    | — (required, positional) | The canonical name of the bounded context                                                                                                                                                                            |
-| `project` | workspace root           | Scope the context to a specific project's `project-docs/bounded-contexts/` instead — prefer this whenever the context already has a natural code home (usually a domain library), not just workspace root by default |
+| Option                 | Default                  | Description                                                                                                                                                                                                           |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | — (required, positional) | The canonical name of the bounded context                                                                                                                                                                             |
+| `project`              | workspace root           | Scope the context to a specific project's `project-docs/bounded-contexts/` instead — prefer this whenever the context already has a natural code home (usually a domain library), not just workspace root by default  |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this context derives from — repeatable; resolved into `project-docs-ancestors`                                                                                            |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this context resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 ```bash
 npx nx g @abgov/nx-agent:bounded-context "Collision Reporting" --project=domain-lib
@@ -236,6 +245,7 @@ Creates `project-docs/domain-models/collision-report-lifecycle.md`:
 ---
 name: Collision Report Lifecycle
 project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]
+resolves: []
 ---
 
 <!-- Design: describe the aggregates, entities, value objects, and invariants here. -->
@@ -243,15 +253,85 @@ project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:coll
 
 ### `domain-model` options
 
-| Option                 | Default                  | Description                                                                                                                                                                                                   |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                 | — (required, positional) | The canonical name of the domain model                                                                                                                                                                        |
-| `project`              | workspace root           | Scope the model to a specific project's `project-docs/domain-models/` instead — prefer this whenever the model already has a natural code home (usually a domain library), not just workspace root by default |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this model derives from — repeatable; normally the bounded context it belongs to plus the domain terms it's composed from                                         |
+| Option                 | Default                  | Description                                                                                                                                                                                                         |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | — (required, positional) | The canonical name of the domain model                                                                                                                                                                              |
+| `project`              | workspace root           | Scope the model to a specific project's `project-docs/domain-models/` instead — prefer this whenever the model already has a natural code home (usually a domain library), not just workspace root by default       |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this model derives from — repeatable; normally the bounded context it belongs to plus the domain terms it's composed from                                               |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this model resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 Re-adding a model that already exists throws rather than silently overwriting or duplicating it. A
 `--project-docs-ancestors` path that doesn't resolve to an existing artifact throws the same way,
 before anything is written.
+
+---
+
+## `open-question`
+
+Something undecided that can't be guessed at — needs input, a decision, or more information before
+work depending on it can proceed:
+
+```bash
+npx nx g @abgov/nx-agent:open-question "Reviewer Authorization" \
+  --project-docs-ancestors=project-docs/requirements/reviewer-role.md
+```
+
+Creates `project-docs/open-questions/reviewer-authorization.md`:
+
+```markdown
+---
+project-docs-ancestors: [requirements:reviewer-role]
+resolves: []
+---
+
+<!-- What's undecided, and why it can't be guessed at. -->
+```
+
+### `open-question` options
+
+| Option                 | Default                  | Description                                                                                                                                 |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `question`             | — (required, positional) | A short slug for what's undecided                                                                                                           |
+| `project`              | workspace root           | Scope the question to a specific project's `project-docs/open-questions/` instead — prefer this whenever it already has a natural code home |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this question grounds on — repeatable; an open question can ground on any artifact kind         |
+
+A question is never marked resolved by editing its own file — some other artifact resolves it via
+its own `--resolves` flag (see `domain-term`/`bounded-context`/`domain-model` above). Re-adding a
+question that already exists throws rather than silently overwriting or duplicating it.
+
+---
+
+## `blocker`
+
+An existing artifact that needs revision — something already established but wrong, incomplete, or
+in conflict with something discovered later:
+
+```bash
+npx nx g @abgov/nx-agent:blocker "Cant Ship Payment Flow" \
+  --project-docs-ancestors=project-docs/domain-models/collision-report-lifecycle.md
+```
+
+Creates `project-docs/blockers/cant-ship-payment-flow.md`:
+
+```markdown
+---
+project-docs-ancestors: [domain-models:collision-report-lifecycle]
+resolves: []
+---
+
+<!-- What needs fixing, and why it is blocking. -->
+```
+
+### `blocker` options
+
+| Option                 | Default                  | Description                                                                                                                          |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `description`          | — (required, positional) | A short slug for what needs fixing                                                                                                   |
+| `project`              | workspace root           | Scope the blocker to a specific project's `project-docs/blockers/` instead — prefer this whenever it already has a natural code home |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this blocker relates to — repeatable; typically the artifact that needs revision         |
+
+Same resolution model as `open-question`: never mark it resolved by editing its own file — the
+artifact that actually revises the thing it's blocking resolves it via `--resolves`.
 
 ---
 
@@ -283,27 +363,53 @@ project, so a reference's meaning never depends on where it's found.
 Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself (or `--dry-run`
 it in your own CI) after adding or changing a reference.
 
+Also reports which `open-question`/`blocker` artifacts are still open versus resolved — see
+`resolutionStatus` below.
+
 ### `project-docs/artifact-schema.json`
 
-An artifact-producing generator (`domain-term`, `bounded-context`, `domain-model`) self-registers its
-own entry here on first use, declaring what ancestor type its kind normally expects — e.g.
-`domain-terms` expects a `bounded-contexts` ancestor:
+An artifact-producing generator (`domain-term`, `bounded-context`, `domain-model`, `open-question`,
+`blocker`) self-registers its own entry here on first use, declaring what ancestor type its kind
+normally expects — e.g. `domain-terms` expects a `bounded-contexts` ancestor — and, separately,
+whether its kind has a resolution lifecycle at all:
 
 ```json
 {
   "bounded-contexts": { "expectedAncestorTypes": [] },
   "domain-terms": { "expectedAncestorTypes": ["bounded-contexts"] },
-  "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] }
+  "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] },
+  "open-questions": { "expectedAncestorTypes": [], "tracksResolution": true },
+  "blockers": { "expectedAncestorTypes": [], "tracksResolution": true }
 }
 ```
 
 `project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
-a hand-added entry for a custom artifact kind gets the same check for free. `expectedAncestorTypes` is
+a hand-added entry for a custom artifact kind gets the same checks for free. `expectedAncestorTypes` is
 an all-of list, not any-of: `domain-models` above requires an ancestor of _both_ `bounded-contexts`
 and `domain-terms`, not either — a model with only one is still missing part of the vocabulary it
 should be built from. An artifact whose type has an entry here but is missing an ancestor of one of
 the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
 as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
+
+`tracksResolution: true` is what makes `open-questions`/`blockers` show up in `resolutionStatus`
+(below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking
+and gets settled by another artifact) gets the same open/resolved report for free by declaring it.
+
+### `resolutionStatus`
+
+`violations.resolutionStatus` in `.nx-agent/lineage.json` splits every artifact whose type has
+`tracksResolution: true` into `open` and `resolved`:
+
+```json
+{ "open": ["open-questions:reviewer-authorization"], "resolved": ["blockers:cant-ship-payment-flow"] }
+```
+
+"Resolved" means some artifact's own `resolves` field names this key — not merely that something
+references it via `project-docs-ancestors`. That distinction matters: a `blocker` or another
+`open-question` citing an existing one _because_ it's still unresolved would, under a looser
+"anything references it" test, get misread as having resolved it. A deferral (explicitly punted, not
+decided) isn't a third computed bucket — it stays `open`, with the _why_ left to the artifact's own
+prose, same as an `orphan` doesn't try to distinguish "temporary" from "abandoned."
 
 ### Programmatic access
 

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -119,6 +119,7 @@ term: Case
 aliases: []
 not_confused_with: []
 project-docs-ancestors: []
+resolves: []
 ---
 
 <!-- Definition: describe this term in the domain's own language. -->
@@ -129,6 +130,9 @@ project-docs-ancestors: []
 - `not_confused_with` — similar-sounding terms this one is deliberately distinct from, and why.
 - `project-docs-ancestors` — other `project-docs/` artifacts this term derives from (see
   `project-docs-lineage` below) — set via `--project-docs-ancestors`, never by hand.
+- `resolves` — which of those ancestors (typically an `open-question`/`blocker`) this term
+  specifically _resolves_, not just builds on — set via `--resolves`, a distinct flag from
+  `--project-docs-ancestors` even though the same ref also lands there.
 
 One file per term rather than a single flat glossary, so frontmatter (a per-file construct in
 every tool that uses the term) is meaningful, and so listing the folder — cheap, just filenames —
@@ -141,11 +145,12 @@ glossary" generator; `domain-term` composes it as an internal step.
 
 ### Options
 
-| Option                 | Default                  | Description                                                                                                                                                                                                |
-| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `term`                 | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                                                                        |
-| `project`              | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — prefer this whenever the term already has a natural code home (usually a domain library), not just workspace root by default |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                                                                        |
+| Option                 | Default                  | Description                                                                                                                                                                                                        |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `term`                 | — (required, positional) | The canonical domain term, as domain experts use it                                                                                                                                                                |
+| `project`              | workspace root           | Scope the term to a specific project's `project-docs/domain-terms/` instead — prefer this whenever the term already has a natural code home (usually a domain library), not just workspace root by default         |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this term derives from — repeatable; resolved into `project-docs-ancestors` (see below)                                                                                |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this term resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 ```bash
 npx nx g @abgov/nx-agent:domain-term Case --project=domain-lib
@@ -172,6 +177,8 @@ Creates `project-docs/bounded-contexts/collision-reporting.md`:
 name: Collision Reporting
 aliases: []
 not_confused_with: []
+project-docs-ancestors: []
+resolves: []
 ---
 
 <!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->
@@ -179,10 +186,12 @@ not_confused_with: []
 
 ### Options
 
-| Option    | Default                  | Description                                                                                                                                                                                                          |
-| --------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`    | — (required, positional) | The canonical name of the bounded context                                                                                                                                                                            |
-| `project` | workspace root           | Scope the context to a specific project's `project-docs/bounded-contexts/` instead — prefer this whenever the context already has a natural code home (usually a domain library), not just workspace root by default |
+| Option                 | Default                  | Description                                                                                                                                                                                                           |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | — (required, positional) | The canonical name of the bounded context                                                                                                                                                                             |
+| `project`              | workspace root           | Scope the context to a specific project's `project-docs/bounded-contexts/` instead — prefer this whenever the context already has a natural code home (usually a domain library), not just workspace root by default  |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this context derives from — repeatable; resolved into `project-docs-ancestors`                                                                                            |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this context resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 ```bash
 npx nx g @abgov/nx-agent:bounded-context "Collision Reporting" --project=domain-lib
@@ -207,6 +216,7 @@ Creates `project-docs/domain-models/collision-report-lifecycle.md`:
 ---
 name: Collision Report Lifecycle
 project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]
+resolves: []
 ---
 
 <!-- Design: describe the aggregates, entities, value objects, and invariants here. -->
@@ -214,15 +224,81 @@ project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:coll
 
 ### Options
 
-| Option                 | Default                  | Description                                                                                                                                                                                                   |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                 | — (required, positional) | The canonical name of the domain model                                                                                                                                                                        |
-| `project`              | workspace root           | Scope the model to a specific project's `project-docs/domain-models/` instead — prefer this whenever the model already has a natural code home (usually a domain library), not just workspace root by default |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this model derives from — repeatable; normally the bounded context it belongs to plus the domain terms it's composed from                                         |
+| Option                 | Default                  | Description                                                                                                                                                                                                         |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                 | — (required, positional) | The canonical name of the domain model                                                                                                                                                                              |
+| `project`              | workspace root           | Scope the model to a specific project's `project-docs/domain-models/` instead — prefer this whenever the model already has a natural code home (usually a domain library), not just workspace root by default       |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this model derives from — repeatable; normally the bounded context it belongs to plus the domain terms it's composed from                                               |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this model resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 Re-adding a model that already exists throws rather than silently overwriting or duplicating it. A
 `--project-docs-ancestors` path that doesn't resolve to an existing artifact throws the same way,
 before anything is written.
+
+## `open-question`
+
+Something undecided that can't be guessed at — needs input, a decision, or more information before
+work depending on it can proceed:
+
+```bash
+npx nx g @abgov/nx-agent:open-question "Reviewer Authorization" \
+  --project-docs-ancestors=project-docs/requirements/reviewer-role.md
+```
+
+Creates `project-docs/open-questions/reviewer-authorization.md`:
+
+```markdown
+---
+project-docs-ancestors: [requirements:reviewer-role]
+resolves: []
+---
+
+<!-- What's undecided, and why it can't be guessed at. -->
+```
+
+### Options
+
+| Option                 | Default                  | Description                                                                                                                                 |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `question`             | — (required, positional) | A short slug for what's undecided                                                                                                           |
+| `project`              | workspace root           | Scope the question to a specific project's `project-docs/open-questions/` instead — prefer this whenever it already has a natural code home |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this question grounds on — repeatable; an open question can ground on any artifact kind         |
+
+A question is never marked resolved by editing its own file — some other artifact resolves it via
+its own `--resolves` flag (see `domain-term`/`bounded-context`/`domain-model` above). Re-adding a
+question that already exists throws rather than silently overwriting or duplicating it.
+
+## `blocker`
+
+An existing artifact that needs revision — something already established but wrong, incomplete, or
+in conflict with something discovered later:
+
+```bash
+npx nx g @abgov/nx-agent:blocker "Cant Ship Payment Flow" \
+  --project-docs-ancestors=project-docs/domain-models/collision-report-lifecycle.md
+```
+
+Creates `project-docs/blockers/cant-ship-payment-flow.md`:
+
+```markdown
+---
+project-docs-ancestors: [domain-models:collision-report-lifecycle]
+resolves: []
+---
+
+<!-- What needs fixing, and why it is blocking. -->
+```
+
+### Options
+
+| Option                 | Default                  | Description                                                                                                                          |
+| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `description`          | — (required, positional) | A short slug for what needs fixing                                                                                                   |
+| `project`              | workspace root           | Scope the blocker to a specific project's `project-docs/blockers/` instead — prefer this whenever it already has a natural code home |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this blocker relates to — repeatable; typically the artifact that needs revision         |
+
+Same resolution model as `open-question`: never mark it resolved by editing its own file — the
+artifact that actually revises the thing it's blocking resolves it via `--resolves`.
 
 ## `project-docs-lineage`
 
@@ -252,27 +328,53 @@ project, so a reference's meaning never depends on where it's found.
 Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself (or `--dry-run`
 it in your own CI) after adding or changing a reference.
 
+Also reports which `open-question`/`blocker` artifacts are still open versus resolved — see
+`resolutionStatus` below.
+
 ### `project-docs/artifact-schema.json`
 
-An artifact-producing generator (`domain-term`, `bounded-context`, `domain-model`) self-registers its
-own entry here on first use, declaring what ancestor type its kind normally expects — e.g.
-`domain-terms` expects a `bounded-contexts` ancestor:
+An artifact-producing generator (`domain-term`, `bounded-context`, `domain-model`, `open-question`,
+`blocker`) self-registers its own entry here on first use, declaring what ancestor type its kind
+normally expects — e.g. `domain-terms` expects a `bounded-contexts` ancestor — and, separately,
+whether its kind has a resolution lifecycle at all:
 
 ```json
 {
   "bounded-contexts": { "expectedAncestorTypes": [] },
   "domain-terms": { "expectedAncestorTypes": ["bounded-contexts"] },
-  "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] }
+  "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] },
+  "open-questions": { "expectedAncestorTypes": [], "tracksResolution": true },
+  "blockers": { "expectedAncestorTypes": [], "tracksResolution": true }
 }
 ```
 
 `project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
-a hand-added entry for a custom artifact kind gets the same check for free. `expectedAncestorTypes` is
+a hand-added entry for a custom artifact kind gets the same checks for free. `expectedAncestorTypes` is
 an all-of list, not any-of: `domain-models` above requires an ancestor of _both_ `bounded-contexts`
 and `domain-terms`, not either — a model with only one is still missing part of the vocabulary it
 should be built from. An artifact whose type has an entry here but is missing an ancestor of one of
 the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
 as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
+
+`tracksResolution: true` is what makes `open-questions`/`blockers` show up in `resolutionStatus`
+(below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking
+and gets settled by another artifact) gets the same open/resolved report for free by declaring it.
+
+### `resolutionStatus`
+
+`violations.resolutionStatus` in `.nx-agent/lineage.json` splits every artifact whose type has
+`tracksResolution: true` into `open` and `resolved`:
+
+```json
+{ "open": ["open-questions:reviewer-authorization"], "resolved": ["blockers:cant-ship-payment-flow"] }
+```
+
+"Resolved" means some artifact's own `resolves` field names this key — not merely that something
+references it via `project-docs-ancestors`. That distinction matters: a `blocker` or another
+`open-question` citing an existing one _because_ it's still unresolved would, under a looser
+"anything references it" test, get misread as having resolved it. A deferral (explicitly punted, not
+decided) isn't a third computed bucket — it stays `open`, with the _why_ left to the artifact's own
+prose, same as an `orphan` doesn't try to distinguish "temporary" from "abandoned."
 
 ### Programmatic access
 

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -23,6 +23,16 @@
       "schema": "./src/generators/domain-model/schema.json",
       "description": "Adds one domain model under project-docs/domain-models/, with a project-docs-ancestors frontmatter list and a free-text design body."
     },
+    "open-question": {
+      "factory": "./src/generators/open-question/open-question",
+      "schema": "./src/generators/open-question/schema.json",
+      "description": "Adds one open question under project-docs/open-questions/, with a project-docs-ancestors frontmatter list and a free-text body describing what's undecided."
+    },
+    "blocker": {
+      "factory": "./src/generators/blocker/blocker",
+      "schema": "./src/generators/blocker/schema.json",
+      "description": "Adds one blocker under project-docs/blockers/, with a project-docs-ancestors frontmatter list and a free-text body describing what needs fixing."
+    },
     "project-docs-lineage": {
       "factory": "./src/generators/project-docs-lineage/project-docs-lineage",
       "schema": "./src/generators/project-docs-lineage/schema.json",

--- a/packages/nx-agent/src/generators/blocker/README.template.md
+++ b/packages/nx-agent/src/generators/blocker/README.template.md
@@ -1,0 +1,28 @@
+# Blockers
+
+An existing artifact that needs revision — something already established but wrong, incomplete, or
+in conflict with something discovered later.{{SHARED_CONTEXT_NOTE}} One file per blocker, so listing
+this folder (cheap — just filenames) is enough to see what's currently blocking.
+
+Add one with `nx g @abgov/nx-agent:blocker "<what needs fixing and why>" --project-docs-ancestors
+<path to the artifact that needs revision>` — don't hand-author files here, so the frontmatter shape
+stays consistent. Each file:
+
+    ---
+    project-docs-ancestors: [domain-models:collision-report-lifecycle]
+    resolves: []
+    ---
+
+    The Closed state requires a resolution code, but the intake form doesn't collect one — this
+    model can't be implemented as designed until that's added upstream.
+
+- `project-docs-ancestors` — the artifact this blocker relates to, typically the one that needs
+  revision — resolved from an existing artifact's path via `--project-docs-ancestors <path>`, not
+  typed by hand.
+- `resolves` — always present, empty here. Only an artifact that _resolves_ this blocker (via its own
+  `--resolves` flag) writes an entry naming it — never edit this file to mark it resolved yourself;
+  that's how a blocker resolved in prose elsewhere and never updated here happens.
+
+A blocker is resolved by another artifact adding it via `--resolves` when that artifact's revision
+actually addresses it — not by hand-editing this file. Run `nx g @abgov/nx-agent:project-docs-lineage`
+to see which blockers are still open versus resolved.

--- a/packages/nx-agent/src/generators/blocker/blocker.spec.ts
+++ b/packages/nx-agent/src/generators/blocker/blocker.spec.ts
@@ -1,0 +1,140 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
+import generator from './blocker';
+
+describe('nx-agent blocker generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('creates the blocker file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { description: 'Cant Ship Payment Flow' });
+
+    const content = host
+      .read('project-docs/blockers/cant-ship-payment-flow.md')
+      .toString();
+    expect(content).toContain('project-docs-ancestors: []');
+    expect(content).toContain('resolves: []');
+  });
+
+  it('resolves --project-docs-ancestors paths into the canonical reference and writes them', async () => {
+    host.write(
+      'project-docs/domain-models/collision-report-lifecycle.md',
+      ['---', 'name: Collision Report Lifecycle', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      description: 'Cant Ship Payment Flow',
+      projectDocsAncestors: [
+        'project-docs/domain-models/collision-report-lifecycle.md',
+      ],
+    });
+
+    const content = host
+      .read('project-docs/blockers/cant-ship-payment-flow.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [domain-models:collision-report-lifecycle]',
+    );
+  });
+
+  it('throws and makes no changes when a --project-docs-ancestors path does not resolve', async () => {
+    await expect(
+      generator(host, {
+        description: 'Cant Ship Payment Flow',
+        projectDocsAncestors: ['project-docs/domain-models/nope.md'],
+      }),
+    ).rejects.toThrow(/not found/);
+
+    expect(host.exists('project-docs/blockers/cant-ship-payment-flow.md')).toBe(
+      false,
+    );
+    expect(host.exists('project-docs/blockers/README.md')).toBe(false);
+  });
+
+  it('throws and makes no changes when the blocker file already exists', async () => {
+    await generator(host, { description: 'Cant Ship Payment Flow' });
+    const before = host
+      .read('project-docs/blockers/cant-ship-payment-flow.md')
+      .toString();
+
+    await expect(
+      generator(host, { description: 'Cant Ship Payment Flow' }),
+    ).rejects.toThrow(/already exists/);
+
+    expect(
+      host.read('project-docs/blockers/cant-ship-payment-flow.md').toString(),
+    ).toBe(before);
+  });
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { description: 'Cant Ship Payment Flow' });
+
+    const readme = host.read('project-docs/blockers/README.md').toString();
+    expect(readme).toContain('# Blockers');
+    expect(readme).toContain('nx g @abgov/nx-agent:blocker');
+  });
+
+  it('scopes the blocker file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      description: 'Cant Ship Payment Flow',
+      project: 'domain-lib',
+    });
+
+    expect(
+      host.exists(
+        'libs/domain-lib/project-docs/blockers/cant-ship-payment-flow.md',
+      ),
+    ).toBe(true);
+    expect(host.exists('project-docs/blockers/cant-ship-payment-flow.md')).toBe(
+      false,
+    );
+  });
+
+  it('adds the shared-context note to the README only when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      description: 'Cant Ship Payment Flow',
+      project: 'domain-lib',
+    });
+
+    const scopedReadme = host
+      .read('libs/domain-lib/project-docs/blockers/README.md')
+      .toString();
+    expect(scopedReadme).toContain(
+      'shared by every project that depends on this library',
+    );
+
+    await generator(host, { description: 'Other Blocker' });
+
+    const rootReadme = host.read('project-docs/blockers/README.md').toString();
+    expect(rootReadme).not.toContain(
+      'shared by every project that depends on this library',
+    );
+  });
+
+  it('registers its own artifact-schema entry with tracksResolution and no expected ancestor type', async () => {
+    await generator(host, { description: 'Cant Ship Payment Flow' });
+
+    expect(readArtifactSchema(host)).toEqual({
+      blockers: {
+        expectedAncestorTypes: [],
+        tracksResolution: true,
+      },
+    });
+  });
+});

--- a/packages/nx-agent/src/generators/blocker/blocker.ts
+++ b/packages/nx-agent/src/generators/blocker/blocker.ts
@@ -9,10 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import { resolveRefFromPath } from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
-const BOUNDED_CONTEXTS_SUBDIR = 'project-docs/bounded-contexts';
+const BLOCKERS_SUBDIR = 'project-docs/blockers';
 const README_TEMPLATE_PATH = join(__dirname, 'README.template.md');
 
 function resolveTargetRoot(host: Tree, project?: string): string {
@@ -20,15 +20,15 @@ function resolveTargetRoot(host: Tree, project?: string): string {
 }
 
 // The container has no standalone value on its own (its README only exists to
-// explain the convention for the context about to be added), so this is an
-// internal step composed by bounded-context rather than its own generator.
+// explain the convention for the blocker about to be added), so this is an
+// internal step composed by blocker rather than its own generator.
 function ensureContainerReadme(
   host: Tree,
   containerDir: string,
   scoped: boolean,
 ): void {
   const sharedNote = scoped
-    ? ' This is shared by every project that depends on this library — keep the boundary consistent across the service and its consumers rather than letting each drift toward its own interpretation.'
+    ? ' This is shared by every project that depends on this library — a blocker raised here may affect every consumer, not just the one that noticed it.'
     : '';
   const content = readFileSync(README_TEMPLATE_PATH, 'utf-8')
     .split('{{SHARED_CONTEXT_NOTE}}')
@@ -38,49 +38,42 @@ function ensureContainerReadme(
 
 export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
-  const containerDir = joinPathFragments(targetRoot, BOUNDED_CONTEXTS_SUBDIR);
-  const slug = names(options.name).fileName;
-  const contextPath = joinPathFragments(containerDir, `${slug}.md`);
+  const containerDir = joinPathFragments(targetRoot, BLOCKERS_SUBDIR);
+  const slug = names(options.description).fileName;
+  const blockerPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently
-  // clobbering or duplicating a context — same posture as domain-term.
+  // clobbering or duplicating a blocker — same posture as domain-model.
   // Checked before any write so a failing run has no side effects.
-  if (host.exists(contextPath)) {
+  if (host.exists(blockerPath)) {
     throw new Error(
-      `[nx-agent] ${contextPath} already exists — edit it directly rather than regenerating it.`,
+      `[nx-agent] ${blockerPath} already exists — edit it directly rather than regenerating it.`,
     );
   }
 
   // Resolved (and, in doing so, validated) before any write — a path that
   // doesn't resolve to an existing project-docs/ artifact throws here, same
   // as the duplicate check above, so a failing run still has no side effects.
-  const { ancestors: projectDocsAncestors, resolvedRefs } =
-    resolveAncestorsAndResolves(
-      host,
-      options.projectDocsAncestors,
-      options.resolves,
-    );
+  const projectDocsAncestors = (options.projectDocsAncestors ?? []).map(
+    (path) => resolveRefFromPath(host, path),
+  );
 
   ensureContainerReadme(host, containerDir, !!options.project);
-  ensureArtifactSchemaEntry(host, 'bounded-contexts', []);
+  // No fixed expected ancestor type — a blocker can relate to any artifact
+  // kind. tracksResolution: true is what makes project-docs-lineage report
+  // this blocker as open/resolved.
+  ensureArtifactSchemaEntry(host, 'blockers', [], true);
 
   const content = [
     '---',
-    `name: ${options.name}`,
-    'aliases: []',
-    'not_confused_with: []',
     `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
-    `resolves: [${resolvedRefs.join(', ')}]`,
+    'resolves: []',
     '---',
     '',
-    "<!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->",
+    '<!-- What needs fixing, and why it is blocking. -->',
     '',
   ].join('\n');
-  host.write(contextPath, content);
-
-  for (const ref of resolvedRefs) {
-    console.log(`✓ this bounded context resolves ${ref}`);
-  }
+  host.write(blockerPath, content);
 
   await formatFiles(host);
 }

--- a/packages/nx-agent/src/generators/blocker/schema.d.ts
+++ b/packages/nx-agent/src/generators/blocker/schema.d.ts
@@ -1,6 +1,5 @@
 export interface Schema {
-  term: string;
+  description: string;
   project?: string;
   projectDocsAncestors?: string[];
-  resolves?: string[];
 }

--- a/packages/nx-agent/src/generators/blocker/schema.json
+++ b/packages/nx-agent/src/generators/blocker/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentBlocker",
+  "title": "Add a blocker",
+  "description": "Creates one file for a blocker under project-docs/blockers/, with a project-docs-ancestors frontmatter list and a free-text body describing what needs fixing and why. Bootstraps the blockers/README.md convention doc on first use.",
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A short slug for what needs fixing (e.g. \"Cant Ship Payment Flow\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What needs fixing, and why is it blocking?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this blocker to a specific project's project-docs/blockers/ instead of the workspace root — prefer this whenever the blocker already has a natural code home; only use the workspace root when it genuinely doesn't have one."
+    },
+    "projectDocsAncestors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing project-docs/ artifacts this blocker relates to — typically the artifact that needs revision. Each path must already exist; a backward reference only makes sense pointing at something already established."
+    }
+  },
+  "required": ["description"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/bounded-context/bounded-context.spec.ts
+++ b/packages/nx-agent/src/generators/bounded-context/bounded-context.spec.ts
@@ -134,4 +134,52 @@ describe('nx-agent bounded-context generator', () => {
       'bounded-contexts': { expectedAncestorTypes: [] },
     });
   });
+
+  it('resolves --project-docs-ancestors paths into the canonical reference and writes them', async () => {
+    host.write(
+      'project-docs/open-questions/reviewer-authorization.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      name: 'Collision Reporting',
+      projectDocsAncestors: [
+        'project-docs/open-questions/reviewer-authorization.md',
+      ],
+    });
+
+    const content = host
+      .read('project-docs/bounded-contexts/collision-reporting.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [open-questions:reviewer-authorization]',
+    );
+  });
+
+  it('--resolves writes the resolved ref into both project-docs-ancestors and resolves, and confirms it', async () => {
+    host.write(
+      'project-docs/open-questions/reviewer-authorization.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await generator(host, {
+      name: 'Collision Reporting',
+      resolves: ['project-docs/open-questions/reviewer-authorization.md'],
+    });
+
+    const content = host
+      .read('project-docs/bounded-contexts/collision-reporting.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [open-questions:reviewer-authorization]',
+    );
+    expect(content).toContain(
+      'resolves: [open-questions:reviewer-authorization]',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      '✓ this bounded context resolves open-questions:reviewer-authorization',
+    );
+    logSpy.mockRestore();
+  });
 });

--- a/packages/nx-agent/src/generators/bounded-context/schema.d.ts
+++ b/packages/nx-agent/src/generators/bounded-context/schema.d.ts
@@ -1,4 +1,6 @@
 export interface Schema {
   name: string;
   project?: string;
+  projectDocsAncestors?: string[];
+  resolves?: string[];
 }

--- a/packages/nx-agent/src/generators/bounded-context/schema.json
+++ b/packages/nx-agent/src/generators/bounded-context/schema.json
@@ -14,6 +14,16 @@
     "project": {
       "type": "string",
       "description": "Scope this bounded context to a specific project's project-docs/bounded-contexts/ instead of the workspace root — prefer this whenever the context already has a natural code home (most often a domain library other projects depend on); only use the workspace root when it genuinely doesn't have one."
+    },
+    "projectDocsAncestors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing project-docs/ artifacts this context derives from (e.g. an open question it grounds on). Each path must already exist; a backward reference only makes sense pointing at something already established."
+    },
+    "resolves": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing open-question/blocker artifacts this context resolves. Recorded distinctly from projectDocsAncestors (though also added there, so lineage traversal sees it as an ancestor too) so project-docs-lineage can report the resolution as such rather than mistaking any ancestor reference for one."
     }
   },
   "required": ["name"],

--- a/packages/nx-agent/src/generators/domain-model/domain-model.spec.ts
+++ b/packages/nx-agent/src/generators/domain-model/domain-model.spec.ts
@@ -55,9 +55,7 @@ describe('nx-agent domain-model generator', () => {
     ).rejects.toThrow(/not found/);
 
     expect(
-      host.exists(
-        'project-docs/domain-models/collision-report-lifecycle.md',
-      ),
+      host.exists('project-docs/domain-models/collision-report-lifecycle.md'),
     ).toBe(false);
     expect(host.exists('project-docs/domain-models/README.md')).toBe(false);
   });
@@ -82,9 +80,7 @@ describe('nx-agent domain-model generator', () => {
   it('creates the container README on first run', async () => {
     await generator(host, { name: 'Collision Report Lifecycle' });
 
-    const readme = host
-      .read('project-docs/domain-models/README.md')
-      .toString();
+    const readme = host.read('project-docs/domain-models/README.md').toString();
     expect(readme).toContain('# Domain models');
     expect(readme).toContain('nx g @abgov/nx-agent:domain-model');
   });
@@ -107,9 +103,7 @@ describe('nx-agent domain-model generator', () => {
       ),
     ).toBe(true);
     expect(
-      host.exists(
-        'project-docs/domain-models/collision-report-lifecycle.md',
-      ),
+      host.exists('project-docs/domain-models/collision-report-lifecycle.md'),
     ).toBe(false);
   });
 
@@ -150,5 +144,57 @@ describe('nx-agent domain-model generator', () => {
         expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
       },
     });
+  });
+
+  it('--resolves writes the resolved ref into both project-docs-ancestors and resolves, and confirms it', async () => {
+    host.write(
+      'project-docs/open-questions/reviewer-authorization.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await generator(host, {
+      name: 'Collision Report Lifecycle',
+      resolves: ['project-docs/open-questions/reviewer-authorization.md'],
+    });
+
+    const content = host
+      .read('project-docs/domain-models/collision-report-lifecycle.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [open-questions:reviewer-authorization]',
+    );
+    expect(content).toContain(
+      'resolves: [open-questions:reviewer-authorization]',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      '✓ this domain model resolves open-questions:reviewer-authorization',
+    );
+    logSpy.mockRestore();
+  });
+
+  it('--resolves dedupes against an identical path already passed via --projectDocsAncestors', async () => {
+    host.write(
+      'project-docs/open-questions/reviewer-authorization.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      name: 'Collision Report Lifecycle',
+      projectDocsAncestors: [
+        'project-docs/open-questions/reviewer-authorization.md',
+      ],
+      resolves: ['project-docs/open-questions/reviewer-authorization.md'],
+    });
+
+    const content = host
+      .read('project-docs/domain-models/collision-report-lifecycle.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [open-questions:reviewer-authorization]',
+    );
+    expect(content).not.toContain(
+      'open-questions:reviewer-authorization, open-questions:reviewer-authorization',
+    );
   });
 });

--- a/packages/nx-agent/src/generators/domain-model/domain-model.ts
+++ b/packages/nx-agent/src/generators/domain-model/domain-model.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveRefFromPath } from '../../utils/project-docs-refs';
+import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const DOMAIN_MODELS_SUBDIR = 'project-docs/domain-models';
@@ -54,9 +54,12 @@ export default async function (host: Tree, options: Schema) {
   // Resolved (and, in doing so, validated) before any write — a path that
   // doesn't resolve to an existing project-docs/ artifact throws here, same
   // as the duplicate check above, so a failing run still has no side effects.
-  const projectDocsAncestors = (options.projectDocsAncestors ?? []).map(
-    (path) => resolveRefFromPath(host, path),
-  );
+  const { ancestors: projectDocsAncestors, resolvedRefs } =
+    resolveAncestorsAndResolves(
+      host,
+      options.projectDocsAncestors,
+      options.resolves,
+    );
 
   ensureContainerReadme(host, containerDir, !!options.project);
   ensureArtifactSchemaEntry(host, 'domain-models', [
@@ -68,12 +71,17 @@ export default async function (host: Tree, options: Schema) {
     '---',
     `name: ${options.name}`,
     `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
+    `resolves: [${resolvedRefs.join(', ')}]`,
     '---',
     '',
     '<!-- Design: describe the aggregates, entities, value objects, and invariants here. -->',
     '',
   ].join('\n');
   host.write(modelPath, content);
+
+  for (const ref of resolvedRefs) {
+    console.log(`✓ this domain model resolves ${ref}`);
+  }
 
   await formatFiles(host);
 }

--- a/packages/nx-agent/src/generators/domain-model/schema.d.ts
+++ b/packages/nx-agent/src/generators/domain-model/schema.d.ts
@@ -2,4 +2,5 @@ export interface Schema {
   name: string;
   project?: string;
   projectDocsAncestors?: string[];
+  resolves?: string[];
 }

--- a/packages/nx-agent/src/generators/domain-model/schema.json
+++ b/packages/nx-agent/src/generators/domain-model/schema.json
@@ -19,6 +19,11 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Paths to existing project-docs/ artifacts this model derives from — normally the bounded context it belongs to plus the domain terms it's composed from (e.g. project-docs/bounded-contexts/collision-reporting.md). Each path must already exist; a backward reference only makes sense pointing at something already established."
+    },
+    "resolves": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing open-question/blocker artifacts this model resolves. Recorded distinctly from projectDocsAncestors (though also added there, so lineage traversal sees it as an ancestor too) so project-docs-lineage can report the resolution as such rather than mistaking any ancestor reference for one."
     }
   },
   "required": ["name"],

--- a/packages/nx-agent/src/generators/domain-term/domain-term.spec.ts
+++ b/packages/nx-agent/src/generators/domain-term/domain-term.spec.ts
@@ -28,7 +28,9 @@ describe('nx-agent domain-term generator', () => {
 
     await generator(host, {
       term: 'Collision Report',
-      projectDocsAncestors: ['project-docs/bounded-contexts/collision-reporting.md'],
+      projectDocsAncestors: [
+        'project-docs/bounded-contexts/collision-reporting.md',
+      ],
     });
 
     const content = host
@@ -152,5 +154,28 @@ describe('nx-agent domain-term generator', () => {
     expect(readArtifactSchema(host)).toEqual({
       'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
     });
+  });
+
+  it('--resolves writes the resolved ref into both project-docs-ancestors and resolves, and confirms it', async () => {
+    host.write(
+      'project-docs/open-questions/what-to-call-this.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await generator(host, {
+      term: 'Case',
+      resolves: ['project-docs/open-questions/what-to-call-this.md'],
+    });
+
+    const content = host.read('project-docs/domain-terms/case.md').toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [open-questions:what-to-call-this]',
+    );
+    expect(content).toContain('resolves: [open-questions:what-to-call-this]');
+    expect(logSpy).toHaveBeenCalledWith(
+      '✓ this domain term resolves open-questions:what-to-call-this',
+    );
+    logSpy.mockRestore();
   });
 });

--- a/packages/nx-agent/src/generators/domain-term/domain-term.ts
+++ b/packages/nx-agent/src/generators/domain-term/domain-term.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveRefFromPath } from '../../utils/project-docs-refs';
+import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const DOMAIN_TERMS_SUBDIR = 'project-docs/domain-terms';
@@ -57,9 +57,12 @@ export default async function (host: Tree, options: Schema) {
   // Resolved (and, in doing so, validated) before any write — a path that
   // doesn't resolve to an existing project-docs/ artifact throws here, same
   // as the duplicate check above, so a failing run still has no side effects.
-  const projectDocsAncestors = (options.projectDocsAncestors ?? []).map(
-    (path) => resolveRefFromPath(host, path),
-  );
+  const { ancestors: projectDocsAncestors, resolvedRefs } =
+    resolveAncestorsAndResolves(
+      host,
+      options.projectDocsAncestors,
+      options.resolves,
+    );
 
   ensureContainerReadme(host, containerDir, !!options.project);
   ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
@@ -70,12 +73,17 @@ export default async function (host: Tree, options: Schema) {
     'aliases: []',
     'not_confused_with: []',
     `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
+    `resolves: [${resolvedRefs.join(', ')}]`,
     '---',
     '',
     "<!-- Definition: describe this term in the domain's own language. -->",
     '',
   ].join('\n');
   host.write(termPath, content);
+
+  for (const ref of resolvedRefs) {
+    console.log(`✓ this domain term resolves ${ref}`);
+  }
 
   await formatFiles(host);
 }

--- a/packages/nx-agent/src/generators/domain-term/schema.json
+++ b/packages/nx-agent/src/generators/domain-term/schema.json
@@ -19,6 +19,11 @@
       "type": "array",
       "items": { "type": "string" },
       "description": "Paths to existing project-docs/ artifacts this term derives from (e.g. project-docs/bounded-contexts/collision-reporting.md) — resolved into the project-docs-ancestors frontmatter convention. Each path must already exist; a backward reference only makes sense pointing at something already established."
+    },
+    "resolves": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing open-question/blocker artifacts this term resolves. Recorded distinctly from projectDocsAncestors (though also added there, so lineage traversal sees it as an ancestor too) so project-docs-lineage can report the resolution as such rather than mistaking any ancestor reference for one."
     }
   },
   "required": ["term"],

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -11,11 +11,22 @@ entirely for a singular one (a type with exactly one file, directly under `proje
 subfolder) — e.g. `domain-terms:case` for a term, `architecture-overview` alone for a one-off doc.
 Only ever reference something that already exists — this is a backward reference, and deriving from
 a thing that doesn't exist yet isn't a real case. `nx g @abgov/nx-agent:domain-term`,
-`:bounded-context`, and `:domain-model` each resolve a `--project-docs-ancestors <path>` for you
-(from an existing artifact's path, not a hand-typed `type:id` string) rather than requiring you to
-know the format; other artifact-producing generators should do the same. Run
-`nx g @abgov/nx-agent:project-docs-lineage` to build the full graph and catch a broken reference —
-not yet wired into the pre-commit hook, so run it yourself after adding or changing a reference.
+`:bounded-context`, `:domain-model`, `:open-question`, and `:blocker` each resolve a
+`--project-docs-ancestors <path>` for you (from an existing artifact's path, not a hand-typed
+`type:id` string) rather than requiring you to know the format; other artifact-producing generators
+should do the same. Run `nx g @abgov/nx-agent:project-docs-lineage` to build the full graph and catch
+a broken reference — not yet wired into the pre-commit hook, so run it yourself after adding or
+changing a reference.
+
+**Open questions and blockers.** `nx g @abgov/nx-agent:open-question`/`:blocker` capture something
+undecided or something that needs revision as its own artifact, rather than leaving it in prose where
+it's easy to lose track of. They're resolved by a _different_ artifact — the one that actually settles
+it — passing `--resolves <path>` (on `domain-term`/`bounded-context`/`domain-model`), not by
+hand-editing the question/blocker file itself. `--resolves` is layered on top of
+`--project-docs-ancestors` (the resolved ref lands in both places), so it's still visible to normal
+lineage traversal; the distinct `resolves` field is what lets `project-docs-lineage` report a question
+or blocker as resolved specifically, rather than mistaking any artifact that merely cites it for
+context as having settled it.
 
 **Where an artifact belongs**, one level below the format above: a bounded context, domain model, or
 domain term can be scoped to a specific project (`--project <p>`) instead of the workspace root, and

--- a/packages/nx-agent/src/generators/open-question/README.template.md
+++ b/packages/nx-agent/src/generators/open-question/README.template.md
@@ -1,0 +1,27 @@
+# Open questions
+
+Something undecided that can't be guessed at — needs input, a decision, or more information before
+work depending on it can proceed.{{SHARED_CONTEXT_NOTE}} One file per question, so listing this
+folder (cheap — just filenames) is enough to see what's still open.
+
+Add one with `nx g @abgov/nx-agent:open-question "<what's undecided>" --project-docs-ancestors <path>
+...` — don't hand-author files here, so the frontmatter shape stays consistent. Each file:
+
+    ---
+    project-docs-ancestors: [requirements:reviewer-role]
+    resolves: []
+    ---
+
+    Which role(s) are allowed to review a submitted collision report? The intake form doesn't
+    specify, and no existing requirement names one.
+
+- `project-docs-ancestors` — whatever this question grounds on (a requirement, a service
+  description, another artifact) — resolved from an existing artifact's path via
+  `--project-docs-ancestors <path>`, not typed by hand.
+- `resolves` — always present, empty here. Only an artifact that _resolves_ this question (via its
+  own `--resolves` flag) writes an entry naming it — never edit this file to mark it resolved
+  yourself; that's how a question resolved in prose elsewhere and never updated here happens.
+
+A question is resolved by another artifact adding it via `--resolves` when that artifact settles it
+— not by hand-editing this file. Run `nx g @abgov/nx-agent:project-docs-lineage` to see which open
+questions are still open versus resolved.

--- a/packages/nx-agent/src/generators/open-question/open-question.spec.ts
+++ b/packages/nx-agent/src/generators/open-question/open-question.spec.ts
@@ -1,0 +1,144 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
+import generator from './open-question';
+
+describe('nx-agent open-question generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('creates the question file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { question: 'Reviewer Authorization' });
+
+    const content = host
+      .read('project-docs/open-questions/reviewer-authorization.md')
+      .toString();
+    expect(content).toContain('project-docs-ancestors: []');
+    expect(content).toContain('resolves: []');
+  });
+
+  it('resolves --project-docs-ancestors paths into the canonical reference and writes them', async () => {
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      ['---', 'term: Collision Report', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      question: 'Reviewer Authorization',
+      projectDocsAncestors: ['project-docs/domain-terms/collision-report.md'],
+    });
+
+    const content = host
+      .read('project-docs/open-questions/reviewer-authorization.md')
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [domain-terms:collision-report]',
+    );
+  });
+
+  it('throws and makes no changes when a --project-docs-ancestors path does not resolve', async () => {
+    await expect(
+      generator(host, {
+        question: 'Reviewer Authorization',
+        projectDocsAncestors: ['project-docs/domain-terms/nope.md'],
+      }),
+    ).rejects.toThrow(/not found/);
+
+    expect(
+      host.exists('project-docs/open-questions/reviewer-authorization.md'),
+    ).toBe(false);
+    expect(host.exists('project-docs/open-questions/README.md')).toBe(false);
+  });
+
+  it('throws and makes no changes when the question file already exists', async () => {
+    await generator(host, { question: 'Reviewer Authorization' });
+    const before = host
+      .read('project-docs/open-questions/reviewer-authorization.md')
+      .toString();
+
+    await expect(
+      generator(host, { question: 'Reviewer Authorization' }),
+    ).rejects.toThrow(/already exists/);
+
+    expect(
+      host
+        .read('project-docs/open-questions/reviewer-authorization.md')
+        .toString(),
+    ).toBe(before);
+  });
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { question: 'Reviewer Authorization' });
+
+    const readme = host
+      .read('project-docs/open-questions/README.md')
+      .toString();
+    expect(readme).toContain('# Open questions');
+    expect(readme).toContain('nx g @abgov/nx-agent:open-question');
+  });
+
+  it('scopes the question file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      question: 'Reviewer Authorization',
+      project: 'domain-lib',
+    });
+
+    expect(
+      host.exists(
+        'libs/domain-lib/project-docs/open-questions/reviewer-authorization.md',
+      ),
+    ).toBe(true);
+    expect(
+      host.exists('project-docs/open-questions/reviewer-authorization.md'),
+    ).toBe(false);
+  });
+
+  it('adds the shared-context note to the README only when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      question: 'Reviewer Authorization',
+      project: 'domain-lib',
+    });
+
+    const scopedReadme = host
+      .read('libs/domain-lib/project-docs/open-questions/README.md')
+      .toString();
+    expect(scopedReadme).toContain(
+      'shared by every project that depends on this library',
+    );
+
+    await generator(host, { question: 'Platform Intake Reuse' });
+
+    const rootReadme = host
+      .read('project-docs/open-questions/README.md')
+      .toString();
+    expect(rootReadme).not.toContain(
+      'shared by every project that depends on this library',
+    );
+  });
+
+  it('registers its own artifact-schema entry with tracksResolution and no expected ancestor type', async () => {
+    await generator(host, { question: 'Reviewer Authorization' });
+
+    expect(readArtifactSchema(host)).toEqual({
+      'open-questions': {
+        expectedAncestorTypes: [],
+        tracksResolution: true,
+      },
+    });
+  });
+});

--- a/packages/nx-agent/src/generators/open-question/open-question.ts
+++ b/packages/nx-agent/src/generators/open-question/open-question.ts
@@ -9,10 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import { resolveRefFromPath } from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
-const BOUNDED_CONTEXTS_SUBDIR = 'project-docs/bounded-contexts';
+const OPEN_QUESTIONS_SUBDIR = 'project-docs/open-questions';
 const README_TEMPLATE_PATH = join(__dirname, 'README.template.md');
 
 function resolveTargetRoot(host: Tree, project?: string): string {
@@ -20,15 +20,15 @@ function resolveTargetRoot(host: Tree, project?: string): string {
 }
 
 // The container has no standalone value on its own (its README only exists to
-// explain the convention for the context about to be added), so this is an
-// internal step composed by bounded-context rather than its own generator.
+// explain the convention for the question about to be added), so this is an
+// internal step composed by open-question rather than its own generator.
 function ensureContainerReadme(
   host: Tree,
   containerDir: string,
   scoped: boolean,
 ): void {
   const sharedNote = scoped
-    ? ' This is shared by every project that depends on this library — keep the boundary consistent across the service and its consumers rather than letting each drift toward its own interpretation.'
+    ? ' This is shared by every project that depends on this library — a question raised here may be relevant to every consumer, not just the one that noticed it.'
     : '';
   const content = readFileSync(README_TEMPLATE_PATH, 'utf-8')
     .split('{{SHARED_CONTEXT_NOTE}}')
@@ -38,49 +38,42 @@ function ensureContainerReadme(
 
 export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
-  const containerDir = joinPathFragments(targetRoot, BOUNDED_CONTEXTS_SUBDIR);
-  const slug = names(options.name).fileName;
-  const contextPath = joinPathFragments(containerDir, `${slug}.md`);
+  const containerDir = joinPathFragments(targetRoot, OPEN_QUESTIONS_SUBDIR);
+  const slug = names(options.question).fileName;
+  const questionPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently
-  // clobbering or duplicating a context — same posture as domain-term.
+  // clobbering or duplicating a question — same posture as domain-model.
   // Checked before any write so a failing run has no side effects.
-  if (host.exists(contextPath)) {
+  if (host.exists(questionPath)) {
     throw new Error(
-      `[nx-agent] ${contextPath} already exists — edit it directly rather than regenerating it.`,
+      `[nx-agent] ${questionPath} already exists — edit it directly rather than regenerating it.`,
     );
   }
 
   // Resolved (and, in doing so, validated) before any write — a path that
   // doesn't resolve to an existing project-docs/ artifact throws here, same
   // as the duplicate check above, so a failing run still has no side effects.
-  const { ancestors: projectDocsAncestors, resolvedRefs } =
-    resolveAncestorsAndResolves(
-      host,
-      options.projectDocsAncestors,
-      options.resolves,
-    );
+  const projectDocsAncestors = (options.projectDocsAncestors ?? []).map(
+    (path) => resolveRefFromPath(host, path),
+  );
 
   ensureContainerReadme(host, containerDir, !!options.project);
-  ensureArtifactSchemaEntry(host, 'bounded-contexts', []);
+  // No fixed expected ancestor type — an open question can ground on any
+  // artifact kind. tracksResolution: true is what makes project-docs-lineage
+  // report this question as open/resolved.
+  ensureArtifactSchemaEntry(host, 'open-questions', [], true);
 
   const content = [
     '---',
-    `name: ${options.name}`,
-    'aliases: []',
-    'not_confused_with: []',
     `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
-    `resolves: [${resolvedRefs.join(', ')}]`,
+    'resolves: []',
     '---',
     '',
-    "<!-- Definition: describe what's inside this boundary, and what's explicitly outside it. -->",
+    "<!-- What's undecided, and why it can't be guessed at. -->",
     '',
   ].join('\n');
-  host.write(contextPath, content);
-
-  for (const ref of resolvedRefs) {
-    console.log(`✓ this bounded context resolves ${ref}`);
-  }
+  host.write(questionPath, content);
 
   await formatFiles(host);
 }

--- a/packages/nx-agent/src/generators/open-question/schema.d.ts
+++ b/packages/nx-agent/src/generators/open-question/schema.d.ts
@@ -1,6 +1,5 @@
 export interface Schema {
-  term: string;
+  question: string;
   project?: string;
   projectDocsAncestors?: string[];
-  resolves?: string[];
 }

--- a/packages/nx-agent/src/generators/open-question/schema.json
+++ b/packages/nx-agent/src/generators/open-question/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentOpenQuestion",
+  "title": "Add an open question",
+  "description": "Creates one file for an open question under project-docs/open-questions/, with a project-docs-ancestors frontmatter list and a free-text body describing what's undecided and why. Bootstraps the open-questions/README.md convention doc on first use.",
+  "type": "object",
+  "properties": {
+    "question": {
+      "type": "string",
+      "description": "A short slug for what's undecided (e.g. \"Reviewer Authorization\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What's undecided?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this open question to a specific project's project-docs/open-questions/ instead of the workspace root — prefer this whenever the question already has a natural code home; only use the workspace root when it genuinely doesn't have one."
+    },
+    "projectDocsAncestors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing project-docs/ artifacts this question grounds on — an open question can ground on any artifact kind (a service description, a requirement, a specific rule). Each path must already exist; a backward reference only makes sense pointing at something already established."
+    }
+  },
+  "required": ["question"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -108,4 +108,49 @@ describe('nx-agent project-docs-lineage generator', () => {
     const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
     expect(lineage.violations.unscoped).toEqual([]);
   });
+
+  it('reports resolutionStatus without throwing, console-logging open and resolved keys', async () => {
+    host.write(
+      'project-docs/artifact-schema.json',
+      JSON.stringify({
+        'open-questions': { expectedAncestorTypes: [], tracksResolution: true },
+      }),
+    );
+    host.write(
+      'project-docs/open-questions/still-open.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/open-questions/resolved-one.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-models/m.md',
+      [
+        '---',
+        'name: M',
+        'project-docs-ancestors: [open-questions:resolved-one]',
+        'resolves: [open-questions:resolved-one]',
+        '---',
+      ].join('\n'),
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await expect(generator(host)).resolves.toBeUndefined();
+
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.resolutionStatus.open).toEqual([
+      'open-questions:still-open',
+    ]);
+    expect(lineage.violations.resolutionStatus.resolved).toEqual([
+      'open-questions:resolved-one',
+    ]);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[nx-agent] open (unresolved): open-questions:still-open',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      '[nx-agent] resolved: open-questions:resolved-one',
+    );
+    logSpy.mockRestore();
+  });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -37,6 +37,14 @@ export default async function (host: Tree) {
       `[nx-agent] broken reference "${broken.ref}" in ${broken.referencedFrom}`,
     );
   }
+  for (const open of violations.resolutionStatus.open) {
+    // eslint-disable-next-line no-console
+    console.log(`[nx-agent] open (unresolved): ${open}`);
+  }
+  for (const resolved of violations.resolutionStatus.resolved) {
+    // eslint-disable-next-line no-console
+    console.log(`[nx-agent] resolved: ${resolved}`);
+  }
 
   host.write(
     LINEAGE_PATH,

--- a/packages/nx-agent/src/utils/artifact-schema.spec.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.spec.ts
@@ -1,6 +1,9 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { Tree } from '@nx/devkit';
-import { ensureArtifactSchemaEntry, readArtifactSchema } from './artifact-schema';
+import {
+  ensureArtifactSchemaEntry,
+  readArtifactSchema,
+} from './artifact-schema';
 
 describe('readArtifactSchema', () => {
   let host: Tree;
@@ -66,6 +69,16 @@ describe('ensureArtifactSchemaEntry', () => {
       'domain-terms': {
         expectedAncestorTypes: ['bounded-contexts', 'something-else'],
       },
+    });
+  });
+
+  it('records tracksResolution when passed, and omits it when not', () => {
+    ensureArtifactSchemaEntry(host, 'open-questions', [], true);
+    ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
+
+    expect(readArtifactSchema(host)).toEqual({
+      'open-questions': { expectedAncestorTypes: [], tracksResolution: true },
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
     });
   });
 

--- a/packages/nx-agent/src/utils/artifact-schema.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.ts
@@ -3,12 +3,15 @@ import { Tree, readJson, writeJson } from '@nx/devkit';
 const ARTIFACT_SCHEMA_PATH = 'project-docs/artifact-schema.json';
 
 // What ancestor types a given artifact `type` is expected to have — e.g.
-// domain-terms expects a bounded-contexts ancestor. This is data the
-// workspace owns, not logic nx-agent owns: project-docs-lineage only ever
-// reads it generically (no per-type branches), so a hand-invented artifact
-// kind with its own entry here gets the same soft check for free.
+// domain-terms expects a bounded-contexts ancestor — and whether that type
+// has a resolution lifecycle at all (open-questions/blockers do; most types
+// don't). Both are data the workspace owns, not logic nx-agent owns:
+// project-docs-lineage only ever reads this generically (no per-type
+// branches), so a hand-invented artifact kind with its own entry here gets
+// the same soft checks for free.
 export interface ArtifactTypeSchema {
   expectedAncestorTypes: string[];
+  tracksResolution?: boolean;
 }
 
 export type ArtifactSchema = Record<string, ArtifactTypeSchema>;
@@ -27,8 +30,12 @@ export function ensureArtifactSchemaEntry(
   host: Tree,
   type: string,
   expectedAncestorTypes: string[],
+  tracksResolution?: boolean,
 ): void {
   const schema = readArtifactSchema(host);
-  schema[type] = { expectedAncestorTypes };
+  schema[type] = {
+    expectedAncestorTypes,
+    ...(tracksResolution ? { tracksResolution } : {}),
+  };
   writeJson(host, ARTIFACT_SCHEMA_PATH, schema);
 }

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -439,6 +439,117 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     expect(violations.unscoped).toEqual([]);
   });
+
+  const OPEN_QUESTIONS_SCHEMA = {
+    'open-questions': { expectedAncestorTypes: [], tracksResolution: true },
+  };
+
+  it('reports an open-questions artifact with no resolves reference as open', () => {
+    host.write(
+      'project-docs/open-questions/q.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      OPEN_QUESTIONS_SCHEMA,
+    );
+
+    expect(violations.resolutionStatus).toEqual({
+      open: ['open-questions:q'],
+      resolved: [],
+    });
+  });
+
+  it("reports an open-questions artifact named in another artifact's resolves field as resolved", () => {
+    host.write(
+      'project-docs/open-questions/q.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-models/m.md',
+      [
+        '---',
+        'name: M',
+        'project-docs-ancestors: [open-questions:q]',
+        'resolves: [open-questions:q]',
+        '---',
+      ].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      OPEN_QUESTIONS_SCHEMA,
+    );
+
+    expect(violations.resolutionStatus).toEqual({
+      open: [],
+      resolved: ['open-questions:q'],
+    });
+  });
+
+  it('does not count a plain project-docs-ancestors citation (no resolves) as a resolution, even from a peer blocker/open-question', () => {
+    host.write(
+      'project-docs/open-questions/q.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    // A blocker citing the question as context, not resolving it.
+    host.write(
+      'project-docs/blockers/b.md',
+      [
+        '---',
+        'project-docs-ancestors: [open-questions:q]',
+        'resolves: []',
+        '---',
+      ].join('\n'),
+    );
+    // A second open question citing the first for context, not resolving it.
+    host.write(
+      'project-docs/open-questions/q2.md',
+      [
+        '---',
+        'project-docs-ancestors: [open-questions:q]',
+        'resolves: []',
+        '---',
+      ].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'open-questions': {
+          expectedAncestorTypes: [],
+          tracksResolution: true,
+        },
+        blockers: { expectedAncestorTypes: [], tracksResolution: true },
+      },
+    );
+
+    expect(violations.resolutionStatus.open).toContain('open-questions:q');
+    expect(violations.resolutionStatus.resolved).not.toContain(
+      'open-questions:q',
+    );
+  });
+
+  it('does not report resolution status for a type without tracksResolution', () => {
+    host.write(
+      'project-docs/domain-terms/t.md',
+      ['---', 'term: T', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'domain-terms': { expectedAncestorTypes: [] },
+      },
+    );
+
+    expect(violations.resolutionStatus).toEqual({ open: [], resolved: [] });
+  });
 });
 
 describe('getAncestors', () => {

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -48,13 +48,18 @@ export function refKey(
 const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/;
 
 // Real YAML parsing, not hand-rolled per-shape regexes — frontmatter is YAML,
-// and `project-docs-ancestors` is a normal YAML sequence that can legally be
+// and a reference-list field is a normal YAML sequence that can legally be
 // written as an inline flow array (`[a, b]`), a block list (`- a\n  - b`), or
 // (what Prettier reformats an inline array into once it's long enough to wrap)
 // a multi-line flow array. A regex per shape silently returned [] — no error,
 // no log — for whichever shape it didn't special-case; a real parser handles
 // all of them, and anything YAML legally allows in the future, uniformly.
-export function extractFrontmatterAncestorRefs(content: string): string[] {
+// Shared by every frontmatter reference-list field (`project-docs-ancestors`,
+// `resolves`) rather than re-implementing the same parse per field.
+export function extractFrontmatterField(
+  content: string,
+  field: string,
+): string[] {
   const block = FRONTMATTER_BLOCK.exec(content);
   if (!block) {
     return [];
@@ -67,13 +72,15 @@ export function extractFrontmatterAncestorRefs(content: string): string[] {
     return [];
   }
 
-  const refs = (frontmatter as Record<string, unknown> | null)?.[
-    'project-docs-ancestors'
-  ];
+  const refs = (frontmatter as Record<string, unknown> | null)?.[field];
   if (!Array.isArray(refs)) {
     return [];
   }
   return refs.filter((ref): ref is string => typeof ref === 'string');
+}
+
+export function extractFrontmatterAncestorRefs(content: string): string[] {
+  return extractFrontmatterField(content, 'project-docs-ancestors');
 }
 
 export function extractCommentAncestorRefs(content: string): string[] {
@@ -146,9 +153,39 @@ export function resolveRefFromPath(host: Tree, rawPath: string): string {
   return refKey({ project, type, id });
 }
 
+// Shared by every artifact-producing generator that supports both
+// --projectDocsAncestors and --resolves: resolves each (same
+// resolveRefFromPath, so an unresolvable path throws before any write either
+// way), then merges the resolved refs into the ancestors list — a resolution
+// is still structurally an ancestor, so getAncestors/getDescendants/unscoped
+// traversal sees it regardless of which flag added it — while keeping the
+// resolved refs available separately so the caller can also write the
+// distinct `resolves` frontmatter field project-docs-lineage's
+// resolutionStatus actually reads.
+export function resolveAncestorsAndResolves(
+  host: Tree,
+  projectDocsAncestors: string[] | undefined,
+  resolves: string[] | undefined,
+): { ancestors: string[]; resolvedRefs: string[] } {
+  const ancestors = (projectDocsAncestors ?? []).map((path) =>
+    resolveRefFromPath(host, path),
+  );
+  const resolvedRefs = (resolves ?? []).map((path) =>
+    resolveRefFromPath(host, path),
+  );
+  return {
+    ancestors: [...new Set([...ancestors, ...resolvedRefs])],
+    resolvedRefs,
+  };
+}
+
 export interface RegistryEntry {
   path: string;
   ancestorRefs: string[];
+  // Refs this artifact explicitly claims to resolve (via --resolves), not
+  // just build on — a strict subset of ancestorRefs, since a resolved ref is
+  // also written there for traversal. See computeViolations' resolutionStatus.
+  resolves: string[];
 }
 
 export type Registry = Map<string, RegistryEntry>;
@@ -263,6 +300,7 @@ function registerArtifact(
   registry.set(key, {
     path,
     ancestorRefs: extractFrontmatterAncestorRefs(content),
+    resolves: extractFrontmatterField(content, 'resolves'),
   });
 }
 
@@ -311,6 +349,7 @@ export interface Violations {
   brokenRefs: { ref: string; referencedFrom: string }[];
   orphans: string[];
   unscoped: string[];
+  resolutionStatus: { open: string[]; resolved: string[] };
 }
 
 // `artifactSchema` is plain data the workspace owns (see utils/artifact-schema.ts)
@@ -354,7 +393,36 @@ export function computeViolations(
     }
   }
 
-  return { brokenRefs, orphans, unscoped };
+  // Which kinds get an open/resolved fact at all is data-driven
+  // (tracksResolution), same as expectedAncestorTypes above — no concrete
+  // type name here either. "Resolved" is a direct registry-to-registry
+  // check (does any artifact's own `resolves` list name this key), not a
+  // proxy on referrer type: a blocker or another open question citing this
+  // one *because* it's still unresolved would, under a type-based proxy,
+  // get misread as resolving it.
+  const resolvedKeys = new Set<string>();
+  for (const entry of registry.values()) {
+    for (const resolved of entry.resolves) {
+      resolvedKeys.add(resolved);
+    }
+  }
+
+  const resolutionStatus: Violations['resolutionStatus'] = {
+    open: [],
+    resolved: [],
+  };
+  for (const key of registry.keys()) {
+    const parsedKey = parseAncestorRef(key);
+    if (!parsedKey || !artifactSchema[parsedKey.type]?.tracksResolution) {
+      continue;
+    }
+    (resolvedKeys.has(key)
+      ? resolutionStatus.resolved
+      : resolutionStatus.open
+    ).push(key);
+  }
+
+  return { brokenRefs, orphans, unscoped, resolutionStatus };
 }
 
 // The two retrieval directions, deliberately not symmetric in cost. Forward


### PR DESCRIPTION
## Summary

Implements `NX-AGENT-OPEN-QUESTIONS-BLOCKERS-GENERATOR-PROPOSAL.md` — promotes `open-question` and `blocker` from hand-authored `project-docs/` artifacts to real generators, following the same path `domain-term`/`bounded-context`/`domain-model` already took (validated by two independent trial runs of the DDDD workflow producing real instances with identical frontmatter shape).

Three separable pieces:

1. **`open-question`/`blocker` generators** — mirror `domain-model`'s exact shape (`--project`, `--projectDocsAncestors`, duplicate-throw, README bootstrap, artifact-schema self-registration).
2. **`--resolves <path>`** on `domain-term`/`bounded-context`/`domain-model` (`bounded-context` also gains `--projectDocsAncestors`, since it had neither field before this). The resolved ref is written to *both* `project-docs-ancestors` (so ordinary lineage traversal is unaffected) and a new, distinct `resolves` field. This is a deliberate change from folding it silently into `project-docs-ancestors` with just a console confirmation — surfaced during design discussion that a resolution and a plain "built on this for context" reference need to stay distinguishable *after the fact* in the data, not just at generation time.
3. **`resolutionStatus` in `project-docs-lineage`** — reports open vs. resolved for any artifact type that opts in via a new `tracksResolution` flag in `artifact-schema.json`, not a hardcoded type-name check in `computeViolations` — matching the existing `expectedAncestorTypes` convention, so a custom artifact kind with the same lifecycle gets the same report for free. "Resolved" means a registered artifact's own `resolves` field names the key — not merely that something references it via `project-docs-ancestors` — because a `blocker` or another `open-question` citing an existing one *specifically because it's still unresolved* would otherwise be misread as resolving it.

## Verification

Ran the real sequence against a packed local tarball in a scratch workspace:
- `open-question "Reviewer Authorization"` → `domain-model --resolves <that path>` → printed `✓ this domain model resolves open-questions:reviewer-authorization`, wrote both `project-docs-ancestors` and `resolves`.
- `project-docs-lineage` → console-logged `resolved: open-questions:reviewer-authorization`; `.nx-agent/lineage.json`'s `resolutionStatus.resolved` contained it.
- A second `open-question` cited only via plain `--projectDocsAncestors` from a peer `blocker` (no `--resolves`) correctly stayed in `resolutionStatus.open` — confirms a peer "issue" artifact citing something for context isn't mistaken for a resolution.

## Test plan

- [x] New `open-question.spec.ts`/`blocker.spec.ts` (8 tests each, mirroring `domain-model.spec.ts`).
- [x] New `--resolves` tests on `domain-term`/`bounded-context`/`domain-model` specs.
- [x] New `computeViolations` tests for `resolutionStatus`, including the false-positive case (peer blocker/open-question citing without resolving).
- [x] New `project-docs-lineage` test for `resolutionStatus` console output + `lineage.json` shape.
- [x] `npx nx run-many -t lint,test,build -p nx-agent` — all green (145 tests).