### PR TITLE
feat(nx-adsp): derive frontend proxy config and sandbox tag from --pairedProject

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -212,14 +212,20 @@ Creates a React/Redux frontend application configured for ADSP. Requires `@nx/re
 npx nx g @abgov/nx-adsp:react-app my-app --env dev --tenant my-tenant
 ```
 
-| Option        | Alias | Required | Description                                                                    |
-| ------------- | ----- | -------- | ------------------------------------------------------------------------------ |
-| `name`        | —     | Yes      | Name of the application                                                        |
-| `env`         | `-e`  | Yes      | ADSP environment: `dev`, `test`, or `prod`                                     |
-| `tenant`      | `-t`  | No       | ADSP tenant name; looks up the Keycloak realm and opens a single browser login |
-| `tenantRealm` | `-tr` | No       | Keycloak realm UUID; overrides the realm resolved from `--tenant`              |
-| `accessToken` | `-at` | No       | Access token for non-interactive retrieval of ADSP configuration               |
-| `proxy`       | —     | No       | Nginx proxy rule(s): `{ location, proxyPass }` or an array of such objects     |
+| Option          | Alias | Required | Description                                                                                                                                                                    |
+| --------------- | ----- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`          | —     | Yes      | Name of the application                                                                                                                                                        |
+| `env`           | `-e`  | Yes      | ADSP environment: `dev`, `test`, or `prod`                                                                                                                                     |
+| `tenant`        | `-t`  | No       | ADSP tenant name; looks up the Keycloak realm and opens a single browser login                                                                                                 |
+| `tenantRealm`   | `-tr` | No       | Keycloak realm UUID; overrides the realm resolved from `--tenant`                                                                                                              |
+| `accessToken`   | `-at` | No       | Access token for non-interactive retrieval of ADSP configuration                                                                                                               |
+| `pairedProject` | —     | No       | Name of an existing backend service project to derive the nginx/dev-server proxy and the `adsp:proxy-service:` sandbox tag from automatically — the project must already exist |
+| `proxy`         | —     | No       | Nginx proxy rule(s): `{ location, proxyPass }` or an array of such objects — additional entries `--pairedProject` doesn't cover; can't duplicate its location                  |
+
+Running this generator standalone against a backend that's already scaffolded? Pass
+`--pairedProject <backend-project-name>` instead of hand-computing `--proxy` — it derives the same
+`http://<name>:3333/<name>/` convention `mern`/`mean`/`pern`/`pean`/`pevn`/`mevn` already use
+internally, plus the tag `@abgov/nx-oc:sandbox` needs to pre-create the backend's Service.
 
 The generated Playwright e2e project includes an axe-core accessibility check (`a11y.spec.ts`),
 scoped to WCAG 2.1 A/AA, that runs automatically as part of the `e2e` target — no separate command

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -152,14 +152,20 @@ Creates a React/Redux frontend application configured for ADSP. Requires `@nx/re
 npx nx g @abgov/nx-adsp:react-app my-app --env dev --tenant my-tenant
 ```
 
-| Option        | Alias | Required | Description                                                                                                                                                                        |
-| ------------- | ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`        | —     | Yes      | Name of the application                                                                                                                                                            |
-| `env`         | `-e`  | No       | ADSP environment / access service. Defaults to `test` = access-uat.alberta.ca (UAT — use for dev and pre-prod); `prod` = access.alberta.ca; `dev` = ADSP platform dev (restricted) |
-| `tenant`      | `-t`  | No       | ADSP tenant name; resolves the Keycloak realm by name (sign in once with `@abgov/adsp-cli` — see Authentication)                                                                   |
-| `tenantRealm` | `-tr` | No       | Keycloak realm UUID; overrides the realm resolved from `--tenant`                                                                                                                  |
-| `accessToken` | `-at` | No       | Access token for non-interactive retrieval of ADSP configuration                                                                                                                   |
-| `proxy`       | —     | No       | Nginx proxy rule(s) as `{ location, proxyPass }` or an array of such objects                                                                                                       |
+| Option          | Alias | Required | Description                                                                                                                                                                        |
+| --------------- | ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`          | —     | Yes      | Name of the application                                                                                                                                                            |
+| `env`           | `-e`  | No       | ADSP environment / access service. Defaults to `test` = access-uat.alberta.ca (UAT — use for dev and pre-prod); `prod` = access.alberta.ca; `dev` = ADSP platform dev (restricted) |
+| `tenant`        | `-t`  | No       | ADSP tenant name; resolves the Keycloak realm by name (sign in once with `@abgov/adsp-cli` — see Authentication)                                                                   |
+| `tenantRealm`   | `-tr` | No       | Keycloak realm UUID; overrides the realm resolved from `--tenant`                                                                                                                  |
+| `accessToken`   | `-at` | No       | Access token for non-interactive retrieval of ADSP configuration                                                                                                                   |
+| `pairedProject` | —     | No       | Name of an existing backend service project to derive the nginx/dev-server proxy and the `adsp:proxy-service:` sandbox tag from automatically — the project must already exist     |
+| `proxy`         | —     | No       | Nginx proxy rule(s) as `{ location, proxyPass }` or an array of such objects — additional entries `--pairedProject` doesn't cover; can't duplicate its location                    |
+
+Running this generator standalone against a backend that's already scaffolded? Pass
+`--pairedProject <backend-project-name>` instead of hand-computing `--proxy` — it derives the same
+`http://<name>:3333/<name>/` convention `pevn`/`pern`/`pean`/`mevn` already use internally, plus the
+tag `@abgov/nx-oc:sandbox` needs to pre-create the backend's Service.
 
 The generated Playwright e2e project includes an axe-core accessibility check (`a11y.spec.ts`),
 scoped to WCAG 2.1 A/AA, that runs automatically as part of the `e2e` target — no separate command

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.spec.ts
@@ -1,5 +1,9 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nx/devkit';
+import {
+  Tree,
+  addProjectConfiguration,
+  readProjectConfiguration,
+} from '@nx/devkit';
 
 import * as utils from '@abgov/nx-oc';
 import { environments } from '@abgov/nx-oc';
@@ -158,5 +162,42 @@ describe('angular app generator', () => {
     );
     expect(proxyConf['/test/'].target).toBe('http://localhost:3333');
     expect(proxyConf['/test/'].pathRewrite['^/test/']).toBe('/api/');
+  });
+
+  it('derives the nginx/dev proxy and the sandbox tag from --pairedProject alone', async () => {
+    addProjectConfiguration(appTree, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await angularApp(appTree, { ...options, pairedProject: 'test-service' });
+
+    const nginxConf = appTree.read('apps/test/nginx.conf').toString();
+    expect(nginxConf).toContain('http://test-service:3333/test-service/');
+
+    const proxyConf = JSON.parse(
+      appTree.read('apps/test/proxy.conf.json').toString(),
+    );
+    expect(proxyConf['/api/'].target).toBe('http://localhost:3333');
+
+    const config = readProjectConfiguration(appTree, 'test');
+    expect(config.tags).toContain('adsp:proxy-service:test-service:3333');
+  });
+
+  it('throws when --pairedProject names a project that does not exist', async () => {
+    await expect(
+      angularApp(appTree, { ...options, pairedProject: 'no-such-service' }),
+    ).rejects.toThrow();
+  });
+
+  it('throws when --pairedProject and an explicit --proxy collide on the same location', async () => {
+    addProjectConfiguration(appTree, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await expect(
+      angularApp(appTree, {
+        ...options,
+        pairedProject: 'test-service',
+        proxy: { location: '/api/', proxyPass: 'http://other:9000/' },
+      }),
+    ).rejects.toThrow(/already derives a proxy/);
   });
 });

--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -31,6 +31,7 @@ import {
   writeJson,
 } from '@nx/devkit';
 import * as path from 'path';
+import { resolvePairedProjectProxy } from '../../utils/paired-project';
 import { NormalizedSchema, AngularAppGeneratorSchema } from './schema';
 
 async function normalizeOptions(
@@ -43,11 +44,24 @@ async function normalizeOptions(
 
   const adsp = await getAdspConfiguration(host, options);
 
-  const nginxProxies = Array.isArray(options.proxy)
+  const explicitProxies = Array.isArray(options.proxy)
     ? [...options.proxy]
     : options.proxy
       ? [options.proxy]
       : [];
+  const paired = resolvePairedProjectProxy(host, options.pairedProject);
+  if (
+    paired &&
+    explicitProxies.some((p) => p.location === paired.proxy.location)
+  ) {
+    throw new Error(
+      `--pairedProject already derives a proxy for "${paired.proxy.location}" — remove the ` +
+        `explicit --proxy entry for that location, or give it a different location.`,
+    );
+  }
+  const nginxProxies = paired
+    ? [paired.proxy, ...explicitProxies]
+    : explicitProxies;
 
   return {
     ...options,
@@ -56,6 +70,7 @@ async function normalizeOptions(
     openshiftDirectory,
     adsp,
     nginxProxies,
+    pairedProjectTag: paired?.tag,
   };
 }
 
@@ -216,6 +231,12 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
       ...config.targets.serve.options,
       proxyConfig: `${normalizedOptions.projectRoot}/proxy.conf.json`,
     };
+  }
+
+  // Lets the sandbox generator ensure the paired backend's Service exists before this
+  // frontend's nginx starts — see utils/paired-project.ts for why.
+  if (normalizedOptions.pairedProjectTag) {
+    config.tags = [...(config.tags ?? []), normalizedOptions.pairedProjectTag];
   }
 
   config.tags = [

--- a/packages/nx-adsp/src/generators/angular-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/angular-app/schema.d.ts
@@ -11,7 +11,7 @@ export interface AngularAppGeneratorSchema {
   proxy?: NginxProxyConfiguration | NginxProxyConfiguration[];
   /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
   skipAgent?: boolean;
-  /** Name of the paired backend service project, set by composite generators (pean, etc.). */
+  /** Name of an existing backend service project to derive the nginx/dev-server proxy and the adsp:proxy-service: sandbox tag from. */
   pairedProject?: string;
 }
 
@@ -21,4 +21,6 @@ export interface NormalizedSchema extends AngularAppGeneratorSchema {
   openshiftDirectory: string;
   adsp: AdspConfiguration;
   nginxProxies: NginxProxyConfiguration[];
+  /** The adsp:proxy-service: tag derived from pairedProject, if one was given. */
+  pairedProjectTag?: string;
 }

--- a/packages/nx-adsp/src/generators/angular-app/schema.json
+++ b/packages/nx-adsp/src/generators/angular-app/schema.json
@@ -75,6 +75,10 @@
         }
       ]
     },
+    "pairedProject": {
+      "type": "string",
+      "description": "Name of an existing backend service project (e.g. an express-service) to derive the nginx/dev-server proxy config from automatically, plus the adsp:proxy-service: tag the sandbox executor reads to pre-create its Service. The project must already exist. --proxy is still available for additional entries this doesn't cover, but can't duplicate the location this derives."
+    },
     "skipAgent": {
       "type": "boolean",
       "description": "Skip the consultAgent interaction and generate base scaffolding only.",

--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -26,12 +26,8 @@ import {
   fixExpressServiceE2eProject,
 } from '../../utils/quality';
 import initGenerator from '../init/init';
+import { DEFAULT_EXPRESS_SERVICE_PORT as DEFAULT_PORT } from '../../utils/express-service-port';
 import { Schema, NormalizedSchema } from './schema';
-
-// Must match environment.ts.__tmpl__'s own `PORT: num({ default: ... })` —
-// there's no --port option to source this from yet, so it's a second literal
-// kept in sync by convention rather than a single shared value.
-const DEFAULT_PORT = 3333;
 
 async function normalizeOptions(
   host: Tree,

--- a/packages/nx-adsp/src/generators/mean/mean.spec.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.spec.ts
@@ -48,5 +48,6 @@ describe('MEAN Generator', () => {
     expect(host.exists('apps/test-app/nginx.conf')).toBeTruthy();
     const nginxConf = host.read('apps/test-app/nginx.conf').toString();
     expect(nginxConf).toContain('http://test-service:3333/');
+    expect(appConfig.tags).toContain('adsp:proxy-service:test-service:3333');
   }, 30000);
 });

--- a/packages/nx-adsp/src/generators/mean/mean.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.ts
@@ -46,15 +46,13 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'mongo',
+    pairedProject: appName,
   });
   await initAngularApp(host, {
     ...normalizedOptions,
     name: appName,
-    proxy: {
-      location: '/api/',
-      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
-    },
     skipAgent: true,
+    pairedProject: serviceName,
   });
 
   if (normalizedOptions.adsp) {

--- a/packages/nx-adsp/src/generators/mern/mern.spec.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.spec.ts
@@ -48,5 +48,6 @@ describe('MERN Generator', () => {
     expect(host.exists('apps/test-app/nginx.conf')).toBeTruthy();
     const nginxConf = host.read('apps/test-app/nginx.conf').toString();
     expect(nginxConf).toContain('http://test-service:3333/');
+    expect(appConfig.tags).toContain('adsp:proxy-service:test-service:3333');
   }, 30000);
 });

--- a/packages/nx-adsp/src/generators/mern/mern.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.ts
@@ -46,15 +46,13 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'mongo',
+    pairedProject: appName,
   });
   await initReactApp(host, {
     ...normalizedOptions,
     name: appName,
-    proxy: {
-      location: '/api/',
-      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
-    },
     skipAgent: true,
+    pairedProject: serviceName,
   });
 
   if (normalizedOptions.adsp) {

--- a/packages/nx-adsp/src/generators/mevn/mevn.spec.ts
+++ b/packages/nx-adsp/src/generators/mevn/mevn.spec.ts
@@ -48,6 +48,7 @@ describe('MEVN Generator', () => {
     expect(host.exists('apps/test-app/public/nginx.conf')).toBeTruthy();
     const nginxConf = host.read('apps/test-app/public/nginx.conf').toString();
     expect(nginxConf).toContain('http://test-service:3333/');
+    expect(appConfig.tags).toContain('adsp:proxy-service:test-service:3333');
 
     expect(host.exists('apps/test-app/src/App.vue')).toBeTruthy();
     expect(host.exists('apps/test-service/src/db/schema.ts')).toBeFalsy();

--- a/packages/nx-adsp/src/generators/mevn/mevn.ts
+++ b/packages/nx-adsp/src/generators/mevn/mevn.ts
@@ -42,15 +42,13 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'mongo',
+    pairedProject: appName,
   });
   await initVueApp(host, {
     ...normalizedOptions,
     name: appName,
-    proxy: {
-      location: '/api/',
-      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
-    },
     skipAgent: true,
+    pairedProject: serviceName,
   });
 
   if (normalizedOptions.adsp) {

--- a/packages/nx-adsp/src/generators/pean/pean.ts
+++ b/packages/nx-adsp/src/generators/pean/pean.ts
@@ -51,10 +51,6 @@ export default async function (host: Tree, options: Schema) {
   await initAngularApp(host, {
     ...normalizedOptions,
     name: appName,
-    proxy: {
-      location: '/api/',
-      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
-    },
     skipAgent: true,
     pairedProject: serviceName,
   });

--- a/packages/nx-adsp/src/generators/pern/pern.ts
+++ b/packages/nx-adsp/src/generators/pern/pern.ts
@@ -51,10 +51,6 @@ export default async function (host: Tree, options: Schema) {
   await initReactApp(host, {
     ...normalizedOptions,
     name: appName,
-    proxy: {
-      location: '/api/',
-      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
-    },
     skipAgent: true,
     pairedProject: serviceName,
   });

--- a/packages/nx-adsp/src/generators/pevn/pevn.ts
+++ b/packages/nx-adsp/src/generators/pevn/pevn.ts
@@ -47,10 +47,6 @@ export default async function (host: Tree, options: Schema) {
   await initVueApp(host, {
     ...normalizedOptions,
     name: appName,
-    proxy: {
-      location: '/api/',
-      proxyPass: `http://${serviceName}:3333/${serviceName}/`,
-    },
     skipAgent: true,
     pairedProject: serviceName,
   });

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -1,4 +1,4 @@
-import { readProjectConfiguration } from '@nx/devkit';
+import { addProjectConfiguration, readProjectConfiguration } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import * as utils from '@abgov/nx-oc';
@@ -163,5 +163,45 @@ describe('React App Generator', () => {
     );
     expect(proxyConf['/test/'].target).toBe('http://localhost:3333');
     expect(proxyConf['/test/'].pathRewrite['^/test/']).toBe('/api/');
+  });
+
+  it('derives the nginx/dev proxy and the sandbox tag from --pairedProject alone', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addProjectConfiguration(host, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await generator(host, { ...options, pairedProject: 'test-service' });
+
+    const nginxConf = host.read('apps/test/nginx.conf').toString();
+    expect(nginxConf).toContain('http://test-service:3333/test-service/');
+
+    const proxyConf = JSON.parse(
+      host.read('apps/test/proxy.conf.json').toString(),
+    );
+    expect(proxyConf['/api/'].target).toBe('http://localhost:3333');
+
+    const config = readProjectConfiguration(host, 'test');
+    expect(config.tags).toContain('adsp:proxy-service:test-service:3333');
+  });
+
+  it('throws when --pairedProject names a project that does not exist', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await expect(
+      generator(host, { ...options, pairedProject: 'no-such-service' }),
+    ).rejects.toThrow();
+  });
+
+  it('throws when --pairedProject and an explicit --proxy collide on the same location', async () => {
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addProjectConfiguration(host, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await expect(
+      generator(host, {
+        ...options,
+        pairedProject: 'test-service',
+        proxy: { location: '/api/', proxyPass: 'http://other:9000/' },
+      }),
+    ).rejects.toThrow(/already derives a proxy/);
   });
 });

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -32,6 +32,7 @@ import {
 } from '@nx/devkit';
 import { Linter } from '@nx/eslint';
 import * as path from 'path';
+import { resolvePairedProjectProxy } from '../../utils/paired-project';
 import { NormalizedSchema, Schema } from './schema';
 
 async function normalizeOptions(
@@ -44,11 +45,24 @@ async function normalizeOptions(
 
   const adsp = await getAdspConfiguration(host, options);
 
-  const nginxProxies = Array.isArray(options.proxy)
+  const explicitProxies = Array.isArray(options.proxy)
     ? [...options.proxy]
     : options.proxy
       ? [options.proxy]
       : [];
+  const paired = resolvePairedProjectProxy(host, options.pairedProject);
+  if (
+    paired &&
+    explicitProxies.some((p) => p.location === paired.proxy.location)
+  ) {
+    throw new Error(
+      `--pairedProject already derives a proxy for "${paired.proxy.location}" — remove the ` +
+        `explicit --proxy entry for that location, or give it a different location.`,
+    );
+  }
+  const nginxProxies = paired
+    ? [paired.proxy, ...explicitProxies]
+    : explicitProxies;
 
   return {
     ...options,
@@ -57,6 +71,7 @@ async function normalizeOptions(
     openshiftDirectory,
     adsp,
     nginxProxies,
+    pairedProjectTag: paired?.tag,
   };
 }
 
@@ -217,6 +232,12 @@ export default async function (host: Tree, options: Schema) {
       ...config.targets.serve.options,
       proxyConfig: `${normalizedOptions.projectRoot}/proxy.conf.json`,
     };
+  }
+
+  // Lets the sandbox generator ensure the paired backend's Service exists before this
+  // frontend's nginx starts — see utils/paired-project.ts for why.
+  if (normalizedOptions.pairedProjectTag) {
+    config.tags = [...(config.tags ?? []), normalizedOptions.pairedProjectTag];
   }
 
   config.tags = [

--- a/packages/nx-adsp/src/generators/react-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/react-app/schema.d.ts
@@ -11,7 +11,7 @@ export interface Schema {
   proxy?: NginxProxyConfiguration | NginxProxyConfiguration[];
   /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
   skipAgent?: boolean;
-  /** Name of the paired backend service project, set by composite generators (pern, etc.). */
+  /** Name of an existing backend service project to derive the nginx/dev-server proxy and the adsp:proxy-service: sandbox tag from. */
   pairedProject?: string;
 }
 
@@ -21,4 +21,6 @@ export interface NormalizedSchema extends Schema {
   openshiftDirectory: string;
   adsp: AdspConfiguration;
   nginxProxies: NginxProxyConfiguration[];
+  /** The adsp:proxy-service: tag derived from pairedProject, if one was given. */
+  pairedProjectTag?: string;
 }

--- a/packages/nx-adsp/src/generators/react-app/schema.json
+++ b/packages/nx-adsp/src/generators/react-app/schema.json
@@ -75,6 +75,10 @@
         }
       ]
     },
+    "pairedProject": {
+      "type": "string",
+      "description": "Name of an existing backend service project (e.g. an express-service) to derive the nginx/dev-server proxy config from automatically, plus the adsp:proxy-service: tag the sandbox executor reads to pre-create its Service. The project must already exist. --proxy is still available for additional entries this doesn't cover, but can't duplicate the location this derives."
+    },
     "skipAgent": {
       "type": "boolean",
       "description": "Skip the consultAgent interaction and generate base scaffolding only.",

--- a/packages/nx-adsp/src/generators/vue-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/vue-app/schema.d.ts
@@ -11,7 +11,7 @@ export interface Schema {
   proxy?: NginxProxyConfiguration | NginxProxyConfiguration[];
   /** When true, skip the agent interaction. Used by composite generators that run the agent themselves. */
   skipAgent?: boolean;
-  /** Name of the paired backend service project, set by composite generators (pevn, etc.). */
+  /** Name of an existing backend service project to derive the nginx/dev-server proxy and the adsp:proxy-service: sandbox tag from. */
   pairedProject?: string;
 }
 
@@ -21,4 +21,6 @@ export interface NormalizedSchema extends Schema {
   openshiftDirectory: string;
   adsp: AdspConfiguration;
   nginxProxies: NginxProxyConfiguration[];
+  /** The adsp:proxy-service: tag derived from pairedProject, if one was given. */
+  pairedProjectTag?: string;
 }

--- a/packages/nx-adsp/src/generators/vue-app/schema.json
+++ b/packages/nx-adsp/src/generators/vue-app/schema.json
@@ -75,6 +75,10 @@
         }
       ]
     },
+    "pairedProject": {
+      "type": "string",
+      "description": "Name of an existing backend service project (e.g. an express-service) to derive the nginx/dev-server proxy config from automatically, plus the adsp:proxy-service: tag the sandbox executor reads to pre-create its Service. The project must already exist. --proxy is still available for additional entries this doesn't cover, but can't duplicate the location this derives."
+    },
     "skipAgent": {
       "type": "boolean",
       "description": "Skip the consultAgent interaction and generate base scaffolding only.",

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -1,4 +1,8 @@
-import { readProjectConfiguration, Tree } from '@nx/devkit';
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import * as utils from '@abgov/nx-oc';
@@ -311,5 +315,57 @@ describe('Vue App Generator', () => {
     );
     expect(proxyConf['/test/'].target).toBe('http://localhost:3333');
     expect(proxyConf['/test/'].pathRewrite['^/test/']).toBe('/api/');
+  });
+
+  it('derives the nginx/dev proxy and the sandbox tag from --pairedProject alone', async () => {
+    addProjectConfiguration(host, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await generator(host, { ...options, pairedProject: 'test-service' });
+
+    const nginxConf = host.read('apps/test/public/nginx.conf').toString();
+    expect(nginxConf).toContain('http://test-service:3333/test-service/');
+
+    const proxyConf = JSON.parse(
+      host.read('apps/test/vite.proxy.json').toString(),
+    );
+    expect(proxyConf['/api/'].target).toBe('http://localhost:3333');
+
+    const config = readProjectConfiguration(host, 'test');
+    expect(config.tags).toContain('adsp:proxy-service:test-service:3333');
+  });
+
+  it('throws when --pairedProject names a project that does not exist', async () => {
+    await expect(
+      generator(host, { ...options, pairedProject: 'no-such-service' }),
+    ).rejects.toThrow();
+  });
+
+  it('throws when --pairedProject and an explicit --proxy collide on the same location', async () => {
+    addProjectConfiguration(host, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await expect(
+      generator(host, {
+        ...options,
+        pairedProject: 'test-service',
+        proxy: { location: '/api/', proxyPass: 'http://other:9000/' },
+      }),
+    ).rejects.toThrow(/already derives a proxy/);
+  });
+
+  it('--pairedProject and an explicit --proxy for a different location coexist', async () => {
+    addProjectConfiguration(host, 'test-service', {
+      root: 'apps/test-service',
+    });
+    await generator(host, {
+      ...options,
+      pairedProject: 'test-service',
+      proxy: { location: '/other/', proxyPass: 'http://other-service:9000/' },
+    });
+
+    const nginxConf = host.read('apps/test/public/nginx.conf').toString();
+    expect(nginxConf).toContain('http://test-service:3333/test-service/');
+    expect(nginxConf).toContain('http://other-service:9000/');
   });
 });

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -31,6 +31,7 @@ import {
   writeJson,
 } from '@nx/devkit';
 import * as path from 'path';
+import { resolvePairedProjectProxy } from '../../utils/paired-project';
 import vueComponentsGenerator, {
   vueComponentsImportPath,
 } from '../vue-components/vue-components';
@@ -44,11 +45,24 @@ async function normalizeOptions(
   const projectRoot = `${getWorkspaceLayout(host).appsDir}/${projectName}`;
   const openshiftDirectory = `.openshift/${projectName}`;
   const adsp = await getAdspConfiguration(host, options);
-  const nginxProxies = Array.isArray(options.proxy)
+  const explicitProxies = Array.isArray(options.proxy)
     ? [...options.proxy]
     : options.proxy
       ? [options.proxy]
       : [];
+  const paired = resolvePairedProjectProxy(host, options.pairedProject);
+  if (
+    paired &&
+    explicitProxies.some((p) => p.location === paired.proxy.location)
+  ) {
+    throw new Error(
+      `--pairedProject already derives a proxy for "${paired.proxy.location}" — remove the ` +
+        `explicit --proxy entry for that location, or give it a different location.`,
+    );
+  }
+  const nginxProxies = paired
+    ? [paired.proxy, ...explicitProxies]
+    : explicitProxies;
   return {
     ...options,
     projectName,
@@ -56,6 +70,7 @@ async function normalizeOptions(
     openshiftDirectory,
     adsp,
     nginxProxies,
+    pairedProjectTag: paired?.tag,
   };
 }
 
@@ -207,28 +222,10 @@ export default async function (host: Tree, options: Schema) {
     };
   }
 
-  // Record the paired backend (name + port) so the sandbox generator can ensure
-  // its Service exists before this frontend's nginx starts — nginx resolves
-  // proxy_pass upstreams at startup, so a missing Service would crashloop the
-  // pod. Only the Service is needed (for DNS), not the backend's deployment.
-  if (normalizedOptions.pairedProject) {
-    const pairedService = names(normalizedOptions.pairedProject).fileName;
-    const proxy = normalizedOptions.nginxProxies.find((p) => {
-      try {
-        return new URL(p.proxyPass).hostname === pairedService;
-      } catch {
-        return false;
-      }
-    });
-    let port = 3333;
-    if (proxy) {
-      const url = new URL(proxy.proxyPass);
-      port = Number(url.port) || (url.protocol === 'https:' ? 443 : 80);
-    }
-    config.tags = [
-      ...(config.tags ?? []),
-      `adsp:proxy-service:${pairedService}:${port}`,
-    ];
+  // Lets the sandbox generator ensure the paired backend's Service exists before this
+  // frontend's nginx starts — see utils/paired-project.ts for why.
+  if (normalizedOptions.pairedProjectTag) {
+    config.tags = [...(config.tags ?? []), normalizedOptions.pairedProjectTag];
   }
 
   config.tags = [

--- a/packages/nx-adsp/src/utils/express-service-port.ts
+++ b/packages/nx-adsp/src/utils/express-service-port.ts
@@ -1,0 +1,7 @@
+// express-service has no --port option to source a real value from yet, so every consumer that
+// needs to reach a paired backend by convention (a frontend's nginx/dev-server proxy, the
+// `adsp:proxy-service:` tag the sandbox executor reads) has to agree on the same default. One
+// exported constant, not a literal repeated at each call site — update this alongside
+// environment.ts.__tmpl__'s own `PORT: num({ default: ... })` if express-service ever gains a
+// real --port option to read instead.
+export const DEFAULT_EXPRESS_SERVICE_PORT = 3333;

--- a/packages/nx-adsp/src/utils/paired-project.ts
+++ b/packages/nx-adsp/src/utils/paired-project.ts
@@ -1,0 +1,36 @@
+import { names, readProjectConfiguration, Tree } from '@nx/devkit';
+import { DEFAULT_EXPRESS_SERVICE_PORT } from './express-service-port';
+import { NginxProxyConfiguration } from './nginx';
+
+export interface PairedProjectProxy {
+  proxy: NginxProxyConfiguration;
+  tag: string;
+}
+
+const PAIRED_PROJECT_LOCATION = '/api/';
+
+// Resolves a frontend's --pairedProject into the nginx/dev-server proxy entry that routes API
+// calls to it, plus the `adsp:proxy-service:<name>:<port>` tag the sandbox executor reads to
+// pre-create the backend's Service before this frontend's nginx starts (nginx resolves
+// proxy_pass upstreams at startup, so a missing Service would crashloop the pod — only the
+// Service is needed, for DNS, not the backend's deployment). Throws if the named project doesn't
+// exist yet — a paired reference only makes sense pointing at something already scaffolded, the
+// same convention project-docs-ancestors uses elsewhere in this workspace.
+export function resolvePairedProjectProxy(
+  host: Tree,
+  pairedProject: string | undefined,
+): PairedProjectProxy | undefined {
+  if (!pairedProject) {
+    return undefined;
+  }
+  const pairedService = names(pairedProject).fileName;
+  readProjectConfiguration(host, pairedService);
+  const port = DEFAULT_EXPRESS_SERVICE_PORT;
+  return {
+    proxy: {
+      location: PAIRED_PROJECT_LOCATION,
+      proxyPass: `http://${pairedService}:${port}/${pairedService}/`,
+    },
+    tag: `adsp:proxy-service:${pairedService}:${port}`,
+  };
+}


### PR DESCRIPTION
## Summary

`vue-app`/`react-app`/`angular-app` previously needed an explicit, hand-computed `--proxy` entry
to reach an existing backend — and `--pairedProject` itself was internal-only (blocked from the
CLI by `additionalProperties: false`), only feeding the `adsp:proxy-service:` sandbox tag, and only
in `vue-app.ts`, by searching an already-present `--proxy` entry for a matching hostname.

- Exposes `--pairedProject <backend-project-name>` as a real public option on all three frontend
  generators. Given an existing backend project, it now derives the nginx/dev-server proxy entry
  itself (`http://<name>:3333/<name>/`, the same convention the composite generators already used)
  **and** the `adsp:proxy-service:<name>:<port>` tag uniformly — closing a gap where
  `react-app`/`angular-app` computed `pairedProject` but never wrote the tag at all.
- Throws if the named project doesn't exist, or if an explicit `--proxy` entry collides with the
  derived one on the same location (would otherwise produce a duplicate, conflicting nginx
  `location` block).
- The port (`3333`) has no `--port` option to read from yet, so it's promoted from a
  generator-local literal (`express-service.ts`) to one exported constant
  (`utils/express-service-port.ts`) shared by the new resolution utility — collapsing what was
  already two independently-hardcoded literals into one.
- `pevn`/`pern`/`pean` already passed both an explicit `--proxy` *and* `--pairedProject` to their
  frontend call — the explicit `--proxy` is now redundant (and would conflict with the derived
  entry if left in), so it's dropped.
- `mern`/`mean`/`mevn` never passed `--pairedProject` to either side at all — fixed to match,
  closing the same sandbox-tag gap for their Mongo-backed variants. (Confirmed via a new tag
  assertion added to each of their existing specs, which passed silently without one before this.)
- `react-dotnet` is explicitly **out of scope**: its backend runs on a different port (5000, ASP.NET
  Core's default) that this feature's `DEFAULT_EXPRESS_SERVICE_PORT` convention doesn't apply to —
  left untouched rather than wired up with the wrong port.

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — 103 tests (10 new + 4 gap-closing assertions), clean
- [x] New unit tests per frontend generator: derives proxy+tag from `--pairedProject` alone, throws
  when the paired project doesn't exist, throws on a `--proxy`/`--pairedProject` location collision,
  and (vue-app) confirms an explicit `--proxy` for a *different* location still coexists correctly
- [x] Existing `pevn`/`pern`/`pean`/`mern`/`mean`/`mevn` specs already assert on the resulting
  nginx/tag content and pass unchanged against the simplified composite-generator calls