### PR TITLE
feat(nx-agent): make artifact content navigable from project-docs-report

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@angular/core": "21.2.17",
         "@nx/devkit": "23.0.1",
         "json-schema-to-typescript": "^13.0.1",
+        "marked": "~15.0.12",
         "mermaid": "~11.16.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -22846,7 +22847,6 @@
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@angular/core": "21.2.17",
     "@nx/devkit": "23.0.1",
     "json-schema-to-typescript": "^13.0.1",
+    "marked": "~15.0.12",
     "mermaid": "~11.16.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -497,6 +497,11 @@ with a "Closed out" badge and a `✓` in the graph) a `terminal`-typed artifact 
 `iteration-retrospective`, so a permanently-zero-descendant close-out reads as done rather than
 looking like an ordinary orphan.
 
+Each artifact's own markdown body — rendered to real HTML via [marked](https://marked.js.org/), not
+shown as raw source — is one click away: both its table row and its graph node link to an in-page
+detail panel (`#artifact-<key>`), shown via plain CSS `:target` rather than any script, so it stays
+part of the same single file.
+
 ### `--project` scoping
 
 `registry`/`index`/`violations` are always computed over the full workspace first, unconditionally —

--- a/packages/nx-agent/package.json
+++ b/packages/nx-agent/package.json
@@ -10,6 +10,7 @@
     "directory": "packages/nx-agent"
   },
   "dependencies": {
+    "marked": "~15.0.12",
     "mermaid": "~11.16.0",
     "yaml": "~2.9.0"
   },

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.spec.ts
@@ -139,6 +139,19 @@ describe('nx-agent project-docs-report generator', () => {
       'LLM synthesis unavailable in this environment — showing computed summary.',
     );
     expect(html).toContain('project-docs artifact(s) tracked');
+
+    // each artifact's own content is navigable in place: a table link and a
+    // graph click directive both point at the same anchor, which holds its
+    // markdown body rendered to real HTML (not raw markdown source)
+    expect(html).toContain(
+      '<td><a href="#artifact-open-questions-still-open">open-questions:still-open</a></td>',
+    );
+    expect(html).toMatch(
+      /click n\d+ &quot;#artifact-open-questions-still-open&quot; &quot;View content&quot;/,
+    );
+    expect(html).toContain('<div id="artifact-open-questions-still-open"');
+    // rendered from markdown to a real <p>, not dumped as raw source text
+    expect(html).toContain('<p>Why this is still undecided.</p>');
   });
 
   it('is excluded from version control via the resolved output path', async () => {
@@ -205,17 +218,19 @@ describe('nx-agent project-docs-report generator', () => {
       await generator(host, { project: 'billing', noSynthesis: true });
       const html = host.read('apps/billing/project-docs/report.html', 'utf-8');
 
-      // in-scope artifact: full table row (its own key as the row's first
-      // cell) + graph node
+      // in-scope artifact: full table row (its own key, linked to its detail
+      // anchor, as the row's first cell) + graph node
       expect(html).toContain(
-        '<tr>\n        <td>billing/bounded-contexts:invoicing</td>',
+        '<tr>\n        <td><a href="#artifact-billing-bounded-contexts-invoicing">billing/bounded-contexts:invoicing</a></td>',
       );
 
       // workspace-level ancestor: graph node (context) + listed as an
       // ancestor in invoicing's own row, but never its own table row. The
       // flowchart text is HTML-escaped when embedded, so `"` -> `&quot;`.
       expect(html).toContain('n1[&quot;domain-terms:money&quot;]:::context');
-      expect(html).not.toContain('<tr>\n        <td>domain-terms:money</td>');
+      expect(html).not.toContain(
+        '<td><a href="#artifact-domain-terms-money">domain-terms:money</a></td>',
+      );
 
       // a different project's unrelated artifact appears nowhere at all
       expect(html).not.toContain('shipping/domain-terms:shipment');

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
@@ -1,5 +1,6 @@
 import { Tree, joinPathFragments, readProjectConfiguration } from '@nx/devkit';
 import { readFileSync } from 'fs';
+import { marked } from 'marked';
 import {
   ArtifactSchema,
   readArtifactSchema,
@@ -36,6 +37,13 @@ function escapeHtml(value: string): string {
 
 function stripFrontmatter(content: string): string {
   return content.replace(/^---\n[\s\S]*?\n---\n?/, '').trim();
+}
+
+// A registry key's own format (<project>/type:id) is already constrained in
+// practice, but this is the one place it becomes an HTML id/URL fragment, so
+// swap anything outside that safe set defensively rather than assume.
+function toAnchorId(key: string): string {
+  return `artifact-${key.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
 }
 
 // Curated, hand-copied subset of @abgov/design-tokens@2.12.0's dist/tokens.css
@@ -109,6 +117,20 @@ function buildStyles(): string {
     th { color: ${TOKENS.textMuted}; font-weight: 600; }
     .synthesis-note { color: ${TOKENS.textMuted}; font-size: 0.8125rem; font-style: italic; }
     .mermaid { text-align: center; }
+    .detail {
+      display: none;
+      background: ${TOKENS.background};
+      border: 1px solid ${TOKENS.interactive.border};
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+      max-width: 960px;
+    }
+    .detail:target { display: block; }
+    .detail h3 { margin-top: 0; color: ${TOKENS.brand}; }
+    .detail-close { float: right; font-size: 0.875rem; font-weight: 400; }
+    .detail-path { color: ${TOKENS.textMuted}; font-size: 0.8125rem; }
+    .detail-body :first-child { margin-top: 0; }
   `;
 }
 
@@ -170,6 +192,15 @@ function buildMermaidFlowchart(
     const label =
       isTerminal && !isContext ? `✓ ${sanitizeLabel(key)}` : sanitizeLabel(key);
     lines.push(`  ${id}["${label}"]${cls ? `:::${cls}` : ''}`);
+  }
+
+  // Every rendered node (including context ones) gets a detail section
+  // built below, so every node can link there — clicking navigates to the
+  // artifact's own content in place, no dangling links.
+  for (const key of renderedKeys) {
+    lines.push(
+      `  click ${nodeIds.get(key)} "#${toAnchorId(key)}" "View content"`,
+    );
   }
 
   const drawnEdges = new Set<string>();
@@ -301,7 +332,7 @@ function buildTable(
       const entry = registry.get(key);
       const type = parseAncestorRef(key)?.type ?? '';
       return `<tr>
-        <td>${escapeHtml(key)}</td>
+        <td><a href="#${toAnchorId(key)}">${escapeHtml(key)}</a></td>
         <td>${escapeHtml(type)}</td>
         <td>${escapeHtml(entry?.ancestorRefs.join(', ') ?? '')}</td>
         <td>${statusBadge(key, resolvedSet, openSet, orphanSet, artifactSchema)}</td>
@@ -325,6 +356,38 @@ function buildBrokenRefsSection(brokenRefs: Violations['brokenRefs']): string {
     )
     .join('');
   return `<h2>Broken references</h2><ul>${items}</ul>`;
+}
+
+// One hidden <div> per rendered node (in-scope + context, matching the
+// graph), each targetable by the `click`/table-link anchors above.
+// `:target` — not JS — toggles visibility: navigating to #artifact-<id>
+// both scrolls to and reveals that one div, and only ever matches one at a
+// time, so this needs nothing beyond plain CSS to behave like a "page" for
+// each artifact while staying inside the one self-contained HTML file.
+function buildArtifactDetails(
+  host: Tree,
+  renderedKeys: string[],
+  registry: Registry,
+): string {
+  const sections = renderedKeys
+    .map((key) => {
+      const entry = registry.get(key);
+      if (!entry) {
+        return '';
+      }
+      const content = host.read(entry.path, 'utf-8') ?? '';
+      const body = stripFrontmatter(content);
+      const bodyHtml = body
+        ? marked.parse(body, { async: false })
+        : '<p><em>No content.</em></p>';
+      return `<div id="${toAnchorId(key)}" class="detail">
+        <h3>${escapeHtml(key)} <a href="#top" class="detail-close">Close ✕</a></h3>
+        <p class="detail-path"><code>${escapeHtml(entry.path)}</code></p>
+        <div class="detail-body">${bodyHtml}</div>
+      </div>`;
+    })
+    .join('\n');
+  return `<section id="artifact-detail-panel">${sections}</section>`;
 }
 
 // The bundled browser build, inlined directly rather than referenced by a
@@ -352,6 +415,7 @@ function buildHtml(params: {
   cardsHtml: string;
   tableHtml: string;
   brokenRefsHtml: string;
+  detailsHtml: string;
   flowchart: string;
   mermaidBundle: string;
 }): string {
@@ -368,7 +432,7 @@ function buildHtml(params: {
 <style>${buildStyles()}</style>
 </head>
 <body>
-<h1>${escapeHtml(params.title)}</h1>
+<h1 id="top">${escapeHtml(params.title)}</h1>
 <p class="generated-at">Generated ${escapeHtml(params.generatedAt)}</p>
 
 <section>
@@ -396,14 +460,18 @@ ${params.cardsHtml}
 
 <section>
 <h2>Artifacts</h2>
+<p>Click a key below, or a node in the graph above, to view its content in place.</p>
 ${params.tableHtml}
 ${params.brokenRefsHtml}
 </section>
+
+${params.detailsHtml}
 
 <script>${params.mermaidBundle}</script>
 <script>
 mermaid.initialize({
   startOnLoad: false,
+  securityLevel: 'loose',
   theme: 'base',
   themeVariables: {
     primaryColor: '${TOKENS.interactive.bg}',
@@ -539,6 +607,7 @@ export default async function (host: Tree, options: Schema) {
       artifactSchema,
     ),
     brokenRefsHtml: buildBrokenRefsSection(inScopeBrokenRefs),
+    detailsHtml: buildArtifactDetails(host, renderedKeys, registry),
     flowchart,
     mermaidBundle: readMermaidBundle(),
   });


### PR DESCRIPTION
## Summary
- Follows up on #372 (already merged). The synthesis step already reads each open/orphaned artifact's raw body to give the LLM something to narrate, but the report itself only ever showed keys/status/ancestor-refs — never the content behind them.
- Adds an in-page detail panel per rendered artifact: its markdown body, rendered to real HTML via [`marked`](https://marked.js.org/) (MIT, zero runtime deps) rather than shown as raw source, linked from both the table (key) and the graph (a `click` directive on each node).
- Uses plain CSS `:target` for the reveal — no client JS — so the report stays a single, self-contained file, matching this generator's existing design constraint.
- `marked` is pinned to `~15.0.12` rather than latest (18.x): that's the version already resolved for `semantic-release`'s `marked-terminal` dependency (which requires `<16`), so this reuses it instead of introducing a hoisting conflict in `package-lock.json` (confirmed via `npm ls marked` before/after).

## Test plan
- [x] `npx nx test nx-agent` — 182/182 passing, including new assertions for the table link, graph `click` directive, and rendered (not raw) markdown body
- [x] `npx nx lint,build nx-agent` — clean
- [x] Real end-to-end dogfood: ran the actual `domain-term`/`blocker`/`iteration-retrospective`/`project-docs-report` generators (not just the mocked spec tree) and wrote a real `report.html` to disk; mechanically verified every table link, every graph `click` target, and every detail-panel `id` line up with no missing or duplicate anchors across all three artifact types; opened the file in a browser to visually confirm