### PR TITLE
feat(nx-agent): promote iteration-retrospectives to a generator

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -335,6 +335,46 @@ artifact that actually revises the thing it's blocking resolves it via `--resolv
 
 ---
 
+## `iteration-retrospective`
+
+A close-out record for a single iteration's pass — what it did, what was found and fixed along the
+way, and an explicit status when "deployment succeeded" and "verified working end-to-end" diverge:
+
+```bash
+npx nx g @abgov/nx-agent:iteration-retrospective "Submit Minor Collision Report" \
+  --project-docs-ancestors=project-docs/requirements/submit-minor-collision-report.md \
+  --resolves=project-docs/blockers/no-write-packages-credential-for-ghcr-sandbox-push.md
+```
+
+Creates `project-docs/iteration-retrospectives/submit-minor-collision-report.md`:
+
+```markdown
+---
+title: Submit Minor Collision Report
+project-docs-ancestors: [requirements:submit-minor-collision-report, blockers:no-write-packages-credential-for-ghcr-sandbox-push]
+resolves: [blockers:no-write-packages-credential-for-ghcr-sandbox-push]
+---
+
+<!-- Free-text body: what this pass did, what was found and fixed along the way, and an
+     explicit status when "deployment succeeded" and "verified working end-to-end" diverge. -->
+```
+
+### `iteration-retrospective` options
+
+| Option                 | Default                  | Description                                                                                                                                                                                                                        |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | — (required, positional) | A short title for this iteration's pass                                                                                                                                                                                            |
+| `project`              | workspace root           | Scope the retrospective to a specific project's `project-docs/iteration-retrospectives/` instead — prefer this whenever the iteration already has a natural code home                                                              |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this pass covered — repeatable; every requirement, domain model, or design substantively created, revised, or touched this iteration, not just the requirement it nominally closes out |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this iteration resolved — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such            |
+
+Self-registers its own `project-docs/artifact-schema.json` entry as `terminal: true` — a
+correctly-closed-out retrospective has zero descendants by design, so it's excluded from
+`project-docs-lineage`'s orphan report rather than flagged alongside a genuine dead-end. Re-adding a
+retrospective that already exists throws rather than silently overwriting or duplicating it.
+
+---
+
 ## `project-docs-lineage`
 
 Scans the whole workspace for `project-docs/` artifacts and `project-docs-ancestors` references —

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -492,6 +492,11 @@ actually reporting on rather than in a new top-level directory. `--outputPath` o
 Unlike `project-docs-lineage`, this never throws on a broken reference — surfacing exactly that kind
 of bad news is the point of a status report, not something to gate on.
 
+Graph nodes and table rows are colored by status — resolved, open, orphaned, or (a distinct style,
+with a "Closed out" badge and a `✓` in the graph) a `terminal`-typed artifact like an
+`iteration-retrospective`, so a permanently-zero-descendant close-out reads as done rather than
+looking like an ordinary orphan.
+
 ### `--project` scoping
 
 `registry`/`index`/`violations` are always computed over the full workspace first, unconditionally —

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -300,6 +300,44 @@ resolves: []
 Same resolution model as `open-question`: never mark it resolved by editing its own file — the
 artifact that actually revises the thing it's blocking resolves it via `--resolves`.
 
+## `iteration-retrospective`
+
+A close-out record for a single iteration's pass — what it did, what was found and fixed along the
+way, and an explicit status when "deployment succeeded" and "verified working end-to-end" diverge:
+
+```bash
+npx nx g @abgov/nx-agent:iteration-retrospective "Submit Minor Collision Report" \
+  --project-docs-ancestors=project-docs/requirements/submit-minor-collision-report.md \
+  --resolves=project-docs/blockers/no-write-packages-credential-for-ghcr-sandbox-push.md
+```
+
+Creates `project-docs/iteration-retrospectives/submit-minor-collision-report.md`:
+
+```markdown
+---
+title: Submit Minor Collision Report
+project-docs-ancestors: [requirements:submit-minor-collision-report, blockers:no-write-packages-credential-for-ghcr-sandbox-push]
+resolves: [blockers:no-write-packages-credential-for-ghcr-sandbox-push]
+---
+
+<!-- Free-text body: what this pass did, what was found and fixed along the way, and an
+     explicit status when "deployment succeeded" and "verified working end-to-end" diverge. -->
+```
+
+### Options
+
+| Option                 | Default                  | Description                                                                                                                                                                                                                        |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | — (required, positional) | A short title for this iteration's pass                                                                                                                                                                                            |
+| `project`              | workspace root           | Scope the retrospective to a specific project's `project-docs/iteration-retrospectives/` instead — prefer this whenever the iteration already has a natural code home                                                              |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this pass covered — repeatable; every requirement, domain model, or design substantively created, revised, or touched this iteration, not just the requirement it nominally closes out |
+| `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this iteration resolved — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such            |
+
+Self-registers its own `project-docs/artifact-schema.json` entry as `terminal: true` (see
+`project-docs-lineage` below) — a correctly-closed-out retrospective has zero descendants by design,
+so it's excluded from the orphan report rather than flagged alongside a genuine dead-end. Re-adding a
+retrospective that already exists throws rather than silently overwriting or duplicating it.
+
 ## `project-docs-lineage`
 
 Scans the whole workspace for `project-docs/` artifacts and `project-docs-ancestors` references —

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -33,6 +33,11 @@
       "schema": "./src/generators/blocker/schema.json",
       "description": "Adds one blocker under project-docs/blockers/, with a project-docs-ancestors frontmatter list and a free-text body describing what needs fixing."
     },
+    "iteration-retrospective": {
+      "factory": "./src/generators/iteration-retrospective/iteration-retrospective",
+      "schema": "./src/generators/iteration-retrospective/schema.json",
+      "description": "Adds one iteration close-out record under project-docs/iteration-retrospectives/, with a project-docs-ancestors frontmatter list and a free-text body describing what the pass did. Self-registers as terminal so a correctly-closed-out record is never reported as an orphan."
+    },
     "project-docs-lineage": {
       "factory": "./src/generators/project-docs-lineage/project-docs-lineage",
       "schema": "./src/generators/project-docs-lineage/schema.json",

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -11,8 +11,8 @@ entirely for a singular one (a type with exactly one file, directly under `proje
 subfolder) — e.g. `domain-terms:case` for a term, `architecture-overview` alone for a one-off doc.
 Only ever reference something that already exists — this is a backward reference, and deriving from
 a thing that doesn't exist yet isn't a real case. `nx g @abgov/nx-agent:domain-term`,
-`:bounded-context`, `:domain-model`, `:open-question`, and `:blocker` each resolve a
-`--project-docs-ancestors <path>` for you (from an existing artifact's path, not a hand-typed
+`:bounded-context`, `:domain-model`, `:open-question`, `:blocker`, and `:iteration-retrospective`
+each resolve a `--project-docs-ancestors <path>` for you (from an existing artifact's path, not a hand-typed
 `type:id` string) rather than requiring you to know the format; other artifact-producing generators
 should do the same. Run `nx g @abgov/nx-agent:project-docs-lineage` to build the full graph and catch
 a broken reference — not yet wired into the pre-commit hook, so run it yourself after adding or
@@ -23,7 +23,8 @@ human-readable, self-contained HTML report (status summary + a Mermaid lineage d
 **Open questions and blockers.** `nx g @abgov/nx-agent:open-question`/`:blocker` capture something
 undecided or something that needs revision as its own artifact, rather than leaving it in prose where
 it's easy to lose track of. They're resolved by a _different_ artifact — the one that actually settles
-it — passing `--resolves <path>` (on `domain-term`/`bounded-context`/`domain-model`), not by
+it — passing `--resolves <path>` (on `domain-term`/`bounded-context`/`domain-model`/
+`iteration-retrospective`), not by
 hand-editing the question/blocker file itself. `--resolves` is layered on top of
 `--project-docs-ancestors` (the resolved ref lands in both places), so it's still visible to normal
 lineage traversal; the distinct `resolves` field is what lets `project-docs-lineage` report a question

--- a/packages/nx-agent/src/generators/iteration-retrospective/README.template.md
+++ b/packages/nx-agent/src/generators/iteration-retrospective/README.template.md
@@ -1,0 +1,35 @@
+# Iteration retrospectives
+
+A close-out record for a single iteration's pass — what it did, what was found and fixed along the
+way, and an explicit status when "deployment succeeded" and "verified working end-to-end"
+diverge.{{SHARED_CONTEXT_NOTE}} One file per pass, so listing this folder (cheap — just filenames) is
+enough to see what's already been closed out.
+
+Not the same thing as a periodic, cross-iteration review that reads back across many of these to
+find drift a single pass can't see on its own — that's a separate, standing process a team runs on
+its own cadence. This folder holds the per-iteration records that process would read, not the
+process itself.
+
+Add one with `nx g @abgov/nx-agent:iteration-retrospective "<title>" --project-docs-ancestors <path>
+...` — don't hand-author files here, so the frontmatter shape stays consistent. Each file:
+
+    ---
+    title: Submit Minor Collision Report
+    project-docs-ancestors: [requirements:submit-minor-collision-report]
+    resolves: []
+    ---
+
+    Implemented the submit-minor-collision-report flow end to end. Revised
+    domain-models:collision-report-lifecycle with invariants 5-7 while doing so. Deployed and
+    verified working against a real sandbox.
+
+- `project-docs-ancestors` — every artifact this pass substantively created, revised, or touched —
+  not just the requirement it nominally closes out. Resolved from an existing artifact's path via
+  `--project-docs-ancestors <path>`, not typed by hand; name domain models and designs the pass
+  actually changed here too, not only the requirement.
+- `resolves` — any open-question/blocker this pass settled, via `--resolves <path>` on the same
+  invocation. Always present, empty if nothing was resolved.
+
+A correctly-closed-out retrospective has zero descendants forever — nothing is ever expected to
+build on a close-out record — so it's excluded from `project-docs-lineage`'s orphan report rather
+than flagged alongside a genuine dead-end.

--- a/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.spec.ts
+++ b/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.spec.ts
@@ -1,0 +1,217 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, addProjectConfiguration } from '@nx/devkit';
+import { readArtifactSchema } from '../../utils/artifact-schema';
+import generator from './iteration-retrospective';
+
+describe('nx-agent iteration-retrospective generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('creates the retrospective file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { title: 'Submit Minor Collision Report' });
+
+    const content = host
+      .read(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      )
+      .toString();
+    expect(content).toContain('title: Submit Minor Collision Report');
+    expect(content).toContain('project-docs-ancestors: []');
+    expect(content).toContain('resolves: []');
+  });
+
+  it('resolves --project-docs-ancestors paths into the canonical reference and writes them', async () => {
+    host.write(
+      'project-docs/requirements/submit-minor-collision-report.md',
+      ['---', 'name: Submit Minor Collision Report', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      title: 'Submit Minor Collision Report',
+      projectDocsAncestors: [
+        'project-docs/requirements/submit-minor-collision-report.md',
+      ],
+    });
+
+    const content = host
+      .read(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      )
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [requirements:submit-minor-collision-report]',
+    );
+  });
+
+  it('throws and makes no changes when a --project-docs-ancestors path does not resolve', async () => {
+    await expect(
+      generator(host, {
+        title: 'Submit Minor Collision Report',
+        projectDocsAncestors: ['project-docs/requirements/nope.md'],
+      }),
+    ).rejects.toThrow(/not found/);
+
+    expect(
+      host.exists(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      ),
+    ).toBe(false);
+    expect(host.exists('project-docs/iteration-retrospectives/README.md')).toBe(
+      false,
+    );
+  });
+
+  it('throws and makes no changes when the retrospective file already exists', async () => {
+    await generator(host, { title: 'Submit Minor Collision Report' });
+    const before = host
+      .read(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      )
+      .toString();
+
+    await expect(
+      generator(host, { title: 'Submit Minor Collision Report' }),
+    ).rejects.toThrow(/already exists/);
+
+    expect(
+      host
+        .read(
+          'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+        )
+        .toString(),
+    ).toBe(before);
+  });
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { title: 'Submit Minor Collision Report' });
+
+    const readme = host
+      .read('project-docs/iteration-retrospectives/README.md')
+      .toString();
+    expect(readme).toContain('# Iteration retrospectives');
+    expect(readme).toContain('nx g @abgov/nx-agent:iteration-retrospective');
+  });
+
+  it('scopes the retrospective file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      title: 'Submit Minor Collision Report',
+      project: 'domain-lib',
+    });
+
+    expect(
+      host.exists(
+        'libs/domain-lib/project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      ),
+    ).toBe(true);
+    expect(
+      host.exists(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      ),
+    ).toBe(false);
+  });
+
+  it('adds the shared-context note to the README only when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    });
+
+    await generator(host, {
+      title: 'Submit Minor Collision Report',
+      project: 'domain-lib',
+    });
+
+    const scopedReadme = host
+      .read('libs/domain-lib/project-docs/iteration-retrospectives/README.md')
+      .toString();
+    expect(scopedReadme).toContain(
+      'shared by every project that depends on this library',
+    );
+
+    await generator(host, { title: 'Second Pass' });
+
+    const rootReadme = host
+      .read('project-docs/iteration-retrospectives/README.md')
+      .toString();
+    expect(rootReadme).not.toContain(
+      'shared by every project that depends on this library',
+    );
+  });
+
+  it('registers its own artifact-schema entry as terminal, with no tracksResolution and no expected ancestor type', async () => {
+    await generator(host, { title: 'Submit Minor Collision Report' });
+
+    expect(readArtifactSchema(host)).toEqual({
+      'iteration-retrospectives': {
+        expectedAncestorTypes: [],
+        terminal: true,
+      },
+    });
+  });
+
+  it('--resolves writes the resolved ref into both project-docs-ancestors and resolves, and confirms it', async () => {
+    host.write(
+      'project-docs/blockers/no-write-packages-credential.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await generator(host, {
+      title: 'Submit Minor Collision Report',
+      resolves: ['project-docs/blockers/no-write-packages-credential.md'],
+    });
+
+    const content = host
+      .read(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      )
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [blockers:no-write-packages-credential]',
+    );
+    expect(content).toContain(
+      'resolves: [blockers:no-write-packages-credential]',
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      '✓ this iteration retrospective resolves blockers:no-write-packages-credential',
+    );
+    logSpy.mockRestore();
+  });
+
+  it('--resolves dedupes against an identical path already passed via --projectDocsAncestors', async () => {
+    host.write(
+      'project-docs/blockers/no-write-packages-credential.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+
+    await generator(host, {
+      title: 'Submit Minor Collision Report',
+      projectDocsAncestors: [
+        'project-docs/blockers/no-write-packages-credential.md',
+      ],
+      resolves: ['project-docs/blockers/no-write-packages-credential.md'],
+    });
+
+    const content = host
+      .read(
+        'project-docs/iteration-retrospectives/submit-minor-collision-report.md',
+      )
+      .toString();
+    expect(content).toContain(
+      'project-docs-ancestors: [blockers:no-write-packages-credential]',
+    );
+    expect(content).not.toContain(
+      'blockers:no-write-packages-credential, blockers:no-write-packages-credential',
+    );
+  });
+});

--- a/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
+++ b/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
@@ -1,0 +1,100 @@
+import {
+  Tree,
+  formatFiles,
+  joinPathFragments,
+  names,
+  readProjectConfiguration,
+} from '@nx/devkit';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
+import { ensureReadme } from '../../utils/readme';
+import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import { Schema } from './schema';
+
+const ITERATION_RETROSPECTIVES_SUBDIR = 'project-docs/iteration-retrospectives';
+const README_TEMPLATE_PATH = join(__dirname, 'README.template.md');
+
+function resolveTargetRoot(host: Tree, project?: string): string {
+  return project ? readProjectConfiguration(host, project).root : '.';
+}
+
+// The container has no standalone value on its own (its README only exists to
+// explain the convention for the retrospective about to be added), so this is
+// an internal step composed by iteration-retrospective rather than its own
+// generator.
+function ensureContainerReadme(
+  host: Tree,
+  containerDir: string,
+  scoped: boolean,
+): void {
+  const sharedNote = scoped
+    ? ' This is shared by every project that depends on this library — a pass against the shared code affects every consumer, not just the one that ran it.'
+    : '';
+  const content = readFileSync(README_TEMPLATE_PATH, 'utf-8')
+    .split('{{SHARED_CONTEXT_NOTE}}')
+    .join(sharedNote);
+  ensureReadme(host, containerDir, content);
+}
+
+export default async function (host: Tree, options: Schema) {
+  const targetRoot = resolveTargetRoot(host, options.project);
+  const containerDir = joinPathFragments(
+    targetRoot,
+    ITERATION_RETROSPECTIVES_SUBDIR,
+  );
+  const slug = names(options.title).fileName;
+  const retrospectivePath = joinPathFragments(containerDir, `${slug}.md`);
+
+  // A repeat/typo'd invocation should fail loudly rather than silently
+  // clobbering or duplicating a retrospective — same posture as domain-model.
+  // Checked before any write so a failing run has no side effects.
+  if (host.exists(retrospectivePath)) {
+    throw new Error(
+      `[nx-agent] ${retrospectivePath} already exists — edit it directly rather than regenerating it.`,
+    );
+  }
+
+  // Resolved (and, in doing so, validated) before any write — a path that
+  // doesn't resolve to an existing project-docs/ artifact throws here, same
+  // as the duplicate check above, so a failing run still has no side effects.
+  const { ancestors: projectDocsAncestors, resolvedRefs } =
+    resolveAncestorsAndResolves(
+      host,
+      options.projectDocsAncestors,
+      options.resolves,
+    );
+
+  ensureContainerReadme(host, containerDir, !!options.project);
+  // expectedAncestorTypes: [] deliberately unconstrained — an iteration's own
+  // coverage varies pass to pass by design, unlike domain-terms/domain-models
+  // which always expect the same fixed ancestor types. terminal: true is what
+  // keeps a correctly-closed-out retrospective (zero descendants by design)
+  // from being reported as an orphan alongside a genuine dead-end.
+  ensureArtifactSchemaEntry(
+    host,
+    'iteration-retrospectives',
+    [],
+    undefined,
+    true,
+  );
+
+  const content = [
+    '---',
+    `title: ${options.title}`,
+    `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
+    `resolves: [${resolvedRefs.join(', ')}]`,
+    '---',
+    '',
+    '<!-- Free-text body: what this pass did, what was found and fixed along the way, and an',
+    '     explicit status when "deployment succeeded" and "verified working end-to-end" diverge. -->',
+    '',
+  ].join('\n');
+  host.write(retrospectivePath, content);
+
+  for (const ref of resolvedRefs) {
+    console.log(`✓ this iteration retrospective resolves ${ref}`);
+  }
+
+  await formatFiles(host);
+}

--- a/packages/nx-agent/src/generators/iteration-retrospective/schema.d.ts
+++ b/packages/nx-agent/src/generators/iteration-retrospective/schema.d.ts
@@ -1,0 +1,6 @@
+export interface Schema {
+  title: string;
+  project?: string;
+  projectDocsAncestors?: string[];
+  resolves?: string[];
+}

--- a/packages/nx-agent/src/generators/iteration-retrospective/schema.json
+++ b/packages/nx-agent/src/generators/iteration-retrospective/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentIterationRetrospective",
+  "title": "Add an iteration retrospective",
+  "description": "Creates one close-out record for a single iteration under project-docs/iteration-retrospectives/, with a project-docs-ancestors frontmatter list and a free-text body describing what the pass did. Bootstraps the iteration-retrospectives/README.md convention doc on first use.",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "A short title for this iteration's pass (e.g. \"Submit Minor Collision Report\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What was this iteration's pass called?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this retrospective to a specific project's project-docs/iteration-retrospectives/ instead of the workspace root — prefer this whenever the iteration already has a natural code home; only use the workspace root when it genuinely doesn't have one."
+    },
+    "projectDocsAncestors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing project-docs/ artifacts this pass covered — every requirement, domain model, or design substantively created, revised, or touched this iteration, not just the requirement it nominally closes out. Each path must already exist; a backward reference only makes sense pointing at something already established."
+    },
+    "resolves": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing open-question/blocker artifacts this iteration resolved. Recorded distinctly from projectDocsAncestors (though also added there, so lineage traversal sees it as an ancestor too) so project-docs-lineage can report the resolution as such rather than mistaking any ancestor reference for one."
+    }
+  },
+  "required": ["title"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.spec.ts
@@ -29,7 +29,21 @@ describe('nx-agent project-docs-report generator', () => {
           expectedAncestorTypes: [],
           tracksResolution: true,
         },
+        'iteration-retrospectives': {
+          expectedAncestorTypes: [],
+          terminal: true,
+        },
       }),
+    );
+    host.write(
+      'project-docs/iteration-retrospectives/closed-out.md',
+      [
+        '---',
+        'title: Closed Out',
+        'project-docs-ancestors: []',
+        'resolves: []',
+        '---',
+      ].join('\n'),
     );
     host.write(
       'project-docs/open-questions/still-open.md',
@@ -85,6 +99,9 @@ describe('nx-agent project-docs-report generator', () => {
     expect(html).toContain(
       '<div class="count">1</div><div class="label">Open</div>',
     );
+    // domain-terms:unused is the only real orphan — iteration-retrospectives:
+    // closed-out has zero descendants too, but is terminal, so it must not
+    // inflate this count.
     expect(html).toContain(
       '<div class="count">1</div><div class="label">Orphaned</div>',
     );
@@ -106,6 +123,16 @@ describe('nx-agent project-docs-report generator', () => {
     expect(html).toContain('<pre class="mermaid">');
     expect(html).toContain('flowchart TD');
     expect(html).toContain('mermaid.initialize');
+
+    // a terminal artifact (zero descendants by design) gets its own distinct
+    // graph style and table badge, rather than looking like a plain orphan
+    expect(html).toContain(
+      '✓ iteration-retrospectives:closed-out&quot;]:::terminal',
+    );
+    expect(html).toContain(
+      '<span class="badge badge-terminal">Closed out</span>',
+    );
+    expect(html).toContain('Closed out (terminal)');
 
     // deterministic fallback, with its explicit note
     expect(html).toContain(

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
@@ -1,6 +1,9 @@
 import { Tree, joinPathFragments, readProjectConfiguration } from '@nx/devkit';
 import { readFileSync } from 'fs';
-import { readArtifactSchema } from '../../utils/artifact-schema';
+import {
+  ArtifactSchema,
+  readArtifactSchema,
+} from '../../utils/artifact-schema';
 import { ensureGitignoreEntries } from '../../utils/gitignore';
 import {
   Registry,
@@ -98,6 +101,7 @@ function buildStyles(): string {
     .badge-resolved { background: ${TOKENS.success.bg}; border: 1px solid ${TOKENS.success.border}; color: ${TOKENS.success.text}; }
     .badge-open { background: ${TOKENS.important.bg}; border: 1px solid ${TOKENS.important.border}; color: ${TOKENS.important.text}; }
     .badge-orphan { background: ${TOKENS.interactive.bg}; border: 1px solid ${TOKENS.interactive.border}; color: ${TOKENS.interactive.text}; }
+    .badge-terminal { background: ${TOKENS.background}; border: 1px solid ${TOKENS.textMuted}; color: ${TOKENS.textMuted}; }
     .legend { display: flex; gap: 1.25rem; flex-wrap: wrap; font-size: 0.875rem; color: ${TOKENS.textMuted}; margin-top: 0.75rem; }
     .legend-swatch { display: inline-block; width: 0.75rem; height: 0.75rem; border-radius: 3px; margin-right: 0.375rem; vertical-align: middle; }
     table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
@@ -106,6 +110,11 @@ function buildStyles(): string {
     .synthesis-note { color: ${TOKENS.textMuted}; font-size: 0.8125rem; font-style: italic; }
     .mermaid { text-align: center; }
   `;
+}
+
+function isTerminalKey(key: string, artifactSchema: ArtifactSchema): boolean {
+  const type = parseAncestorRef(key)?.type;
+  return !!type && !!artifactSchema[type]?.terminal;
 }
 
 function sanitizeLabel(label: string): string {
@@ -129,6 +138,7 @@ function buildMermaidFlowchart(
   resolvedKeys: Set<string>,
   openKeys: Set<string>,
   orphanKeys: Set<string>,
+  artifactSchema: ArtifactSchema,
 ): string {
   const nodeIds = new Map<string, string>();
   renderedKeys.forEach((key, i) => nodeIds.set(key, `n${i}`));
@@ -138,12 +148,14 @@ function buildMermaidFlowchart(
     `classDef resolved fill:${TOKENS.success.bg},stroke:${TOKENS.success.border},color:${TOKENS.success.text}`,
     `classDef open fill:${TOKENS.important.bg},stroke:${TOKENS.important.border},color:${TOKENS.important.text}`,
     `classDef orphan fill:${TOKENS.interactive.bg},stroke:${TOKENS.interactive.border},color:${TOKENS.interactive.text}`,
+    `classDef terminal fill:${TOKENS.background},stroke:${TOKENS.textMuted},color:${TOKENS.textMuted}`,
     `classDef context fill:${TOKENS.backgroundSubtle},stroke:${TOKENS.textMuted},color:${TOKENS.textMuted},stroke-dasharray: 4 4`,
   ];
 
   for (const key of renderedKeys) {
     const id = nodeIds.get(key);
     const isContext = !inScopeSet.has(key);
+    const isTerminal = isTerminalKey(key, artifactSchema);
     const cls = isContext
       ? 'context'
       : resolvedKeys.has(key)
@@ -152,8 +164,12 @@ function buildMermaidFlowchart(
           ? 'open'
           : orphanKeys.has(key)
             ? 'orphan'
-            : '';
-    lines.push(`  ${id}["${sanitizeLabel(key)}"]${cls ? `:::${cls}` : ''}`);
+            : isTerminal
+              ? 'terminal'
+              : '';
+    const label =
+      isTerminal && !isContext ? `✓ ${sanitizeLabel(key)}` : sanitizeLabel(key);
+    lines.push(`  ${id}["${label}"]${cls ? `:::${cls}` : ''}`);
   }
 
   const drawnEdges = new Set<string>();
@@ -254,6 +270,7 @@ function statusBadge(
   resolvedSet: Set<string>,
   openSet: Set<string>,
   orphanSet: Set<string>,
+  artifactSchema: ArtifactSchema,
 ): string {
   if (resolvedSet.has(key)) {
     return '<span class="badge badge-resolved">Resolved</span>';
@@ -264,6 +281,9 @@ function statusBadge(
   if (orphanSet.has(key)) {
     return '<span class="badge badge-orphan">Orphan</span>';
   }
+  if (isTerminalKey(key, artifactSchema)) {
+    return '<span class="badge badge-terminal">Closed out</span>';
+  }
   return '';
 }
 
@@ -273,6 +293,7 @@ function buildTable(
   resolvedSet: Set<string>,
   openSet: Set<string>,
   orphanSet: Set<string>,
+  artifactSchema: ArtifactSchema,
 ): string {
   const rows = [...inScopeKeys]
     .sort()
@@ -283,7 +304,7 @@ function buildTable(
         <td>${escapeHtml(key)}</td>
         <td>${escapeHtml(type)}</td>
         <td>${escapeHtml(entry?.ancestorRefs.join(', ') ?? '')}</td>
-        <td>${statusBadge(key, resolvedSet, openSet, orphanSet)}</td>
+        <td>${statusBadge(key, resolvedSet, openSet, orphanSet, artifactSchema)}</td>
       </tr>`;
     })
     .join('');
@@ -368,6 +389,7 @@ ${params.cardsHtml}
 <span><span class="legend-swatch" style="background:${TOKENS.success.bg};border:1px solid ${TOKENS.success.border}"></span>Resolved</span>
 <span><span class="legend-swatch" style="background:${TOKENS.important.bg};border:1px solid ${TOKENS.important.border}"></span>Open</span>
 <span><span class="legend-swatch" style="background:${TOKENS.interactive.bg};border:1px solid ${TOKENS.interactive.border}"></span>Orphaned</span>
+<span><span class="legend-swatch" style="background:${TOKENS.background};border:1px solid ${TOKENS.textMuted}"></span>Closed out (terminal)</span>
 <span><span class="legend-swatch" style="background:${TOKENS.backgroundSubtle};border:1px dashed ${TOKENS.textMuted}"></span>Context (out of scope)</span>
 </div>
 </section>
@@ -497,6 +519,7 @@ export default async function (host: Tree, options: Schema) {
     resolvedKeySet,
     openKeySet,
     orphanKeySet,
+    artifactSchema,
   );
 
   const html = buildHtml({
@@ -513,6 +536,7 @@ export default async function (host: Tree, options: Schema) {
       resolvedKeySet,
       openKeySet,
       orphanKeySet,
+      artifactSchema,
     ),
     brokenRefsHtml: buildBrokenRefsSection(inScopeBrokenRefs),
     flowchart,


### PR DESCRIPTION
## Summary
- Promotes `iteration-retrospectives` from a hand-authored `project-docs/` convention to a real generator (`nx g @abgov/nx-agent:iteration-retrospective`), per `NX-AGENT-ITERATION-RETROSPECTIVE-AND-DDD-LOOP-GENERATORS-PROPOSAL.md`'s Piece 1. Three independent instances (a Workflow-tool pass and two Copilot-CLI-driven passes) converged on the same frontmatter shape, clearing this workspace's usual two-independent-instances promotion bar.
- Structurally combines two existing patterns: `open-question`/`blocker`'s README-bootstrap/duplicate-check/project-scoping shape, plus `domain-model`'s `--resolves` handling (`iteration-retrospective` is a "closer" that can resolve prior open-questions/blockers, unlike `open-question`/`blocker` which have no `--resolves` at all).
- Self-registers its own `project-docs/artifact-schema.json` entry as `terminal: true` (no `tracksResolution`, unconstrained `expectedAncestorTypes`) — a correctly-closed-out retrospective has zero descendants by design, so `project-docs-lineage` never flags it as an orphan.
- Adds `## iteration-retrospective` sections to `packages/nx-agent/README.md` and `docs/nx-agent/nx-agent.md`, and lists the new generator alongside the others in the `conventions-and-consistency/project-docs-lineage.md` guidance file (both the `--project-docs-ancestors`-resolution list and the `--resolves`-capable list).

**Out of scope, left open**: the proposal's Piece 2 (`ddd-loop`, a workspace-setup generator scaffolding scripts proven in a different repo's branch) isn't implemented here — it needs the actual proven script content from that other repo, which this session doesn't have access to. The proposal doc stays at the repo root rather than moving to `resolved/` since only Piece 1 is done.

## Test plan
- [x] `npx nx test nx-agent` — 182/182 passing (10 new tests for the generator: base frontmatter, `--projectDocsAncestors` resolution/validation, duplicate-throw, README bootstrap, `--project` scoping + shared-context note, artifact-schema self-registration as terminal, `--resolves` writing to both fields + confirmation log, `--resolves`/`--projectDocsAncestors` dedup)
- [x] `npx nx lint,build nx-agent` — clean
- [x] End-to-end dogfood: ran the real `blocker` generator, then `iteration-retrospective` with `--resolves` pointing at it, then `project-docs-lineage` — confirmed the retrospective never appears in `orphans` and the blocker correctly appears in `resolutionStatus.resolved`