### PR TITLE
docs(nx-adsp): mark react-form and react-task-list as deprecated

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -279,7 +279,12 @@ Accepts the same options as `dotnet-service`.
 
 ---
 
-### react-form
+### react-form (deprecated)
+
+**Deprecated** — superseded by ADSP's hosted [Form App](https://govalta.github.io/adsp-monorepo/tutorials/form-service/form-app.html),
+which renders a form definition directly with no custom code. This generator's dynamic-templating
+approach — generating bespoke React source from a form definition's `dataSchema` — predates that
+and is no longer the recommended integration path.
 
 Adds a React component generated from an existing [ADSP Form Definition](https://govalta.github.io/adsp-monorepo/) to an existing project. The generator fetches available form definitions from the ADSP Form service for the target environment.
 
@@ -295,7 +300,11 @@ npx nx g @abgov/nx-adsp:react-form my-app --env test
 
 ---
 
-### react-task-list
+### react-task-list (deprecated)
+
+**Deprecated** — superseded by ADSP's hosted [Task App](https://govalta.github.io/adsp-monorepo/tutorials/task-service/task-app.html),
+which reviews/assesses queue items directly with no custom code. Same dynamic-templating approach
+as `react-form`, and no longer the recommended integration path for the same reason.
 
 Adds a React task list component driven by an [ADSP Task Queue](https://govalta.github.io/adsp-monorepo/) to an existing project.
 

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -207,7 +207,12 @@ Accepts the same options as `dotnet-service`.
 
 ---
 
-### `react-form`
+### `react-form` (deprecated)
+
+**Deprecated** — superseded by ADSP's hosted [Form App](https://govalta.github.io/adsp-monorepo/tutorials/form-service/form-app.html),
+which renders a form definition directly with no custom code. This generator's dynamic-templating
+approach — generating bespoke React source from a form definition's `dataSchema` — predates that
+and is no longer the recommended integration path.
 
 Adds a React component generated from an existing [ADSP Form Definition](https://govalta.github.io/adsp-monorepo/) to an existing project. The generator fetches form definitions from the ADSP Form service for the target environment.
 
@@ -223,7 +228,11 @@ npx nx g @abgov/nx-adsp:react-form my-app --env test
 
 ---
 
-### `react-task-list`
+### `react-task-list` (deprecated)
+
+**Deprecated** — superseded by ADSP's hosted [Task App](https://govalta.github.io/adsp-monorepo/tutorials/task-service/task-app.html),
+which reviews/assesses queue items directly with no custom code. Same dynamic-templating approach
+as `react-form`, and no longer the recommended integration path for the same reason.
 
 Adds a React task list component driven by an [ADSP Task Queue](https://govalta.github.io/adsp-monorepo/) to an existing project.
 

--- a/packages/nx-adsp/generators.json
+++ b/packages/nx-adsp/generators.json
@@ -37,12 +37,14 @@
     "react-form": {
       "factory": "./src/generators/react-form/react-form",
       "schema": "./src/generators/react-form/schema.json",
-      "description": "Generator that creates a React component based on an ADSP Form Definition."
+      "description": "Generator that creates a React component based on an ADSP Form Definition.",
+      "x-deprecated": "Superseded by ADSP's hosted Form App, which renders a form definition with no custom code (see https://govalta.github.io/adsp-monorepo/tutorials/form-service/form-app.html). This generator's dynamic-templating approach — generating bespoke React source from a form definition's dataSchema — predates that and is no longer the recommended integration path."
     },
     "react-task-list": {
       "factory": "./src/generators/react-task-list/react-task-list",
       "schema": "./src/generators/react-task-list/schema.json",
-      "description": "Generator that creates a React component based on an ADSP Task Queue."
+      "description": "Generator that creates a React component based on an ADSP Task Queue.",
+      "x-deprecated": "Superseded by ADSP's hosted Task App, which reviews/assesses queue items with no custom code (see https://govalta.github.io/adsp-monorepo/tutorials/task-service/task-app.html). This generator's dynamic-templating approach predates that and is no longer the recommended integration path."
     },
     "angular-app": {
       "factory": "./src/generators/angular-app/angular-app",


### PR DESCRIPTION
## Summary

`react-form` and `react-task-list` both generate bespoke React source at scaffold time (a component derived from a form definition's `dataSchema`, or from a task queue definition) by hitting the ADSP Configuration Service directly and templating output into the consumer's own repo. That dynamic-templating approach predates two things ADSP now ships that supersede it:

- **[Form App](https://govalta.github.io/adsp-monorepo/tutorials/form-service/form-app.html)** — a hosted, JSON-Forms-driven app that renders any form definition with zero custom code, at a URL derived from tenant + form ID.
- **[Task App](https://govalta.github.io/adsp-monorepo/tutorials/task-service/task-app.html)** — the same story for reviewing/assessing queue items.

I verified the generators still work mechanically before marking them deprecated rather than assuming: both call generic Configuration Service endpoints (`GET /configuration/:namespace/:name/latest`, `GET /configuration/:namespace/:name/active`, `PATCH /configuration/:namespace/:name` with `operation: UPDATE`) that are still current against the live `configuration-service` router source in `GovAlta/adsp-monorepo`. So this isn't "these are broken" — it's "there's now a zero-code recommended path that makes generating and maintaining this component in your own repo unnecessary."

Marked via Nx's own `x-deprecated` field on the generator entry in `generators.json` (the same mechanism `@nx/angular`/`@nx/react` use for their own deprecated generators) rather than removing them outright:
- `nx g @abgov/nx-adsp:react-form` / `react-task-list` still run, but print a deprecation warning naming the replacement.
- They're grouped separately (not hidden) in the interactive `nx g` picker.

Also updated both `packages/nx-adsp/README.md` and `docs/nx-adsp/nx-adsp.md` with a `(deprecated)` marker and a short explanation + link, so this shows up wherever someone reads about these generators, not just at generation time.

## Test plan

- [x] `npx nx run-many -t lint,test,build -p nx-adsp` — all green, no regressions (no existing test asserts on `generators.json` shape)
- [x] Verified `generators.json` still parses as valid JSON with the new field
- [x] Verified the underlying Configuration Service endpoints these generators call are still current against `GovAlta/adsp-monorepo`'s live router source
- [x] Pre-commit hook (affected lint/test/build) passed