### PR TITLE
fix(nx-adsp): load design tokens so goa-* elements are actually styled

### DIFF
--- a/packages/nx-adsp/src/generators/react-app/files/src/main.tsx__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/src/main.tsx__tmpl__
@@ -1,3 +1,8 @@
+// Design tokens must load before web-components' own CSS — every goa-*
+// element styles itself through --goa-* custom properties (spacing,
+// color, type) defined here; without them, headers/banners/buttons render
+// with no spacing at all rather than looking unbranded but boxy.
+import '@abgov/design-tokens/dist/tokens.css';
 import '@abgov/web-components';
 import '@abgov/web-components/index.css';
 import { StrictMode } from 'react';

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -36,6 +36,19 @@ describe('React App Generator', () => {
     expect(host.exists('apps/test/nginx.conf')).toBeTruthy();
   }, 30000);
 
+  it('loads design tokens before web-components CSS, so goa-* elements are actually styled', async () => {
+    // @abgov/web-components' own CSS only defines rules in terms of --goa-*
+    // custom properties — without the tokens stylesheet also loaded, every
+    // goa-* element (header, banner, buttons) renders with no spacing at
+    // all, not just unbranded. Regression guard for exactly that gap.
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    const mainTsx = host.read('apps/test/src/main.tsx').toString();
+    expect(mainTsx).toContain("import '@abgov/design-tokens/dist/tokens.css';");
+    expect(mainTsx).toContain("import '@abgov/web-components/index.css';");
+  }, 30000);
+
   it("runs nx-adsp's own workspace-root setup (ADSP SDK MCP server + VS Code settings)", async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, options);

--- a/packages/nx-adsp/src/generators/vue-app/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/main.ts__tmpl__
@@ -1,3 +1,8 @@
+// Design tokens must load before web-components' own CSS — every goa-*
+// element styles itself through --goa-* custom properties (spacing,
+// color, type) defined here; without them, headers/banners/buttons render
+// with no spacing at all rather than looking unbranded but boxy.
+import '@abgov/design-tokens/dist/tokens.css';
 import '@abgov/web-components';
 import '@abgov/web-components/index.css';
 import { createApp } from 'vue';

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -63,6 +63,18 @@ describe('Vue App Generator', () => {
     expect(host.exists('.vscode/settings.json')).toBeTruthy();
   }, 30000);
 
+  it('loads design tokens before web-components CSS, so goa-* elements are actually styled', async () => {
+    // @abgov/web-components' own CSS only defines rules in terms of --goa-*
+    // custom properties — without the tokens stylesheet also loaded, every
+    // goa-* element (header, banner, buttons) renders with no spacing at
+    // all, not just unbranded. Regression guard for exactly that gap.
+    await generator(host, options);
+
+    const mainTs = host.read('apps/test/src/main.ts').toString();
+    expect(mainTs).toContain("import '@abgov/design-tokens/dist/tokens.css';");
+    expect(mainTs).toContain("import '@abgov/web-components/index.css';");
+  }, 30000);
+
   it('records the resolved env/tenant as project tags for the sandbox generator', async () => {
     await generator(host, options);
     const config = readProjectConfiguration(host, 'test');


### PR DESCRIPTION
## Summary

Found by actually running a generated app: `react-app` and `vue-app` both import `@abgov/web-components` and its CSS in `main.tsx`/`main.ts`, but never import `@abgov/design-tokens/dist/tokens.css` — even though `@abgov/design-tokens` is already a declared dependency of the generated project. Every `goa-*` element styles itself entirely through `--goa-*` CSS custom properties defined in that stylesheet; without it, the header, hero banner, and buttons render with no spacing at all, not just unbranded.

`angular-app` already gets this right — its `styles.css__tmpl__` imports both stylesheets. This brings the other two frontend generators in line with that existing, working pattern.

### Verified live, not just by reading the template

Generated a real `react-app` project (mocking `getAdspConfiguration` the same way the generator's own tests do, so no real ADSP tenant/credentials needed), installed its dependencies, and ran the actual dev server:
- Before the fix: header/banner spacing visibly broken.
- After adding the missing import: `vendor.css` grew from 65.4 KiB to 158 KiB (the tokens stylesheet actually landing in the bundle), and the spacing rendered correctly.

## Test plan

- [x] New regression test in both `react-app.spec.ts` and `vue-app.spec.ts` asserting `main.tsx`/`main.ts` imports `@abgov/design-tokens/dist/tokens.css` alongside the existing `@abgov/web-components/index.css` import
- [x] `npx nx test nx-adsp` (with `--experimental-vm-modules`, since a raw `jest` invocation without it flakes on an unrelated dynamic-import interop issue present even on unmodified `main`) — 90/90 passing
- [x] `npx nx lint,build nx-adsp`
- [x] Pre-commit hook ran the full affected suite — all green