### PR TITLE
docs(nx-adsp): document the ADSP MCP server's new config-schema tool in generated AGENTS.md

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -96,6 +96,7 @@ describe('Express Service Generator', () => {
     const agents = host.read('apps/test/AGENTS.md').toString();
     expect(agents).toContain('@abgov/adsp-sdk-mcp-server');
     expect(agents).toContain('get_platform_quickstart');
+    expect(agents).toContain('get_service_configuration_schema');
     expect(agents).toContain('search_sdk_reference');
   }, 60000);
 

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -26,6 +26,13 @@ APIs from memory** when integrating ADSP capabilities:
 
 - `get_platform_quickstart` — the canonical `initializePlatform` usage pattern and
   a capabilities summary. Start here for "how do I use ADSP from this service?".
+  Covers `serviceConfigurations` too — registration creates resources, not just
+  declares a dependency, and there's both a `NamedConfiguration` and a
+  plain-object variant.
+- `get_service_configuration_schema` — fetches the live configuration schema for
+  a platform service from configuration-service. Use this before writing a
+  `serviceConfigurations` entry in `initializeService()` so its shape matches
+  what that service actually expects, instead of guessing.
 - `search_sdk_reference` — look up `@abgov/adsp-service-sdk` by symbol, module, or
   keyword; returns kind, description, option/return shape, example, deprecation.
 - `search_adsp_docs` — keyword search across ADSP platform docs (getting started,


### PR DESCRIPTION
## Summary

`@abgov/adsp-sdk-mcp-server` (checked upstream — GovAlta/adsp-monorepo release `adsp-sdk-mcp-server-v1.10.0`, unpinned in this repo since it's always run fresh via `npx -y`, so no dependency bump is needed here) added a new tool:

- **`get_service_configuration_schema`** — fetches a platform service's *live* configuration schema from configuration-service, so an agent adding a `serviceConfigurations` entry to `initializeService()` knows the exact shape that service expects instead of guessing.
- `get_platform_quickstart`'s own guidance was also clarified: registration actually creates resources (not just declares a dependency), and there are two `serviceConfigurations` variants (`NamedConfiguration` and plain-object).

`express-service`'s generated `AGENTS.md` lists this MCP server's available tools explicitly, for exactly this kind of "look this up instead of recalling it from memory" case — it's the only nx-adsp template that documents this MCP server's tools at all (the only generator using `@abgov/adsp-service-sdk`), so it's the only place needing the addition.

## Test plan

- [x] Extended the existing `express-service.spec.ts` assertion that checks the generated `AGENTS.md`'s tool list to also expect `get_service_configuration_schema`.
- [x] `npx nx run-many -t lint,test,build -p nx-adsp` — all green (88 tests).