### PR TITLE
fix(nx-adsp): bring GoA design-system deps current across frontend generators

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -47,6 +47,19 @@ describe('angular app generator', () => {
     expect(appTree.exists('apps/test/nginx.conf')).toBeTruthy();
   }, 120000);
 
+  it('renders the sign-in button in the app header (needs the "utilities" slot)', async () => {
+    // goab-app-header (v2) only renders content placed in a named slot — GoA's
+    // own design system docs put account/sign-in actions in "utilities" (vs.
+    // "navigation" for nav links). A bare child with no slot attribute
+    // renders nothing, silently dropping the sign-in button. Regression
+    // guard for exactly that gap.
+    await angularApp(appTree, options);
+    const appHtml = appTree
+      .read('apps/test/src/app/app.component.html')
+      .toString();
+    expect(appHtml).toMatch(/<div slot="utilities">[\s\S]*<goab-button-group/);
+  }, 120000);
+
   it("runs nx-adsp's own workspace-root setup (ADSP SDK MCP server + VS Code settings)", async () => {
     await angularApp(appTree, options);
 

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -140,7 +140,7 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
     host,
     {
       '@abgov/angular-components': '5.3.0',
-      '@abgov/design-tokens': '2.9.0',
+      '@abgov/design-tokens': '2.12.0',
       // Pin exact (not ^2.0.0): angular-components 5.3.0 imports symbols added in
       // ui-components-common 2.3.0 (e.g. GoabWorkspaceLayoutScrollState), so a
       // lower 2.x resolves and fails the build. Keep this in lockstep with the

--- a/packages/nx-adsp/src/generators/angular-app/files/src/app/app.component.html__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/src/app/app.component.html__tmpl__
@@ -1,14 +1,20 @@
 <div class="app">
   <goab-microsite-header type="alpha"></goab-microsite-header>
   <goab-app-header url="/" heading="<%= projectName %>">
-    <goab-button-group alignment="end">
-      @if (userName) { <span>{{ userName }}</span> }
-      @if (!isLoggedIn) {
-        <goab-button type="tertiary" (onClick)="login()">Sign in</goab-button>
-      } @else {
-        <goab-button type="tertiary" (onClick)="logout()">Sign out</goab-button>
-      }
-    </goab-button-group>
+    <!-- goab-app-header only renders content placed in a named slot — the
+         "utilities" slot is where GoA's own design system docs put
+         account/sign-in actions (as opposed to "navigation" for nav links).
+         A bare child with no slot attribute renders nothing. -->
+    <div slot="utilities">
+      <goab-button-group alignment="end">
+        @if (userName) { <span>{{ userName }}</span> }
+        @if (!isLoggedIn) {
+          <goab-button type="tertiary" (onClick)="login()">Sign in</goab-button>
+        } @else {
+          <goab-button type="tertiary" (onClick)="logout()">Sign out</goab-button>
+        }
+      </goab-button-group>
+    </div>
   </goab-app-header>
   <goab-hero-banner #heroBanner heading="<%= projectName %>"></goab-hero-banner>
   <main>

--- a/packages/nx-adsp/src/generators/angular-app/files/src/index.html__tmpl__
+++ b/packages/nx-adsp/src/generators/angular-app/files/src/index.html__tmpl__
@@ -6,8 +6,8 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.esm.js"></script>
-    <script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@latest/dist/ionicons/ionicons.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/ionicons@8.1.0/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule src="https://cdn.jsdelivr.net/npm/ionicons@8.1.0/dist/ionicons/ionicons.js"></script>
   </head>
   <body>
     <<%= projectName %>-root></<%= projectName %>-root>

--- a/packages/nx-adsp/src/generators/react-app/files/src/app/app.tsx__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/src/app/app.tsx__tmpl__
@@ -35,18 +35,24 @@ export function App() {
     <div className={styles.app}>
       <GoabMicrositeHeader type="alpha" />
       <GoabAppHeader url="/" heading="<%= projectName %>">
-        <GoabButtonGroup alignment="end">
-          {name && <span>{name}</span>}
-          {!authenticated ? (
-            <GoabButton type="tertiary" onClick={() => dispatch(loginUser())}>
-              Sign in
-            </GoabButton>
-          ) : (
-            <GoabButton type="tertiary" onClick={() => dispatch(logoutUser())}>
-              Sign out
-            </GoabButton>
-          )}
-        </GoabButtonGroup>
+        {/* GoabAppHeader only renders content placed in a named slot — the
+            "utilities" slot is where GoA's own design system docs put
+            account/sign-in actions (as opposed to "navigation" for nav
+            links). A bare child with no slot attribute renders nothing. */}
+        <div slot="utilities">
+          <GoabButtonGroup alignment="end">
+            {name && <span>{name}</span>}
+            {!authenticated ? (
+              <GoabButton type="tertiary" onClick={() => dispatch(loginUser())}>
+                Sign in
+              </GoabButton>
+            ) : (
+              <GoabButton type="tertiary" onClick={() => dispatch(logoutUser())}>
+                Sign out
+              </GoabButton>
+            )}
+          </GoabButtonGroup>
+        </div>
       </GoabAppHeader>
       <GoabHeroBanner heading="<%= projectName %>" backgroundUrl="/assets/banner.jpg" />
       <main>

--- a/packages/nx-adsp/src/generators/react-app/files/src/index.html__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/src/index.html__tmpl__
@@ -10,11 +10,11 @@
 
     <script
       type="module"
-      src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"
+      src="https://unpkg.com/ionicons@8.1.0/dist/ionicons/ionicons.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"
+      src="https://unpkg.com/ionicons@8.1.0/dist/ionicons/ionicons.js"
     ></script>
   </head>
   <body>

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -49,6 +49,19 @@ describe('React App Generator', () => {
     expect(mainTsx).toContain("import '@abgov/web-components/index.css';");
   }, 30000);
 
+  it('renders the sign-in button in the app header (needs the "utilities" slot)', async () => {
+    // GoabAppHeader (v2) only renders content placed in a named slot — GoA's
+    // own design system docs put account/sign-in actions in "utilities" (vs.
+    // "navigation" for nav links). A bare child with no slot attribute
+    // renders nothing, silently dropping the sign-in button. Regression
+    // guard for exactly that gap.
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+
+    const appTsx = host.read('apps/test/src/app/app.tsx').toString();
+    expect(appTsx).toMatch(/<div slot="utilities">[\s\S]*<GoabButtonGroup/);
+  }, 30000);
+
   it("runs nx-adsp's own workspace-root setup (ADSP SDK MCP server + VS Code settings)", async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, options);

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -150,7 +150,7 @@ export default async function (host: Tree, options: Schema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/design-tokens': '2.9.0',
+      '@abgov/design-tokens': '2.12.0',
       '@abgov/react-components': '7.3.0',
       '@abgov/web-components': '2.3.0',
       '@reduxjs/toolkit': '^2.5.1',

--- a/packages/nx-adsp/src/generators/vue-app/files/index.html__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/index.html__tmpl__
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <script
       type="module"
-      src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"
+      src="https://unpkg.com/ionicons@8.1.0/dist/ionicons/ionicons.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"
+      src="https://unpkg.com/ionicons@8.1.0/dist/ionicons/ionicons.js"
     ></script>
   </head>
   <body>

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -24,18 +24,24 @@ function logout() { kc.keycloak?.logout({ redirectUri: window.location.origin })
 <template>
   <goa-microsite-header type="alpha" />
   <goa-app-header url="/" heading="<%= projectName %>">
-    <goa-button-group alignment="end">
-      <span v-if="kc.authenticated && kc.fullName">{{ kc.fullName }}</span>
-      <!-- Gate on !authenticated only, never on `ready`: with no load-time SSO
-           check, `ready` flips true immediately but stays informational — the
-           sign-in affordance must always show until the user is authenticated. -->
-      <goa-button v-if="!kc.authenticated" type="tertiary" @_click="login">
-        Sign in
-      </goa-button>
-      <goa-button v-if="kc.authenticated" type="tertiary" @_click="logout">
-        Sign out
-      </goa-button>
-    </goa-button-group>
+    <!-- goa-app-header only renders content placed in a named slot — the
+         "utilities" slot is where GoA's own design system docs put
+         account/sign-in actions (as opposed to "navigation" for nav links).
+         A bare child with no slot attribute renders nothing. -->
+    <div slot="utilities">
+      <goa-button-group alignment="end">
+        <span v-if="kc.authenticated && kc.fullName">{{ kc.fullName }}</span>
+        <!-- Gate on !authenticated only, never on `ready`: with no load-time SSO
+             check, `ready` flips true immediately but stays informational — the
+             sign-in affordance must always show until the user is authenticated. -->
+        <goa-button v-if="!kc.authenticated" type="tertiary" @_click="login">
+          Sign in
+        </goa-button>
+        <goa-button v-if="kc.authenticated" type="tertiary" @_click="logout">
+          Sign out
+        </goa-button>
+      </goa-button-group>
+    </div>
   </goa-app-header>
   <goa-hero-banner heading="<%= projectName %>" backgroundurl="/assets/banner.jpg" />
   <AppLayout :variant="layout">

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -247,6 +247,17 @@ describe('Vue App Generator', () => {
     expect(app).toContain('goa-button-group');
   }, 30000);
 
+  it('renders the sign-in button in the app header (needs the "utilities" slot)', async () => {
+    // goa-app-header (v2) only renders content placed in a named slot — GoA's
+    // own design system docs put account/sign-in actions in "utilities" (vs.
+    // "navigation" for nav links). A bare child with no slot attribute
+    // renders nothing, silently dropping the sign-in button. Regression
+    // guard for exactly that gap.
+    await generator(host, options);
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).toMatch(/<div slot="utilities">[\s\S]*<goa-button-group/);
+  }, 30000);
+
   it('removes the @nx/vue demo scaffold and ships a passing App test', async () => {
     await generator(host, options);
     // The stale nx demo + its failing test must be gone (they fail against our shell).

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -132,13 +132,17 @@ export default async function (host: Tree, options: Schema) {
 
   // Ensure the shared GoA wrapper library exists (idempotent — created once per
   // workspace, refreshed on later runs). Apps import it instead of each carrying
-  // their own copy, so it's one place to swap for @abgov/vue-components later.
+  // their own copy. This stays the long-term approach, not a stopgap: the
+  // published @abgov/vue-components package (checked directly) is an abandoned
+  // Vue 2 relic from 2021 across every dist-tag (latest/next/alpha/beta) — not a
+  // real current alternative — and GoA's own design-system docs don't list Vue
+  // as a supported framework at all.
   await vueComponentsGenerator(host);
 
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/design-tokens': '2.9.0',
+      '@abgov/design-tokens': '2.12.0',
       '@abgov/web-components': '2.3.0',
       // keycloak-js is a transitive dependency of @dsb-norge/vue-keycloak-js;
       // don't pin it directly or the versions diverge into two copies.


### PR DESCRIPTION
## Summary

**The real fix (found via live dogfooding):** the sign-in button was silently missing from the app header in all three frontend generators. `GoabAppHeader`/`goa-app-header`/`goab-app-header` (v2) only renders content placed in a named slot — GoA's own design system docs put account/sign-in actions in the `"utilities"` slot (as opposed to `"navigation"` for nav links). All three generators put the sign-in `ButtonGroup` as a bare child with no `slot` attribute, so it rendered nowhere — not broken/unstyled, just entirely absent. This predates this branch; it's a leftover from the original v1→v2 GoA bump (`23f4607`), not something the version bumps below introduced. Fixed by wrapping each header's `ButtonGroup` in `<div slot="utilities">`, verified live in a browser (regenerated the app, restarted the dev server, watched the button actually appear).

**The version-currency work this branch started with:**
- `@abgov/design-tokens` was pinned `2.9.0` (three minors behind latest `2.12.0`) in react-app/vue-app/angular-app. Confirmed safe before bumping: diffed the two published `tokens.css` files directly — zero custom properties removed, only 46 added.
- react-app/vue-app pinned `ionicons@5.5.2` (three majors behind current `8.1.0`); angular-app floated `ionicons@latest` (unpinned). Checked what icon names `@abgov/web-components` references internally — `chevron-expand` is used by a component but doesn't exist at all in ionicons 5.5.2. Bumped react-app/vue-app to `8.1.0`, pinned angular-app to the same exact version.
- Corrected a stale comment in `vue-app.ts` suggesting `@abgov/vue-components` as a future replacement for the interim hand-rolled Vue wrapper library — that npm package's every dist-tag is Vue 2 only, with real content dating to 2021. A dead end, not a future path.
- `@abgov/web-components`/`@abgov/react-components`/`@abgov/angular-components`/`@abgov/ui-components-common` were all already current.

**Found but out of scope, flagging separately**: angular-app's `keycloak-angular@^19.0.2` peers on `@angular/common@^19`, but the template pins Angular `~21.2.0` — a pre-existing, unrelated peer conflict that fails a plain `npm install` (needs `--legacy-peer-deps`).

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — all green (93 tests, 3 new regression tests for the slot fix)
- [x] Generated real react-app/vue-app/angular-app instances (mocking `getAdspConfiguration`, matching each generator's own test convention) and installed dependencies for all three
- [x] react-app and vue-app: served both live, confirmed 200 responses, `ionicons@8.1.0` resolving from the CDN, and — after the slot fix — the Sign in button actually rendering in the header
- [x] angular-app: production build succeeds cleanly (only pre-existing, unrelated `keycloak-js` CJS-interop warnings)