### PR TITLE
feat(nx-oc): bump adsp-cli to ^1.7.0 and wire up CI client-credentials login

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -379,6 +379,10 @@ also offers a **+ Create a new tenant** choice, in `dev`/`test` (never `prod`), 
 accounts — see the [package README](https://github.com/GovAlta/nx-tools/blob/main/packages/nx-adsp/README.md#authentication)
 for the exact eligibility rules.
 
+A non-interactive run (CI) can also authenticate as a CI service account by setting
+`ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET`, instead of pre-obtaining a token for `--accessToken` — see the
+package README linked above.
+
 ## Agent consultation
 
 `express-service`, `react-app`, `angular-app`, `vue-app`, and the fullstack composites connect to

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abgov/adsp-cli": "^1.6.0",
+        "@abgov/adsp-cli": "^1.7.0",
         "@angular/core": "21.2.17",
         "@nx/devkit": "23.0.1",
         "json-schema-to-typescript": "^13.0.1",
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@abgov/adsp-cli": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.6.0.tgz",
-      "integrity": "sha512-jBh3t5aPGJ3EVc9E5UW9fJQsLKL2ExmEfmwIZaHSzCdkiNmy6NzXxH0rACjFSChStVVGRszQx3UV8neAKQKoiA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.8.0.tgz",
+      "integrity": "sha512-nJphvfqHJCgKBKzWeNS+ChhB4ED6HDK0oFIRvPuEaDYTFssrXLiNCXj1SlSM6ZlVINeB0w7A6ic0eYQcr3Bcjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "private": true,
   "dependencies": {
-    "@abgov/adsp-cli": "^1.6.0",
+    "@abgov/adsp-cli": "^1.7.0",
     "@angular/core": "21.2.17",
     "@nx/devkit": "23.0.1",
     "json-schema-to-typescript": "^13.0.1",

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -251,9 +251,13 @@ npx @abgov/adsp-cli login --env <dev|test|prod> --tenant "<Your Tenant>" --scope
 When you run a generator:
 
 - if a valid cached token exists, generation proceeds with no prompt;
-- if not, an **interactive** run launches `adsp login` for you (browser); a
-  **non-interactive** run (`--no-interactive` / CI) fails with the exact
-  `adsp login` command to run first.
+- if `ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET` are set (a CI service account â€” requires
+  `@abgov/adsp-cli` ^1.7.0+ and the tenant's `adsp-cli-ci` Keycloak client enabled with credentials
+  generated), a fresh token is acquired non-interactively via that account, no browser and no prior
+  `adsp login` needed;
+- otherwise, an **interactive** run launches `adsp login` for you (browser); a **non-interactive**
+  run (`--no-interactive` / CI) fails with the exact `adsp login` command to run first, or the two
+  env vars above to set instead.
 
 Generator flags that steer which tenant/token is used:
 
@@ -269,7 +273,7 @@ have a tenant yet? That picker also offers a **+ Create a new tenant** choice â€
 `tenant-service-admin`, and (unless `tenant-service-admin`) that doesn't already own a tenant (one
 per admin email). Picking it prompts for a name and waits for the new realm to finish provisioning
 before continuing the login as that tenant. Requires `@abgov/adsp-cli` ^1.4.0+ (this plugin pins
-^1.6.0 or later).
+^1.7.0 or later).
 
 ## Agent consultation
 

--- a/packages/nx-oc/package.json
+++ b/packages/nx-oc/package.json
@@ -14,7 +14,7 @@
     "tslib": "^2.0.0"
   },
   "dependencies": {
-    "@abgov/adsp-cli": "^1.6.0",
+    "@abgov/adsp-cli": "^1.7.0",
     "axios": "^1.16.0",
     "enquirer": "^2.3.6",
     "yaml": "~2.9.0"

--- a/packages/nx-oc/src/adsp/adsp-utils.spec.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.spec.ts
@@ -1,4 +1,26 @@
-import { adspProjectTags, detectAdspEnv, detectAdspTenant } from './adsp-utils';
+import { spawnSync } from 'child_process';
+import { getAccessToken } from '@abgov/adsp-cli';
+import { isNonInteractive } from '../utils/interactive';
+import {
+  adspProjectTags,
+  detectAdspEnv,
+  detectAdspTenant,
+  ensureAdspToken,
+} from './adsp-utils';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawnSync: jest.fn(),
+}));
+jest.mock('@abgov/adsp-cli', () => ({
+  ...jest.requireActual('@abgov/adsp-cli'),
+  getAccessToken: jest.fn(),
+}));
+jest.mock('../utils/interactive', () => ({ isNonInteractive: jest.fn() }));
+
+const mockedGetAccessToken = getAccessToken as jest.Mock;
+const mockedSpawnSync = spawnSync as jest.Mock;
+const mockedIsNonInteractive = isNonInteractive as jest.Mock;
 
 describe('adspProjectTags', () => {
   it('always includes the env tag', () => {
@@ -47,5 +69,86 @@ describe('detectAdspTenant', () => {
 
   it('returns undefined for an undefined tags array', () => {
     expect(detectAdspTenant(undefined)).toBeUndefined();
+  });
+});
+
+describe('ensureAdspToken', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.ADSP_TENANT_REALM;
+    mockedGetAccessToken.mockReset();
+    mockedSpawnSync.mockReset();
+    mockedIsNonInteractive.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns the token from the fast path without touching ADSP_TENANT_REALM when no realm is given', async () => {
+    mockedGetAccessToken.mockResolvedValue({ status: 'ok', token: 'tok' });
+
+    const token = await ensureAdspToken({ env: 'test' });
+
+    expect(token).toBe('tok');
+    expect(process.env.ADSP_TENANT_REALM).toBeUndefined();
+  });
+
+  it('sets ADSP_TENANT_REALM to the given realm for the duration of the call', async () => {
+    let seenDuringCall: string | undefined;
+    mockedGetAccessToken.mockImplementation(async () => {
+      seenDuringCall = process.env.ADSP_TENANT_REALM;
+      return { status: 'ok', token: 'tok' };
+    });
+
+    await ensureAdspToken({ env: 'test', realm: 'realm-abc' });
+
+    expect(seenDuringCall).toBe('realm-abc');
+    expect(process.env.ADSP_TENANT_REALM).toBeUndefined();
+  });
+
+  it('restores a pre-existing ADSP_TENANT_REALM after the call, rather than leaving the new one set', async () => {
+    process.env.ADSP_TENANT_REALM = 'pre-existing-realm';
+    mockedGetAccessToken.mockResolvedValue({ status: 'ok', token: 'tok' });
+
+    await ensureAdspToken({ env: 'test', realm: 'realm-abc' });
+
+    expect(process.env.ADSP_TENANT_REALM).toBe('pre-existing-realm');
+  });
+
+  it('throws with the CI credentials alternative mentioned, in a non-interactive run with no token', async () => {
+    mockedGetAccessToken.mockResolvedValue({ status: 'not-authenticated' });
+    mockedIsNonInteractive.mockReturnValue(true);
+
+    await expect(
+      ensureAdspToken({ env: 'test', tenant: 'my-tenant' }),
+    ).rejects.toThrow(/ADSP_CLIENT_ID and ADSP_CLIENT_SECRET/);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('drives an interactive login and retries when the fast path misses', async () => {
+    mockedIsNonInteractive.mockReturnValue(false);
+    mockedGetAccessToken
+      .mockResolvedValueOnce({ status: 'not-authenticated' })
+      .mockResolvedValueOnce({ status: 'ok', token: 'tok-after-login' });
+    mockedSpawnSync.mockReturnValue({ status: 0 });
+
+    const token = await ensureAdspToken({ env: 'test', tenant: 'my-tenant' });
+
+    expect(token).toBe('tok-after-login');
+    expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores ADSP_TENANT_REALM (deleting it) even when the call throws', async () => {
+    mockedGetAccessToken.mockResolvedValue({ status: 'not-authenticated' });
+    mockedIsNonInteractive.mockReturnValue(true);
+
+    await expect(
+      ensureAdspToken({ env: 'test', realm: 'realm-abc' }),
+    ).rejects.toThrow();
+
+    expect(process.env.ADSP_TENANT_REALM).toBeUndefined();
   });
 });

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -103,10 +103,13 @@ function runAdspLogin(options: {
 
 /**
  * Obtain an ADSP access token via @abgov/adsp-cli. Fast path: a cached/refreshed
- * token from a prior `adsp login` (no browser). If none — and the run is
- * interactive — drive `adsp login` (browser) once, then read the fresh token.
- * In a non-interactive run it never opens a browser; it throws with the exact
- * `adsp login` command to run instead.
+ * token from a prior `adsp login` (no browser) — or, since @abgov/adsp-cli
+ * ^1.7.0, a fresh client_credentials token when ADSP_CLIENT_ID/ADSP_CLIENT_SECRET
+ * are set (a CI service account; see the 'adsp-cli-ci' Keycloak client). If
+ * neither works — and the run is interactive — drive `adsp login` (browser)
+ * once, then read the fresh token. In a non-interactive run it never opens a
+ * browser; it throws with the exact `adsp login` command to run instead (or
+ * the CI env vars to set).
  *
  * When `scopes` (e.g. the admin scope) can't be satisfied even after a login —
  * a user who isn't a realm admin — it falls back to a base-scope token so
@@ -119,46 +122,72 @@ export async function ensureAdspToken(options: {
   scopes?: string[];
 }): Promise<string | undefined> {
   const { env, realm, tenant, scopes = [] } = options;
-  // Force the CLI to talk to the generator's target environment. Note: we set
-  // ADSP_ENV, never ADSP_TENANT_REALM — the latter would make getStatus() drop
-  // the persisted tenantName (it can't trust a name against an overridden realm).
-  // Default to 'test' (UAT), never 'prod' — matches every generator's schema
-  // default and avoids an accidental production hit if env is ever unset.
+  // Force the CLI to talk to the generator's target environment. Default to
+  // 'test' (UAT), never 'prod' — matches every generator's schema default and
+  // avoids an accidental production hit if env is ever unset.
   process.env.ADSP_ENV = env || process.env.ADSP_ENV || 'test';
 
-  const fetchToken = async (): Promise<string | undefined> => {
-    const result = await getAccessToken(scopes.length ? { scopes } : undefined);
-    return result.status === 'ok' ? result.token : undefined;
-  };
-
-  let token = await fetchToken();
-  if (token) return token;
-
-  if (isNonInteractive()) {
-    const loginCmd = [
-      'npx @abgov/adsp-cli login',
-      `--env ${env}`,
-      tenant ? `--tenant "${tenant}"` : realm ? `--realm ${realm}` : '',
-      ...scopes.map((s) => `--scope ${s}`),
-    ]
-      .filter(Boolean)
-      .join(' ');
-    throw new Error(
-      `Not signed in to ADSP (non-interactive run). Sign in first with:\n  ${loginCmd}`,
-    );
+  // getAccessToken()'s cache lookup and its CI client_credentials fallback both
+  // require a resolvable realm (ADSP_TENANT_REALM or a persisted config) — set
+  // it only when we already know it (the --tenant/--tenantRealm path), and only
+  // for the duration of this call. Left unset otherwise (no realm known yet, so
+  // nothing to set) and always restored afterward rather than left set, so it
+  // doesn't leak into a later, --tenant-less call in the same process — that
+  // path relies on getStatus() trusting the *persisted* tenant name, which it
+  // only does when the realm didn't come from this env var.
+  const previousRealmEnv = process.env.ADSP_TENANT_REALM;
+  if (realm) {
+    process.env.ADSP_TENANT_REALM = realm;
   }
 
-  runAdspLogin({ env, realm, tenant, scopes });
-  token = await fetchToken();
-  if (token) return token;
+  try {
+    const fetchToken = async (): Promise<string | undefined> => {
+      const result = await getAccessToken(
+        scopes.length ? { scopes } : undefined,
+      );
+      return result.status === 'ok' ? result.token : undefined;
+    };
 
-  // The requested scope wasn't granted (e.g. non-admin user). Fall back to a
-  // base-scope token so the rest of generation still works.
-  if (scopes.length) {
-    const base = await getAccessToken();
-    if (base.status === 'ok') return base.token;
+    let token = await fetchToken();
+    if (token) return token;
+
+    if (isNonInteractive()) {
+      const loginCmd = [
+        'npx @abgov/adsp-cli login',
+        `--env ${env}`,
+        tenant ? `--tenant "${tenant}"` : realm ? `--realm ${realm}` : '',
+        ...scopes.map((s) => `--scope ${s}`),
+      ]
+        .filter(Boolean)
+        .join(' ');
+      throw new Error(
+        `Not signed in to ADSP (non-interactive run). Sign in first with:\n  ${loginCmd}\n` +
+          'Or, for a CI service account, set ADSP_CLIENT_ID and ADSP_CLIENT_SECRET ' +
+          "(requires @abgov/adsp-cli ^1.7.0 and the tenant's 'adsp-cli-ci' Keycloak " +
+          'client to be enabled with credentials generated).',
+      );
+    }
+
+    runAdspLogin({ env, realm, tenant, scopes });
+    token = await fetchToken();
+    if (token) return token;
+
+    // The requested scope wasn't granted (e.g. non-admin user). Fall back to a
+    // base-scope token so the rest of generation still works.
+    if (scopes.length) {
+      const base = await getAccessToken();
+      if (base.status === 'ok') return base.token;
+    }
+    return undefined;
+  } finally {
+    if (realm) {
+      if (previousRealmEnv === undefined) {
+        delete process.env.ADSP_TENANT_REALM;
+      } else {
+        process.env.ADSP_TENANT_REALM = previousRealmEnv;
+      }
+    }
   }
-  return undefined;
 }
 
 export async function getServiceUrls(directoryUrl: string) {


### PR DESCRIPTION
## Summary

`@abgov/adsp-cli@1.7.0` adds a non-interactive login path for CI: when `ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET` are set, `getAccessToken()` acquires a token via `client_credentials` against a tenant's `adsp-cli-ci` Keycloak client, instead of requiring a prior interactive `adsp-cli login`.

That fallback (and the existing cache-lookup fast path) both require a resolvable realm first — `ADSP_TENANT_REALM` env var or a persisted config. `ensureAdspToken` already receives a resolved `realm` (from the `--tenant`/`--tenantRealm` anonymous lookup) but never wrote it to `process.env`, so `getAccessToken()`'s internal resolution had nothing to go on for that path — bumping the version alone wouldn't have been enough to actually engage this.

- Bumped `@abgov/adsp-cli` to `^1.7.0` (root + `nx-oc`), `npm install` (scoped 4-line lockfile diff, resolved to `1.8.0` — a compatible, unrelated MCP-server change, confirmed via the upstream changelog). No new vulnerabilities traced to this dependency.
- `ensureAdspToken` now sets `ADSP_TENANT_REALM` for the duration of the call *only* when a realm is already known, and restores the previous value (or deletes it) afterward rather than leaving it set — the `--tenant`-less path relies on `getStatus()` trusting the *persisted* tenant name, which it only does when the realm didn't come from this env var, so leaving it set would risk a stale realm leaking into a later, `--tenant`-less call within the same process (e.g. a composite generator scaffolding several apps).
- The non-interactive failure message now also names `ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET` as an alternative to running `adsp-cli login` manually.
- Updated `packages/nx-adsp/README.md`'s Authentication section and version-pin note, and `docs/nx-adsp/nx-adsp.md`.

## Test plan

- [x] New `ensureAdspToken` tests (previously untested): fast-path success without touching `ADSP_TENANT_REALM` when no realm given; sets it to the given realm *during* the call; restores a pre-existing value afterward; deletes it afterward when there wasn't one; non-interactive throw now mentions the CI env vars; interactive fallback via `adsp-cli login` still works; restoration happens even when the call throws.
- [x] `npx nx run-many -t lint,test,build -p nx-oc,nx-adsp` — all green (nx-oc: 138 tests, +6 new).