### PR TITLE
fix(nx-oc): resolve registry-login username via GITHUB_ACTOR for CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,11 @@ Key wiring to preserve when editing:
   `delete:packages` is missing — needed only by `sandbox-teardown`'s best-effort GHCR package
   deletion, which already tolerates failing silently. It can't check registry-org access
   itself, though — that still only surfaces as a push/import auth error.
+- **CI**: the registry-login and pull-secret username falls back through `GITHUB_ACTOR` before
+  calling `gh api user -q .login` — `GET /user` categorically 403s for a GitHub App/installation
+  token (`GITHUB_TOKEN`), so a workflow running this executor under its own token (no PAT) needs the
+  `GITHUB_ACTOR` fallback the Actions runner always sets. Local/interactive use is unaffected —
+  `GITHUB_ACTOR` is unset there, so it still resolves the active `gh` account.
 - The generator unit tests assert the target/manifest shape; the executor tests mock `child_process`
   `execSync` and assert the command sequence/preflight/retry.
 

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -67,6 +67,19 @@ describe('sandbox executor', () => {
       true,
     );
     expect(has('oc create secret docker-registry ghcr-pull')).toBe(true);
+    // GITHUB_ACTOR (set by the Actions runner) must take priority over `gh api
+    // user -q .login`, which 403s for a GitHub App/installation token — the
+    // registry login and the pull secret both need this fallback to work in CI.
+    const registryLogin = cmds.find((c) => c.includes('podman login'));
+    const pullSecret = cmds.find((c) =>
+      c.includes('oc create secret docker-registry ghcr-pull'),
+    );
+    expect(registryLogin).toContain(
+      '-u "${GITHUB_ACTOR:-$(gh api user -q .login)}"',
+    );
+    expect(pullSecret).toContain(
+      '--docker-username="${GITHUB_ACTOR:-$(gh api user -q .login)}"',
+    );
     expect(
       has(
         'oc process -f .openshift/test/test.sandbox.yml -p PROJECT=test-sandbox',

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -319,10 +319,16 @@ export default async function runExecutor(
     }
     if (!skipPush) {
       // gh supplies the token so no PAT is stored; the same session token backs
-      // the pull secret below.
+      // the pull secret below. GITHUB_ACTOR (always set by the Actions runner)
+      // takes priority over `gh api user -q .login`: GET /user categorically
+      // 403s for a GitHub App/installation token (GITHUB_TOKEN), regardless of
+      // its granted permissions — confirmed against a real CI run — so a
+      // workflow with `packages: write` still needs this fallback to publish
+      // under its own GITHUB_TOKEN with no PAT. Local/interactive use (no
+      // GITHUB_ACTOR set) is unaffected — still resolves the active gh account.
       run(
         'Registry login',
-        `gh auth token | podman login ${registryHost} -u "$(gh api user -q .login)" --password-stdin`,
+        `gh auth token | podman login ${registryHost} -u "\${GITHUB_ACTOR:-$(gh api user -q .login)}" --password-stdin`,
         cwd,
       );
       run('Push image', `podman push ${imageRef}`, cwd);
@@ -330,10 +336,11 @@ export default async function runExecutor(
 
     // ---- import into the namespace imagestream + roll out ----
     // Per-deploy pull secret from the gh session (no long-lived PAT needed).
+    // Same GITHUB_ACTOR fallback as the registry login above, same reason.
     run(
       'Upsert pull secret',
       `oc create secret docker-registry ghcr-pull ` +
-        `--docker-server=${registryHost} --docker-username="$(gh api user -q .login)" --docker-password="$(gh auth token)" ` +
+        `--docker-server=${registryHost} --docker-username="\${GITHUB_ACTOR:-$(gh api user -q .login)}" --docker-password="$(gh auth token)" ` +
         `-n ${sandboxProject} --dry-run=client -o yaml | oc apply -f -`,
       cwd,
     );


### PR DESCRIPTION
## Summary

The sandbox executor's registry login and pull-secret provisioning both resolve the registry username via `gh api user -q .login` — `GET /user`. That endpoint categorically 403s for a GitHub App/installation token (e.g. a workflow's own `GITHUB_TOKEN`), regardless of granted permissions. So a CI job running this executor under its own token (no PAT stored, matching the existing "no long-lived PAT" design) would fail at exactly this step even with `packages: write` granted.

Fix: resolve the username as `${GITHUB_ACTOR:-$(gh api user -q .login)}` instead — `GITHUB_ACTOR` is always set by the Actions runner, and bash's `${VAR:-cmd}` short-circuits the command substitution entirely when the variable is set, so the failing API call is never attempted in CI. Local/interactive use is unaffected since `GITHUB_ACTOR` is unset there — it still resolves the active `gh` account exactly as before.

Reviewed the change already present in the working copy and added the two gaps needed before shipping:
- Test coverage asserting the exact `${GITHUB_ACTOR:-$(gh api user -q .login)}` substitution in both the registry-login and pull-secret commands (previously only a loose substring check on the pull-secret command existed, nothing on the username resolution itself).
- A new **CI** bullet in `AGENTS.md`'s Sandbox deployment "Key wiring to preserve when editing" section, matching how the existing Auth/Registry bullets there document this kind of wiring nuance.

## Test plan

- [x] `npx nx test nx-oc` — new assertions pass, no regressions (138/138)
- [x] `npx nx lint,build nx-oc`
- [x] Pre-commit hook ran affected lint/test/build for `nx-oc` + `nx-adsp` — all green