### PR TITLE
fix(nx-adsp): bump drizzle-orm past a high-severity SQL injection CVE

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -124,8 +124,12 @@ export default async function (host: Tree, options: Schema) {
       passport: '^0.7.0',
       'passport-anonymous': '^1.0.1',
       zod: '^3.0.0',
+      // ^0.45.2, not ^0.44.0: CVE-2026-39356 (GHSA-gpj5-g38j-94v9, high) — sql.identifier()/.as()
+      // didn't escape embedded quote delimiters before 0.45.2, allowing SQL injection through
+      // identifier/alias construction built from untrusted input. Fixed upstream in 0.45.2; every
+      // 0.44.x release is affected (0.x caret ranges don't cross the minor).
       ...(normalizedOptions.database === 'postgres'
-        ? { 'drizzle-orm': '^0.44.0', pg: '^8.11.0' }
+        ? { 'drizzle-orm': '^0.45.2', pg: '^8.11.0' }
         : {}),
       ...(normalizedOptions.database === 'mongo' ? { mongoose: '^8.0.0' } : {}),
     },


### PR DESCRIPTION
## Summary
- `express-service`'s `--database postgres` template pinned `drizzle-orm ^0.44.0`, which is entirely inside the vulnerable range for **CVE-2026-39356** ([GHSA-gpj5-g38j-94v9](https://github.com/advisories/GHSA-gpj5-g38j-94v9), CVSS 7.5, high): `sql.identifier()`/`.as()` didn't escape embedded quote delimiters before 0.45.2, letting untrusted input used in identifier/alias construction (e.g. dynamic sort columns) break out of the quotes and inject SQL.
- `0.x` caret ranges don't cross the minor, so no `^0.44.x` release ever picks up the fix — confirmed via a real `npm audit` against the exact pinned range. Bumped to `^0.45.2`.
- Checked the 0.45.0/0.45.1/0.45.2 changelogs directly before bumping: bug fixes and additions only (subquery support, `Date`-handling fixes, pg-native detection), nothing that touches APIs this template's generated code uses.
- Our own generated `database.ts`/`schema.ts` templates don't call `sql.identifier()`/`.as()` themselves, so this isn't currently exploitable as-shipped — but that's exactly the kind of API a consuming team adds later (dynamic sorting, report builders), so the dependency itself should ship patched regardless.

**Found but out of scope, flagging separately**: `drizzle-kit` (dev dependency, `^0.31.0`) transitively pulls in a moderate esbuild advisory ([GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99)) via `@esbuild-kit/esm-loader`, present in *every* `0.31.x` release including latest (`0.31.10`). This is a real local-dev risk — the generated `db:studio` target runs `drizzle-kit studio`, which starts an actual dev server the advisory targets. No stable release fixes this: the fix (dropping `@esbuild-kit` for `jiti`) only exists in the still-unstable `1.0.0-rc` line. Not bumping to a pre-release here — wanted to raise it rather than silently leave it unmentioned.

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — all green
- [x] Generated a real `express-service` with `--database postgres` (mocking `getAdspConfiguration`, matching the generator's own test convention), installed dependencies
- [x] Ran `npm audit` against the real installed tree — confirmed the drizzle-orm finding is gone after the bump
- [x] Confirmed the generated service still builds cleanly with webpack