### PR TITLE
docs(nx-oc): cross-reference sandbox and deployment in the package README

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/AGENTS.md__tmpl__
@@ -166,7 +166,7 @@ nx run <%= projectName %>:teardown-dev      # remove from dev environment
 
 ## Sandbox deployment (local build)
 
-`nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
+**Deployment target: `sandbox`.** `nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
 
 ```bash
 nx g @abgov/nx-oc:sandbox <%= projectName %> --sandboxProject <your-namespace>

--- a/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/AGENTS.md__tmpl__
@@ -585,7 +585,7 @@ nx run <%= projectName %>:teardown-dev      # remove from dev environment
 
 ## Sandbox deployment (local build)
 
-`nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
+**Deployment target: `sandbox`.** `nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
 
 ```bash
 nx g @abgov/nx-oc:sandbox <%= projectName %> --sandboxProject <your-namespace>

--- a/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
@@ -148,7 +148,7 @@ nx run <%= projectName %>:teardown-dev      # remove from dev environment
 
 ## Sandbox deployment (local build)
 
-`nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
+**Deployment target: `sandbox`.** `nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
 
 ```bash
 nx g @abgov/nx-oc:sandbox <%= projectName %> --sandboxProject <your-namespace>

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -225,7 +225,7 @@ nx run <%= projectName %>:teardown-dev      # remove from dev environment
 
 ## Sandbox deployment (local build)
 
-`nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
+**Deployment target: `sandbox`.** `nx run <%= projectName %>:sandbox` builds the image **locally with podman**, pushes it to GHCR, and deploys it to your namespace — no git push or CI wait. Run the generator once first to add the targets:
 
 ```bash
 nx g @abgov/nx-oc:sandbox <%= projectName %> --sandboxProject <your-namespace>

--- a/packages/nx-oc/README.md
+++ b/packages/nx-oc/README.md
@@ -155,6 +155,12 @@ the image **locally with podman**, pushes it to a container registry (GHCR), and
 imports it into your OpenShift namespace — no git push or CI wait. (Requires the
 Nx 23 line, `@abgov/nx-oc` 13.x.)
 
+`sandbox` writes `.openshift/<project>/<project>.sandbox.yml`, alongside
+[`deployment`](#deployment)'s `.openshift/<project>/<project>.yml` — the two share
+the same `.openshift/<project>/Dockerfile` (identical either way) but never touch
+each other's manifest. A project can have both — a real CI-driven pipeline
+deployment and a sandbox for local experimentation — at the same time.
+
 ```bash
 # Add the sandbox targets to a project (run once per app)
 npx nx g @abgov/nx-oc:sandbox my-app --sandboxProject=<namespace> --registry=ghcr.io/<org>
@@ -193,8 +199,15 @@ sequence, quota/auth/CrashLoopBackOff guidance).
 
 ## Typical workflow
 
+### Production pipeline
+
 1. Run `pipeline` once per workspace to generate shared build infrastructure manifests.
 2. Run `apply-infra` (or pass `--apply` to `pipeline`) to provision the resources on the cluster.
 3. Run `deployment` for each application and environment combination.
 4. Add an `apply` executor target to each application's `project.json`.
 5. In your GitHub Actions or Jenkins pipeline, call `npx nx run my-app:deploy` to apply manifests during CI/CD.
+
+### Sandbox iteration
+
+1. Run `sandbox` for each application, passing `--sandboxProject` and `--database` as needed.
+2. Run `npx nx run my-app:sandbox` to build, push, and deploy. Repeat on every change.


### PR DESCRIPTION
## Summary

`packages/nx-oc/README.md`'s "Sandbox deployment" section never mentioned `deployment`, and "Typical workflow" was a single pipeline-only list with no sandbox path at all. `docs/nx-oc/nx-oc.md` (the docs site) already had both of these fixed, but the published package README never got the same update.

This was the one piece of `NX-OC-SANDBOX-DEPLOYMENT-MANIFEST-OVERWRITE-BUG.md`'s suggested fix ("document the collision in both generators' output/README") that didn't get carried over once the actual manifest-collision bug itself was fixed in #357 — the code fix and `docs.md` update happened, but `README.md` was left behind.

Brings `README.md` in line with `docs.md`:
- A cross-reference note in "Sandbox deployment" mirroring the one `deployment`'s own section already has (`sandbox` writes `<project>.sandbox.yml` alongside `deployment`'s `<project>.yml`, sharing the same `Dockerfile`, neither touches the other's manifest).
- "Typical workflow" split into "Production pipeline" / "Sandbox iteration", matching `docs.md`'s existing structure exactly (same steps, just no longer README-exclusive drift).

## Test plan

- [x] Docs-only change — no code touched
- [x] Pre-commit hook ran the full affected suite (`nx-oc` + `nx-adsp`) — 90+ tests, all green