### PR TITLE
fix(nx-adsp): bump react-router-dom past an open-redirect CVE

### DIFF
--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -156,7 +156,14 @@ export default async function (host: Tree, options: Schema) {
       '@reduxjs/toolkit': '^2.5.1',
       'keycloak-js': '^23.0.7',
       'react-redux': '^9.2.0',
-      'react-router-dom': '6.30.3',
+      // 6.30.4, not 6.30.3: GHSA-2j2x-hqr9-3h42 (moderate) — a same-origin
+      // redirect whose path starts with "//" was reinterpreted as a
+      // protocol-relative URL, causing an open redirect. Fixed in 6.30.4,
+      // the last 6.x release. Two other advisories affecting this line
+      // (GHSA-jjmj-jmhj-qwj2, GHSA-wrjc-x8rr-h8h6) have no 6.x fix at all —
+      // only React Router v7 (a breaking migration: v7 merges
+      // react-router-dom into react-router and changes several APIs).
+      'react-router-dom': '6.30.4',
     },
     {
       '@axe-core/playwright': '^4.12.1',


### PR DESCRIPTION
## Summary
- react-app's exact pin (`6.30.3`) was inside the vulnerable range for **GHSA-2j2x-hqr9-3h42** (moderate): a same-origin redirect whose path started with `//` was reinterpreted as a protocol-relative URL, causing an open redirect. Fixed in `6.30.4`, the last release on the 6.x line. Bumped to `6.30.4`.
- Found via the same audit sweep as #375 (this repo's other open CVE-fix PR). Two other advisories flagged against this dependency — **GHSA-jjmj-jmhj-qwj2** (open redirect → XSS, CVSS 6.9) and **GHSA-wrjc-x8rr-h8h6** (backslash bypass) — were checked directly against their own first-patched-version data: neither has a fix on the 6.x line at all, only React Router v7 (a breaking migration — v7 merges `react-router-dom` into `react-router` and changes several APIs). Not pursued here; this PR is just the safe, non-breaking part.

**Found in the same sweep, not actionable from this repo**: `@abgov/adsp-service-sdk` (pinned `^2.23.0`, resolving to the actual latest published `2.24.0`) transitively pins several vulnerable `@opentelemetry/*` packages (one high, several moderate). Confirmed the latest published SDK version still carries these — there's no newer release to bump to. This is an upstream issue in GoA's own SDK, not something fixable by changing our version pin.

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — all green
- [x] Generated a real react-app, installed dependencies, ran `npm audit` — confirmed both 6.x-fixable findings (`2j2x`, and their overlap) are gone, only the v7-only one (`wrjc`) remains as expected
- [x] Confirmed the generated app still builds cleanly