### PR TITLE
chore(nx-agent): skip Nx's GitHub Actions log grouping in the iteration workflow

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
@@ -58,6 +58,11 @@ permissions:
 
 env:
   MAX_ITERATIONS: ${{ vars.MAX_ITERATIONS || '6' }}
+  # Nx wraps every `nx run <project>:<target>` in a collapsible ::group::/::endgroup:: block
+  # whenever it detects GITHUB_ACTIONS -- one more fold per task, on top of this workflow's own
+  # step-level ones, for output that's already scoped to one bounded iteration. Purely local log
+  # formatting (no Nx Cloud connection or telemetry involved); this just skips it.
+  NX_SKIP_LOG_GROUPING: 'true'
 
 jobs:
   iterate:


### PR DESCRIPTION
## Summary

Nx wraps every `nx run <project>:<target>` in a collapsible `::group::`/`::endgroup::` block
whenever it detects the `GITHUB_ACTIONS` env var (confirmed directly in the installed package,
`node_modules/nx/dist/src/utils/output.js`) — purely local log formatting, no Nx Cloud connection
or telemetry involved. Redundant here on top of the workflow's own step-level folding, for output
that's already scoped to one bounded iteration, so `NX_SKIP_LOG_GROUPING: 'true'` turns it off —
the exact env var the same source checks.

## Test plan
- [x] `npx nx test,lint,build nx-agent` — clean
- [x] YAML parses