### PR TITLE
fix(nx-agent): close two orphan-signal false-positive shapes

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -379,7 +379,8 @@ whether its kind has a resolution lifecycle at all:
   "domain-terms": { "expectedAncestorTypes": ["bounded-contexts"] },
   "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] },
   "open-questions": { "expectedAncestorTypes": [], "tracksResolution": true },
-  "blockers": { "expectedAncestorTypes": [], "tracksResolution": true }
+  "blockers": { "expectedAncestorTypes": [], "tracksResolution": true },
+  "iteration-retrospectives": { "expectedAncestorTypes": [], "terminal": true }
 }
 ```
 
@@ -394,6 +395,22 @@ as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 `tracksResolution: true` is what makes `open-questions`/`blockers` show up in `resolutionStatus`
 (below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking
 and gets settled by another artifact) gets the same open/resolved report for free by declaring it.
+
+`terminal: true` marks a type where zero descendants is what correct looks like, not a sign of
+neglect — a close-out/retrospective artifact, working exactly as intended, still has nothing ever
+built on top of it. See `orphans` below.
+
+### `orphans`
+
+`violations.orphans` lists every registered artifact nothing in the workspace references — the
+"nothing derives from it yet" case, distinct from `unscoped` (missing an _expected_ ancestor,
+the opposite direction). Two things feed correctly into what counts as "referenced":
+
+- A reference counts whether it's a plain `project-docs-ancestors` citation or a `resolves` one —
+  a resolution is a real reference too, even when it's the only field naming the target (the normal
+  shape for a hand-authored artifact, before its type earns a generator with a `--resolves` flag
+  that would otherwise duplicate the ref into `project-docs-ancestors` for you).
+- A type with `terminal: true` is excluded from `orphans` entirely, regardless of descendant count.
 
 ### `resolutionStatus`
 

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -344,7 +344,8 @@ whether its kind has a resolution lifecycle at all:
   "domain-terms": { "expectedAncestorTypes": ["bounded-contexts"] },
   "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] },
   "open-questions": { "expectedAncestorTypes": [], "tracksResolution": true },
-  "blockers": { "expectedAncestorTypes": [], "tracksResolution": true }
+  "blockers": { "expectedAncestorTypes": [], "tracksResolution": true },
+  "iteration-retrospectives": { "expectedAncestorTypes": [], "terminal": true }
 }
 ```
 
@@ -359,6 +360,22 @@ as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 `tracksResolution: true` is what makes `open-questions`/`blockers` show up in `resolutionStatus`
 (below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking
 and gets settled by another artifact) gets the same open/resolved report for free by declaring it.
+
+`terminal: true` marks a type where zero descendants is what correct looks like, not a sign of
+neglect — a close-out/retrospective artifact, working exactly as intended, still has nothing ever
+built on top of it. See `orphans` below.
+
+### `orphans`
+
+`violations.orphans` lists every registered artifact nothing in the workspace references — the
+"nothing derives from it yet" case, distinct from `unscoped` (missing an _expected_ ancestor,
+the opposite direction). Two things feed correctly into what counts as "referenced":
+
+- A reference counts whether it's a plain `project-docs-ancestors` citation or a `resolves` one —
+  a resolution is a real reference too, even when it's the only field naming the target (the normal
+  shape for a hand-authored artifact, before its type earns a generator with a `--resolves` flag
+  that would otherwise duplicate the ref into `project-docs-ancestors` for you).
+- A type with `terminal: true` is excluded from `orphans` entirely, regardless of descendant count.
 
 ### `resolutionStatus`
 

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -28,7 +28,10 @@ hand-editing the question/blocker file itself. `--resolves` is layered on top of
 `--project-docs-ancestors` (the resolved ref lands in both places), so it's still visible to normal
 lineage traversal; the distinct `resolves` field is what lets `project-docs-lineage` report a question
 or blocker as resolved specifically, rather than mistaking any artifact that merely cites it for
-context as having settled it.
+context as having settled it. Hand-authoring a resolution for a type with no generator yet (the
+normal state before one exists) doesn't need that duplication done by hand — a `resolves:` entry
+alone is enough; lineage traversal unions it in for you, so the resolved artifact doesn't also need
+to appear in `project-docs-ancestors` to avoid being misreported as an orphan.
 
 **Where an artifact belongs**, one level below the format above: a bounded context, domain model, or
 domain term can be scoped to a specific project (`--project <p>`) instead of the workspace root, and
@@ -48,4 +51,7 @@ domain model expecting both a bounded context and a domain term is still missing
 vocabulary with only one of the two. `project-docs-lineage` reads this file generically, with no
 knowledge of any specific type baked in, and reports — never fails, since this is a convention nudge
 rather than a hard rule — an artifact of a scoped type missing one of its expected ancestors as
-"unscoped."
+"unscoped." The same file also supports `"terminal": true` for a type meant purely as a close-out
+record (a retrospective, for instance) — nothing is ever expected to derive from it, so it's excluded
+from the "orphan" report (zero descendants) that would otherwise flag it identically to a
+domain-model nobody's built on yet.

--- a/packages/nx-agent/src/utils/artifact-schema.spec.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.spec.ts
@@ -82,6 +82,34 @@ describe('ensureArtifactSchemaEntry', () => {
     });
   });
 
+  it('records terminal when passed, and omits it when not', () => {
+    ensureArtifactSchemaEntry(
+      host,
+      'iteration-retrospectives',
+      [],
+      undefined,
+      true,
+    );
+    ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
+
+    expect(readArtifactSchema(host)).toEqual({
+      'iteration-retrospectives': { expectedAncestorTypes: [], terminal: true },
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
+  });
+
+  it('records both tracksResolution and terminal together when both are passed', () => {
+    ensureArtifactSchemaEntry(host, 'blockers', [], true, true);
+
+    expect(readArtifactSchema(host)).toEqual({
+      blockers: {
+        expectedAncestorTypes: [],
+        tracksResolution: true,
+        terminal: true,
+      },
+    });
+  });
+
   it('preserves a hand-added entry for a type nx-agent knows nothing about', () => {
     host.write(
       'project-docs/artifact-schema.json',

--- a/packages/nx-agent/src/utils/artifact-schema.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.ts
@@ -3,15 +3,19 @@ import { Tree, readJson, writeJson } from '@nx/devkit';
 const ARTIFACT_SCHEMA_PATH = 'project-docs/artifact-schema.json';
 
 // What ancestor types a given artifact `type` is expected to have — e.g.
-// domain-terms expects a bounded-contexts ancestor — and whether that type
-// has a resolution lifecycle at all (open-questions/blockers do; most types
-// don't). Both are data the workspace owns, not logic nx-agent owns:
-// project-docs-lineage only ever reads this generically (no per-type
-// branches), so a hand-invented artifact kind with its own entry here gets
-// the same soft checks for free.
+// domain-terms expects a bounded-contexts ancestor — whether that type has a
+// resolution lifecycle at all (open-questions/blockers do; most types don't)
+// — and whether it's terminal: nothing is ever expected to derive from it, so
+// zero descendants is what correct looks like, not a sign of neglect (a
+// close-out/retrospective artifact, working exactly as intended, still has
+// zero descendants forever). All three are data the workspace owns, not
+// logic nx-agent owns: project-docs-lineage only ever reads this
+// generically (no per-type branches), so a hand-invented artifact kind with
+// its own entry here gets the same soft checks for free.
 export interface ArtifactTypeSchema {
   expectedAncestorTypes: string[];
   tracksResolution?: boolean;
+  terminal?: boolean;
 }
 
 export type ArtifactSchema = Record<string, ArtifactTypeSchema>;
@@ -31,11 +35,13 @@ export function ensureArtifactSchemaEntry(
   type: string,
   expectedAncestorTypes: string[],
   tracksResolution?: boolean,
+  terminal?: boolean,
 ): void {
   const schema = readArtifactSchema(host);
   schema[type] = {
     expectedAncestorTypes,
     ...(tracksResolution ? { tracksResolution } : {}),
+    ...(terminal ? { terminal } : {}),
   };
   writeJson(host, ARTIFACT_SCHEMA_PATH, schema);
 }

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -144,6 +144,31 @@ describe('extractFrontmatterAncestorRefs', () => {
     );
     expect(extractFrontmatterAncestorRefs(content)).toEqual([]);
   });
+
+  it('unions in resolves — a hand-authored resolution counts as an ancestor reference too', () => {
+    const content = [
+      '---',
+      'project-docs-ancestors: [requirements:some-requirement]',
+      'resolves: [blockers:some-blocker]',
+      '---',
+    ].join('\n');
+    expect(extractFrontmatterAncestorRefs(content)).toEqual([
+      'requirements:some-requirement',
+      'blockers:some-blocker',
+    ]);
+  });
+
+  it('dedupes when resolves is already duplicated into project-docs-ancestors (the generator-authored shape)', () => {
+    const content = [
+      '---',
+      'project-docs-ancestors: [blockers:some-blocker]',
+      'resolves: [blockers:some-blocker]',
+      '---',
+    ].join('\n');
+    expect(extractFrontmatterAncestorRefs(content)).toEqual([
+      'blockers:some-blocker',
+    ]);
+  });
 });
 
 describe('extractCommentAncestorRefs', () => {
@@ -275,6 +300,78 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     expect(violations.orphans).toEqual(['domain-terms:unused']);
     expect(violations.brokenRefs).toEqual([]);
+  });
+
+  it('does not flag a hand-authored resolution as an orphan, even without duplicating the ref into project-docs-ancestors', () => {
+    // Mirrors the real case that motivated this: a resolution authored by
+    // hand (no generator for the referencing type yet) that only sets
+    // `resolves`, unlike a generator-authored one which also duplicates the
+    // ref into project-docs-ancestors at write time.
+    host.write(
+      'project-docs/blockers/some-blocker.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/iteration-retrospectives/first.md',
+      [
+        '---',
+        'project-docs-ancestors: [requirements:some-requirement]',
+        'resolves: [blockers:some-blocker]',
+        '---',
+      ].join('\n'),
+    );
+    host.write(
+      'project-docs/requirements/some-requirement.md',
+      ['---', 'name: Some requirement', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+
+    expect(violations.orphans).not.toContain('blockers:some-blocker');
+  });
+
+  it('excludes a terminal-typed artifact from orphans even with zero descendants', () => {
+    host.write(
+      'project-docs/iteration-retrospectives/first.md',
+      ['---', 'project-docs-ancestors: []', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'iteration-retrospectives': {
+          expectedAncestorTypes: [],
+          terminal: true,
+        },
+      },
+    );
+
+    expect(violations.orphans).not.toContain('iteration-retrospectives:first');
+  });
+
+  it('still flags a non-terminal artifact with zero descendants as an orphan, alongside a terminal one with none', () => {
+    host.write(
+      'project-docs/iteration-retrospectives/first.md',
+      ['---', 'project-docs-ancestors: []', '---'].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-models/unpicked-up.md',
+      ['---', 'name: Unpicked up', '---'].join('\n'),
+    );
+
+    const violations = computeViolations(
+      buildRegistry(host),
+      buildIndex(host),
+      {
+        'iteration-retrospectives': {
+          expectedAncestorTypes: [],
+          terminal: true,
+        },
+      },
+    );
+
+    expect(violations.orphans).toEqual(['domain-models:unpicked-up']);
   });
 
   it('handles a multi-ref file deriving from more than one artifact', () => {

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -79,8 +79,22 @@ export function extractFrontmatterField(
   return refs.filter((ref): ref is string => typeof ref === 'string');
 }
 
+// Every artifact-producing generator that supports both --projectDocsAncestors
+// and --resolves already duplicates a resolved ref into project-docs-ancestors
+// at write time (resolveAncestorsAndResolves, below) — "a resolution is still
+// structurally an ancestor" — but that's only true for generator-authored
+// files. A hand-authored artifact (the normal state before a type earns its
+// own generator) has no such write-time step, so its resolves field is easy
+// to write without remembering to duplicate the ref into
+// project-docs-ancestors too — nothing enforces that duplication. Unioning
+// here, in the one function every ancestor-ref reader (the registry, the
+// index buildIndex uses for orphans/brokenRefs, and getAncestors at depth 1)
+// already shares, makes the invariant true unconditionally instead of only
+// for generator-produced content.
 export function extractFrontmatterAncestorRefs(content: string): string[] {
-  return extractFrontmatterField(content, 'project-docs-ancestors');
+  const ancestors = extractFrontmatterField(content, 'project-docs-ancestors');
+  const resolves = extractFrontmatterField(content, 'resolves');
+  return [...new Set([...ancestors, ...resolves])];
 }
 
 export function extractCommentAncestorRefs(content: string): string[] {
@@ -374,7 +388,18 @@ export function computeViolations(
     }
   }
 
-  const orphans = [...registry.keys()].filter((key) => !index.has(key));
+  // A terminal type (declared, same as expectedAncestorTypes/tracksResolution,
+  // by its own generator — no hardcoded type name here either) always has
+  // zero descendants by design once it's closed out correctly: that's what
+  // correct looks like, not neglect, so it's excluded from orphans rather
+  // than reported alongside a domain-model nobody's designed against yet.
+  const orphans = [...registry.keys()].filter((key) => {
+    if (index.has(key)) {
+      return false;
+    }
+    const parsedKey = parseAncestorRef(key);
+    return !parsedKey || !artifactSchema[parsedKey.type]?.terminal;
+  });
 
   const unscoped: string[] = [];
   for (const [key, entry] of registry) {


### PR DESCRIPTION
## Summary

Two real, already-observed false-positive shapes in `project-docs-lineage`'s `orphans` signal, both from `NX-AGENT-ORPHAN-SIGNAL-FALSE-POSITIVES-PROPOSAL.md` (moved to `resolved/` — this PR closes it).

**Case 1 — a hand-authored resolution still showed as an orphan.** A generator-authored resolution (`--resolves`) duplicates the resolved ref into `project-docs-ancestors` at write time, so it's already visible to lineage traversal. A hand-authored one (the normal state for any artifact type before it earns a `--resolves`-capable generator) has no such write-time step — only `resolves:` gets set, and nothing enforces duplicating the ref into `project-docs-ancestors` too.

The proposal's own suggested fix location (`buildRegistry`/`registerArtifact`) turned out not to actually work: `buildIndex` — the function orphan status depends on — never reads the registry at all; it independently re-parses each file's raw frontmatter. I relocated the fix one level down, to `extractFrontmatterAncestorRefs` itself, which all three ancestor-ref readers (the registry, `buildIndex`, and `getAncestors` at depth 1) share — it now unions in `resolves`, so the fix applies consistently everywhere instead of only to whichever call site got patched first. Safe for the already-working case too: a generator-authored file already has the ref duplicated, so the union there is a no-op (deduped via `Set`).

**Case 2 — a genuinely terminal artifact type will always show as an orphan, by design, forever.** A close-out/retrospective artifact working exactly as intended has zero descendants — that's correct, not neglect, but it showed up identically to a domain-model nobody's designed against yet. Added `terminal?: boolean` to `ArtifactTypeSchema`, same data-driven shape as `expectedAncestorTypes`/`tracksResolution` (no hardcoded type names in `computeViolations` — a type opts in by declaring the flag in its own `artifact-schema.json` entry). `orphans` now excludes any type declaring `terminal: true`.

## Test plan

- [x] `npx nx test nx-agent` — 172/172 passing (7 new tests): `extractFrontmatterAncestorRefs` unions `resolves` and dedupes the already-duplicated case; a hand-authored resolution (mirroring the real motivating case — a blocker resolved only via an `iteration-retrospectives`-shaped artifact's `resolves:` field) no longer shows as an orphan; a `terminal: true` type with zero descendants is excluded from `orphans`; a non-terminal type with zero descendants still correctly shows up alongside a terminal one that doesn't; `ensureArtifactSchemaEntry` records/omits `terminal` correctly, alone and combined with `tracksResolution`
- [x] `npx nx lint,build nx-agent`
- [x] Pre-commit hook ran affected lint/test/build — all green