### PR TITLE
feat(nx-agent): automate GitHub Actions secret/variable provisioning in agent-delivery

### DIFF
--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -151,11 +151,11 @@ resolves: []
 
 ### `feature` options
 
-| Option                 | Default                  | Description                                                                                                                              |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `title`                | — (required, positional) | The canonical name of the feature                                                                                                        |
-| `project`              | workspace root           | Scope the feature to a specific project's `project-docs/features/` instead — prefer this whenever it already has a natural code home     |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this feature relates to — repeatable; typically an existing service-description if this extends an initiative that already exists |
+| Option                 | Default                  | Description                                                                                                                                                                                                           |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | — (required, positional) | The canonical name of the feature                                                                                                                                                                                     |
+| `project`              | workspace root           | Scope the feature to a specific project's `project-docs/features/` instead — prefer this whenever it already has a natural code home                                                                                  |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this feature relates to — repeatable; typically an existing service-description if this extends an initiative that already exists                                         |
 | `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this feature resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 Re-adding a feature that already exists throws rather than silently overwriting or duplicating it. A
@@ -188,15 +188,15 @@ resolves: []
 
 ### `bug` options
 
-| Option                 | Default                  | Description                                                                                                                         |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `description`          | — (required, positional) | A short slug for what's wrong                                                                                                        |
-| `project`              | workspace root           | Scope the bug to a specific project's `project-docs/bugs/` instead — prefer this whenever it already has a natural code home         |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this bug relates to, if already known — often genuinely empty until triaged             |
+| Option                 | Default                  | Description                                                                                                                  |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `description`          | — (required, positional) | A short slug for what's wrong                                                                                                |
+| `project`              | workspace root           | Scope the bug to a specific project's `project-docs/bugs/` instead — prefer this whenever it already has a natural code home |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this bug relates to, if already known — often genuinely empty until triaged      |
 
 A bug tracks open/resolved status the same generic way as `open-question`/`blocker`
 (`resolutionStatus.open`/`.resolved`), but resolves differently — see `develop/SKILL.md`'s bug-fixing
-section in the `agent-delivery` output below. Investigating a bug and finding the *spec* itself was
+section in the `agent-delivery` output below. Investigating a bug and finding the _spec_ itself was
 wrong escalates to a real `blocker` against the implicated artifact; filing that blocker does not
 itself resolve the bug — only an `iteration-retrospective --resolves` naming the bug's own path does.
 
@@ -645,14 +645,47 @@ overwrites what's already present.
 
 ### `agent-delivery` options
 
-| Option          | Default | Description                                                                                                                                                                                                                                                                                                                                |
-| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `githubActions` | `false` | Additionally scaffold a self-dispatching GitHub Actions iteration loop — `.github/workflows/agent-delivery-iteration.yml`, its harness/task-identification scripts, and a `learnings.md` header — for driving the same skills autonomously across many iterations, instead of a human or an orchestrating tool driving them one at a time. |
+| Option                                                                                                                        | Default | Description                                                                                                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `githubActions`                                                                                                               | `false` | Additionally scaffold a self-dispatching GitHub Actions iteration loop — `.github/workflows/agent-delivery-iteration.yml`, its harness/task-identification scripts, and a `learnings.md` header — for driving the same skills autonomously across many iterations, instead of a human or an orchestrating tool driving them one at a time. |
+| `provisionSecrets`                                                                                                            | `false` | Best-effort, non-interactive provisioning of the scaffolded workflow's own GitHub repo secrets/variables — see below. No effect unless `githubActions` is also `true`. Requires `@abgov/nx-oc`.                                                                                                                                            |
+| `project`                                                                                                                     | —       | Scope `provisionSecrets`'s project-derived values to one project's own `sandbox` target/tags. Auto-detected across the workspace when omitted.                                                                                                                                                                                             |
+| `openshiftServer`, `openshiftToken`, `openshiftNamespace`, `adspEnv`, `adspTenantName`, `adspTenantRealm`, `adspClientSecret` | —       | Explicit value for the correspondingly-named secret/variable — used verbatim by `provisionSecrets`, skipping derivation entirely for that one. No `adspClientId` option: it's always the fixed `adsp-cli-ci` client ID.                                                                                                                    |
+| `maxIterations`                                                                                                               | —       | Explicit `MAX_ITERATIONS` value for `provisionSecrets` to write. Optional either way — the workflow already defaults to `6` when unset.                                                                                                                                                                                                    |
+| `accessToken`                                                                                                                 | —       | Pre-obtained ADSP admin-scoped access token for `provisionSecrets`'s ADSP lookups — skips any `adsp-cli` login attempt, matching every `nx-adsp` app/service generator's own `--accessToken`.                                                                                                                                              |
+| `overwriteExisting`                                                                                                           | `false` | Let `provisionSecrets` overwrite a secret/variable that already exists on the repo. Default is to always leave an existing one unchanged.                                                                                                                                                                                                  |
 
 ### `--githubActions` setup
 
 The scaffolded workflow needs repo secrets and variables it doesn't set itself: secrets
 `OPENSHIFT_SERVER`, `OPENSHIFT_TOKEN`, `ADSP_CLIENT_ID`, `ADSP_CLIENT_SECRET`; variables `ADSP_ENV`,
 `ADSP_TENANT_NAME`, `ADSP_TENANT_REALM`, `OPENSHIFT_NAMESPACE`, and optionally `MAX_ITERATIONS`
-(defaults to `6`). It also needs the org policy enabling Copilot CLI billed to the organization (for
-the workflow's own `copilot-requests: write` permission to actually authenticate).
+(defaults to `6`).
+
+`--provisionSecrets` automates most of this on a best-effort basis, once at least one app/service
+has been scaffolded (and, for `OPENSHIFT_*`, sandboxed):
+
+```bash
+npx nx g @abgov/nx-agent:agent-delivery --githubActions --provisionSecrets
+```
+
+It derives `OPENSHIFT_NAMESPACE` from a project's own `sandbox` target, `ADSP_ENV`/
+`ADSP_TENANT_NAME` from the tags every app/service generator already writes, `ADSP_TENANT_REALM`
+from a live (re-)resolution of the tenant name, `ADSP_CLIENT_ID` as the fixed `adsp-cli-ci`
+constant, and `ADSP_CLIENT_SECRET` via a Keycloak admin lookup — using an `oc`/`gh` login already
+active on this machine, or an explicit option/`--accessToken` in place of any of them. It **never**
+overwrites a secret/variable that already exists on the repo unless `--overwriteExisting` is also
+passed, and reports anything it couldn't determine as a warning with the exact next step. There's
+no requirement to run this before or after any other generator — see the generator's own
+`provision-github-secrets.ts` header for exactly how each value degrades when the state it'd
+otherwise read doesn't exist yet.
+
+Two things it deliberately never automates, reported as warnings with exact manual steps instead:
+
+- **The tenant's `adsp-cli-ci` Keycloak client being disabled.** It's bootstrapped disabled at
+  tenant creation — a tenant admin has to enable it and generate its secret via the Keycloak admin
+  console (Clients → `adsp-cli-ci` → Settings → enable → Credentials tab → regenerate). This is a
+  real tenant-level decision, not something a generator should do on anyone's behalf.
+- **The org-level Copilot CLI billing policy** — a GitHub org admin console setting, not a repo
+  secret or variable, needed for the workflow's own `copilot-requests: write` permission to
+  actually authenticate.

--- a/packages/nx-agent/.eslintrc.json
+++ b/packages/nx-agent/.eslintrc.json
@@ -1,6 +1,17 @@
 {
   "extends": ["../../.eslintrc.json"],
   "ignorePatterns": ["!**/*"],
+  "rules": {
+    "@nx/dependency-checks": [
+      "error",
+      {
+        "ignoredDependencies": ["@abgov/nx-oc"],
+        "checkMissingDependencies": true, // toggle to disable
+        "checkObsoleteDependencies": true, // toggle to disable
+        "checkVersionMismatches": true // toggle to disable
+      }
+    ]
+  },
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -126,11 +126,11 @@ resolves: []
 
 ### Options
 
-| Option                 | Default                  | Description                                                                                                                              |
-| ----------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `title`                | — (required, positional) | The canonical name of the feature                                                                                                        |
-| `project`              | workspace root           | Scope the feature to a specific project's `project-docs/features/` instead — prefer this whenever it already has a natural code home     |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this feature relates to — repeatable; typically an existing service-description if this extends an initiative that already exists |
+| Option                 | Default                  | Description                                                                                                                                                                                                           |
+| ---------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                | — (required, positional) | The canonical name of the feature                                                                                                                                                                                     |
+| `project`              | workspace root           | Scope the feature to a specific project's `project-docs/features/` instead — prefer this whenever it already has a natural code home                                                                                  |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this feature relates to — repeatable; typically an existing service-description if this extends an initiative that already exists                                         |
 | `resolves`             | none                     | Paths to existing `open-question`/`blocker` artifacts this feature resolves — repeatable; also added to `project-docs-ancestors`, but recorded distinctly so `project-docs-lineage` can report the resolution as such |
 
 Re-adding a feature that already exists throws rather than silently overwriting or duplicating it. A
@@ -161,15 +161,15 @@ resolves: []
 
 ### Options
 
-| Option                 | Default                  | Description                                                                                                                         |
-| ---------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `description`          | — (required, positional) | A short slug for what's wrong                                                                                                        |
-| `project`              | workspace root           | Scope the bug to a specific project's `project-docs/bugs/` instead — prefer this whenever it already has a natural code home         |
-| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this bug relates to, if already known — often genuinely empty until triaged             |
+| Option                 | Default                  | Description                                                                                                                  |
+| ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `description`          | — (required, positional) | A short slug for what's wrong                                                                                                |
+| `project`              | workspace root           | Scope the bug to a specific project's `project-docs/bugs/` instead — prefer this whenever it already has a natural code home |
+| `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this bug relates to, if already known — often genuinely empty until triaged      |
 
 A bug tracks open/resolved status the same generic way as `open-question`/`blocker`
 (`resolutionStatus.open`/`.resolved`), but resolves differently — see `develop/SKILL.md`'s bug-fixing
-section in the `agent-delivery` output below. Investigating a bug and finding the *spec* itself was
+section in the `agent-delivery` output below. Investigating a bug and finding the _spec_ itself was
 wrong escalates to a real `blocker` against the implicated artifact; filing that blocker does not
 itself resolve the bug — only an `iteration-retrospective --resolves` naming the bug's own path does.
 
@@ -612,14 +612,47 @@ overwrites what's already present.
 
 ### Options
 
-| Option          | Default | Description                                                                                                                                                                                                                                                                                                                                |
-| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `githubActions` | `false` | Additionally scaffold a self-dispatching GitHub Actions iteration loop — `.github/workflows/agent-delivery-iteration.yml`, its harness/task-identification scripts, and a `learnings.md` header — for driving the same skills autonomously across many iterations, instead of a human or an orchestrating tool driving them one at a time. |
+| Option                                                                                                                        | Default | Description                                                                                                                                                                                                                                                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `githubActions`                                                                                                               | `false` | Additionally scaffold a self-dispatching GitHub Actions iteration loop — `.github/workflows/agent-delivery-iteration.yml`, its harness/task-identification scripts, and a `learnings.md` header — for driving the same skills autonomously across many iterations, instead of a human or an orchestrating tool driving them one at a time. |
+| `provisionSecrets`                                                                                                            | `false` | Best-effort, non-interactive provisioning of the scaffolded workflow's own GitHub repo secrets/variables — see below. No effect unless `githubActions` is also `true`. Requires `@abgov/nx-oc`.                                                                                                                                            |
+| `project`                                                                                                                     | —       | Scope `provisionSecrets`'s project-derived values to one project's own `sandbox` target/tags. Auto-detected across the workspace when omitted.                                                                                                                                                                                             |
+| `openshiftServer`, `openshiftToken`, `openshiftNamespace`, `adspEnv`, `adspTenantName`, `adspTenantRealm`, `adspClientSecret` | —       | Explicit value for the correspondingly-named secret/variable — used verbatim by `provisionSecrets`, skipping derivation entirely for that one. No `adspClientId` option: it's always the fixed `adsp-cli-ci` client ID.                                                                                                                    |
+| `maxIterations`                                                                                                               | —       | Explicit `MAX_ITERATIONS` value for `provisionSecrets` to write. Optional either way — the workflow already defaults to `6` when unset.                                                                                                                                                                                                    |
+| `accessToken`                                                                                                                 | —       | Pre-obtained ADSP admin-scoped access token for `provisionSecrets`'s ADSP lookups — skips any `adsp-cli` login attempt, matching every `nx-adsp` app/service generator's own `--accessToken`.                                                                                                                                              |
+| `overwriteExisting`                                                                                                           | `false` | Let `provisionSecrets` overwrite a secret/variable that already exists on the repo. Default is to always leave an existing one unchanged.                                                                                                                                                                                                  |
 
 ### `--githubActions` setup
 
 The scaffolded workflow needs repo secrets and variables it doesn't set itself: secrets
 `OPENSHIFT_SERVER`, `OPENSHIFT_TOKEN`, `ADSP_CLIENT_ID`, `ADSP_CLIENT_SECRET`; variables `ADSP_ENV`,
 `ADSP_TENANT_NAME`, `ADSP_TENANT_REALM`, `OPENSHIFT_NAMESPACE`, and optionally `MAX_ITERATIONS`
-(defaults to `6`). It also needs the org policy enabling Copilot CLI billed to the organization (for
-the workflow's own `copilot-requests: write` permission to actually authenticate).
+(defaults to `6`).
+
+`--provisionSecrets` automates most of this on a best-effort basis, once at least one app/service
+has been scaffolded (and, for `OPENSHIFT_*`, sandboxed):
+
+```bash
+npx nx g @abgov/nx-agent:agent-delivery --githubActions --provisionSecrets
+```
+
+It derives `OPENSHIFT_NAMESPACE` from a project's own `sandbox` target, `ADSP_ENV`/
+`ADSP_TENANT_NAME` from the tags every app/service generator already writes, `ADSP_TENANT_REALM`
+from a live (re-)resolution of the tenant name, `ADSP_CLIENT_ID` as the fixed `adsp-cli-ci`
+constant, and `ADSP_CLIENT_SECRET` via a Keycloak admin lookup — using an `oc`/`gh` login already
+active on this machine, or an explicit option/`--accessToken` in place of any of them. It **never**
+overwrites a secret/variable that already exists on the repo unless `--overwriteExisting` is also
+passed, and reports anything it couldn't determine as a warning with the exact next step. There's
+no requirement to run this before or after any other generator — see the generator's own
+`provision-github-secrets.ts` header for exactly how each value degrades when the state it'd
+otherwise read doesn't exist yet.
+
+Two things it deliberately never automates, reported as warnings with exact manual steps instead:
+
+- **The tenant's `adsp-cli-ci` Keycloak client being disabled.** It's bootstrapped disabled at
+  tenant creation — a tenant admin has to enable it and generate its secret via the Keycloak admin
+  console (Clients → `adsp-cli-ci` → Settings → enable → Credentials tab → regenerate). This is a
+  real tenant-level decision, not something a generator should do on anyone's behalf.
+- **The org-level Copilot CLI billing policy** — a GitHub org admin console setting, not a repo
+  secret or variable, needed for the workflow's own `copilot-requests: write` permission to
+  actually authenticate.

--- a/packages/nx-agent/package.json
+++ b/packages/nx-agent/package.json
@@ -15,8 +15,14 @@
     "yaml": "~2.9.0"
   },
   "peerDependencies": {
+    "@abgov/nx-oc": "^13.0.0-0",
     "@nx/devkit": "^23.0.0",
     "tslib": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@abgov/nx-oc": {
+      "optional": true
+    }
   },
   "generators": "./generators.json",
   "scripts": {}

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts
@@ -6,6 +6,7 @@ import {
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { mergeManagedSection } from '../../utils/agents-md';
+import { provisionGithubActionsSecrets } from './provision-github-secrets';
 import { Schema } from './schema';
 
 const FILES_DIR = join(__dirname, 'files');
@@ -97,4 +98,9 @@ export default async function (host: Tree, options: Schema) {
   }
 
   mergeManagedSection(host, AGENTS_MD_SECTION_ID, readGuidance());
+
+  // Last, and independent of everything above: file scaffolding always succeeds regardless of
+  // what live oc/gh/ADSP calls this finds. No-ops entirely unless both --githubActions and
+  // --provisionSecrets are set — see provision-github-secrets.ts's own header for the full design.
+  await provisionGithubActionsSecrets(host, options);
 }

--- a/packages/nx-agent/src/generators/agent-delivery/provision-github-secrets.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/provision-github-secrets.spec.ts
@@ -1,0 +1,337 @@
+import { addProjectConfiguration, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { provisionGithubActionsSecrets } from './provision-github-secrets';
+import { Schema } from './schema';
+
+// @abgov/nx-oc is lazy-loaded (an optional peer -- see provision-github-secrets.ts's own
+// `await import(...)`), so @nx/enforce-module-boundaries forbids a static import of it anywhere
+// in this project. Obtain the mocked module the same lazy way instead.
+jest.mock('@abgov/nx-oc');
+let mocked: jest.Mocked<typeof import('@abgov/nx-oc')>;
+
+const REPO = 'GovAlta/nx-tools';
+const BASE: Schema = { githubActions: true, provisionSecrets: true };
+
+function logSpy() {
+  return jest.spyOn(console, 'log').mockImplementation(() => undefined);
+}
+
+describe('provisionGithubActionsSecrets', () => {
+  let host: Tree;
+
+  beforeEach(async () => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    jest.resetAllMocks();
+    mocked = (await import('@abgov/nx-oc')) as jest.Mocked<
+      typeof import('@abgov/nx-oc')
+    >;
+
+    mocked.isNonInteractive.mockReturnValue(false);
+    mocked.isOcLoggedIn.mockReturnValue(false);
+    mocked.getGitRemoteUrl.mockReturnValue('git@github.com:GovAlta/nx-tools.git');
+    mocked.getGitHubRepo.mockReturnValue(REPO);
+    mocked.checkGhCli.mockImplementation(() => undefined);
+    mocked.listGhSecretNames.mockReturnValue([]);
+    mocked.listGhVariableNames.mockReturnValue([]);
+    mocked.setGhSecret.mockReturnValue(true);
+    mocked.setGhVariable.mockReturnValue(true);
+  });
+
+  it('no-ops entirely when provisionSecrets is not set', async () => {
+    await provisionGithubActionsSecrets(host, { githubActions: true });
+    expect(mocked.checkGhCli).not.toHaveBeenCalled();
+    expect(mocked.isOcLoggedIn).not.toHaveBeenCalled();
+  });
+
+  it('warns and does nothing when githubActions is not set', async () => {
+    const log = logSpy();
+    await provisionGithubActionsSecrets(host, { provisionSecrets: true });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('no effect without --githubActions'),
+    );
+    expect(mocked.checkGhCli).not.toHaveBeenCalled();
+  });
+
+  it('uses every explicit value verbatim, attempting zero derivation calls', async () => {
+    logSpy();
+    await provisionGithubActionsSecrets(host, {
+      ...BASE,
+      openshiftServer: 'https://api.example.com:6443',
+      openshiftToken: 'tok',
+      openshiftNamespace: 'my-ns',
+      adspEnv: 'dev',
+      adspTenantName: 'my-tenant',
+      adspTenantRealm: 'my-realm',
+      adspClientSecret: 'shh',
+      maxIterations: 6,
+    });
+
+    expect(mocked.isOcLoggedIn).not.toHaveBeenCalled();
+    expect(mocked.getOcServerUrl).not.toHaveBeenCalled();
+    expect(mocked.getSaToken).not.toHaveBeenCalled();
+    expect(mocked.detectAdspEnv).not.toHaveBeenCalled();
+    expect(mocked.detectAdspTenant).not.toHaveBeenCalled();
+    expect(mocked.getAdspConfiguration).not.toHaveBeenCalled();
+    expect(mocked.getAdspCliCiStatus).not.toHaveBeenCalled();
+
+    expect(mocked.setGhSecret).toHaveBeenCalledWith(
+      'OPENSHIFT_SERVER',
+      'https://api.example.com:6443',
+      REPO,
+    );
+    expect(mocked.setGhSecret).toHaveBeenCalledWith('OPENSHIFT_TOKEN', 'tok', REPO);
+    expect(mocked.setGhVariable).toHaveBeenCalledWith(
+      'OPENSHIFT_NAMESPACE',
+      'my-ns',
+      REPO,
+    );
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('ADSP_ENV', 'dev', REPO);
+    expect(mocked.setGhVariable).toHaveBeenCalledWith(
+      'ADSP_TENANT_NAME',
+      'my-tenant',
+      REPO,
+    );
+    expect(mocked.setGhVariable).toHaveBeenCalledWith(
+      'ADSP_TENANT_REALM',
+      'my-realm',
+      REPO,
+    );
+    expect(mocked.setGhSecret).toHaveBeenCalledWith(
+      'ADSP_CLIENT_SECRET',
+      'shh',
+      REPO,
+    );
+    expect(mocked.setGhSecret).toHaveBeenCalledWith(
+      'ADSP_CLIENT_ID',
+      'adsp-cli-ci',
+      REPO,
+    );
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('MAX_ITERATIONS', '6', REPO);
+  });
+
+  it('derives every project-backed value from an already-generated project', async () => {
+    logSpy();
+    addProjectConfiguration(host, 'my-app', {
+      root: 'apps/my-app',
+      tags: ['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:my-tenant'],
+      targets: { sandbox: { executor: '@abgov/nx-oc:sandbox', options: { sandboxProject: 'my-ns' } } },
+    });
+    mocked.detectAdspEnv.mockReturnValue('dev');
+    mocked.detectAdspTenant.mockReturnValue('my-tenant');
+    mocked.isOcLoggedIn.mockReturnValue(true);
+    mocked.getOcServerUrl.mockReturnValue('https://api.example.com:6443');
+    mocked.getSaToken.mockReturnValue('sa-tok');
+    mocked.getAdspConfiguration.mockResolvedValue({
+      tenant: 'my-tenant',
+      tenantRealm: 'realm-abc',
+      accessServiceUrl: 'https://access.example.com',
+      directoryServiceUrl: 'https://directory.example.com',
+      accessToken: 'admin-tok',
+    });
+    mocked.getAdspCliCiStatus.mockResolvedValue({
+      found: true,
+      enabled: true,
+      secret: 'client-secret',
+    });
+
+    await provisionGithubActionsSecrets(host, BASE);
+
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('OPENSHIFT_NAMESPACE', 'my-ns', REPO);
+    expect(mocked.setGhSecret).toHaveBeenCalledWith('OPENSHIFT_TOKEN', 'sa-tok', REPO);
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('ADSP_ENV', 'dev', REPO);
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('ADSP_TENANT_NAME', 'my-tenant', REPO);
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('ADSP_TENANT_REALM', 'realm-abc', REPO);
+    expect(mocked.setGhSecret).toHaveBeenCalledWith('ADSP_CLIENT_SECRET', 'client-secret', REPO);
+    expect(mocked.getSaToken).toHaveBeenCalledWith('github-actions', 'my-ns');
+  });
+
+  it('resolves ADSP_ENV/ADSP_TENANT_NAME from tags even with no sandbox target yet — the decoupled-scan / ordering case', async () => {
+    logSpy();
+    addProjectConfiguration(host, 'my-app', {
+      root: 'apps/my-app',
+      tags: ['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:my-tenant'],
+    });
+    mocked.detectAdspEnv.mockReturnValue('dev');
+    mocked.detectAdspTenant.mockReturnValue('my-tenant');
+
+    await provisionGithubActionsSecrets(host, BASE);
+
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('ADSP_ENV', 'dev', REPO);
+    expect(mocked.setGhVariable).toHaveBeenCalledWith('ADSP_TENANT_NAME', 'my-tenant', REPO);
+    // Namespace has no sandbox target anywhere yet -- cascades to undetermined, not a throw.
+    expect(mocked.setGhVariable).not.toHaveBeenCalledWith(
+      'OPENSHIFT_NAMESPACE',
+      expect.anything(),
+      REPO,
+    );
+    expect(mocked.getSaToken).not.toHaveBeenCalled();
+  });
+
+  it('never throws in a workspace with zero projects, and reports everything project-derived as undetermined', async () => {
+    const log = logSpy();
+
+    await expect(provisionGithubActionsSecrets(host, BASE)).resolves.toBeUndefined();
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('OPENSHIFT_NAMESPACE'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('ADSP_ENV'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('ADSP_TENANT_NAME'));
+    expect(mocked.setGhVariable).not.toHaveBeenCalledWith(
+      'OPENSHIFT_NAMESPACE',
+      expect.anything(),
+      REPO,
+    );
+  });
+
+  it('reports an ambiguous OPENSHIFT_NAMESPACE across two projects with differing sandboxProject values, naming both', async () => {
+    const log = logSpy();
+    addProjectConfiguration(host, 'app-a', {
+      root: 'apps/app-a',
+      targets: { sandbox: { executor: '@abgov/nx-oc:sandbox', options: { sandboxProject: 'ns-a' } } },
+    });
+    addProjectConfiguration(host, 'app-b', {
+      root: 'apps/app-b',
+      targets: { sandbox: { executor: '@abgov/nx-oc:sandbox', options: { sandboxProject: 'ns-b' } } },
+    });
+
+    await provisionGithubActionsSecrets(host, BASE);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringMatching(/OPENSHIFT_NAMESPACE.*ambiguous.*ns-a.*app-a.*ns-b.*app-b|OPENSHIFT_NAMESPACE.*ambiguous.*ns-b.*app-b.*ns-a.*app-a/),
+    );
+    expect(mocked.setGhVariable).not.toHaveBeenCalledWith(
+      'OPENSHIFT_NAMESPACE',
+      expect.anything(),
+      REPO,
+    );
+  });
+
+  it('scopes derivation to --project when given, even if a different project has the value', async () => {
+    logSpy();
+    addProjectConfiguration(host, 'app-a', {
+      root: 'apps/app-a',
+      targets: { sandbox: { executor: '@abgov/nx-oc:sandbox', options: { sandboxProject: 'ns-a' } } },
+    });
+    addProjectConfiguration(host, 'app-b', { root: 'apps/app-b' });
+
+    await provisionGithubActionsSecrets(host, { ...BASE, project: 'app-b' });
+
+    expect(mocked.setGhVariable).not.toHaveBeenCalledWith(
+      'OPENSHIFT_NAMESPACE',
+      expect.anything(),
+      REPO,
+    );
+  });
+
+  it('reports the exact manual-enable warning when adsp-cli-ci is disabled, and never attempts to enable it', async () => {
+    const log = logSpy();
+    addProjectConfiguration(host, 'my-app', {
+      root: 'apps/my-app',
+      tags: ['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:my-tenant'],
+    });
+    mocked.detectAdspEnv.mockReturnValue('dev');
+    mocked.detectAdspTenant.mockReturnValue('my-tenant');
+    mocked.getAdspConfiguration.mockResolvedValue({
+      tenant: 'my-tenant',
+      tenantRealm: 'realm-abc',
+      accessServiceUrl: 'https://access.example.com',
+      directoryServiceUrl: 'https://directory.example.com',
+      accessToken: 'admin-tok',
+    });
+    mocked.getAdspCliCiStatus.mockResolvedValue({ found: true, enabled: false });
+
+    await provisionGithubActionsSecrets(host, BASE);
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "the tenant's adsp-cli-ci Keycloak client is disabled",
+      ),
+    );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('--adspClientSecret'));
+    expect(mocked.setGhSecret).not.toHaveBeenCalledWith(
+      'ADSP_CLIENT_SECRET',
+      expect.anything(),
+      REPO,
+    );
+  });
+
+  it('never hangs or prompts in non-interactive mode with nothing cached -- everything ends up undetermined with a real reason', async () => {
+    const log = logSpy();
+    mocked.isNonInteractive.mockReturnValue(true);
+    mocked.isOcLoggedIn.mockReturnValue(false);
+    mocked.getAdspConfiguration.mockRejectedValue(
+      new Error('Not signed in to ADSP (non-interactive run). Sign in first with:\n  ...'),
+    );
+    addProjectConfiguration(host, 'my-app', {
+      root: 'apps/my-app',
+      tags: ['adsp:scaffold-env:dev', 'adsp:scaffold-tenant:my-tenant'],
+    });
+    mocked.detectAdspEnv.mockReturnValue('dev');
+    mocked.detectAdspTenant.mockReturnValue('my-tenant');
+
+    await provisionGithubActionsSecrets(host, BASE);
+
+    expect(mocked.ensureOcLogin).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('OPENSHIFT_SERVER'));
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Not signed in to ADSP'),
+    );
+  });
+
+  it('reports Phase 1 results but skips every write when gh is unauthenticated', async () => {
+    const log = logSpy();
+    mocked.checkGhCli.mockImplementation(() => {
+      throw new Error('gh CLI is not installed or not authenticated.');
+    });
+
+    await provisionGithubActionsSecrets(host, {
+      ...BASE,
+      openshiftServer: 'https://api.example.com:6443',
+    });
+
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('gh CLI is not installed'),
+    );
+    expect(mocked.setGhSecret).not.toHaveBeenCalled();
+    expect(mocked.setGhVariable).not.toHaveBeenCalled();
+  });
+
+  it('never overwrites a secret/variable that already exists on the repo by default', async () => {
+    logSpy();
+    mocked.listGhSecretNames.mockReturnValue(['OPENSHIFT_SERVER']);
+    mocked.listGhVariableNames.mockReturnValue(['OPENSHIFT_NAMESPACE']);
+
+    await provisionGithubActionsSecrets(host, {
+      ...BASE,
+      openshiftServer: 'https://api.example.com:6443',
+      openshiftNamespace: 'my-ns',
+    });
+
+    expect(mocked.setGhSecret).not.toHaveBeenCalledWith(
+      'OPENSHIFT_SERVER',
+      expect.anything(),
+      REPO,
+    );
+    expect(mocked.setGhVariable).not.toHaveBeenCalledWith(
+      'OPENSHIFT_NAMESPACE',
+      expect.anything(),
+      REPO,
+    );
+  });
+
+  it('overwrites an already-existing value only when --overwriteExisting is passed', async () => {
+    logSpy();
+    mocked.listGhSecretNames.mockReturnValue(['OPENSHIFT_SERVER']);
+
+    await provisionGithubActionsSecrets(host, {
+      ...BASE,
+      openshiftServer: 'https://api.example.com:6443',
+      overwriteExisting: true,
+    });
+
+    expect(mocked.setGhSecret).toHaveBeenCalledWith(
+      'OPENSHIFT_SERVER',
+      'https://api.example.com:6443',
+      REPO,
+    );
+  });
+});

--- a/packages/nx-agent/src/generators/agent-delivery/provision-github-secrets.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/provision-github-secrets.ts
@@ -1,0 +1,329 @@
+import { getProjects, ProjectConfiguration, Tree } from '@nx/devkit';
+import { Schema } from './schema';
+
+// Best-effort, non-interactive provisioning of agent-delivery-iteration.yml's own GitHub repo
+// secrets/variables -- see the approved plan (packages/nx-agent's PR history) for the full design.
+// Every live call here degrades to an `undetermined` item with an actionable reason rather than
+// throwing; the one hard invariant is that an item already sitting on the repo is never touched
+// unless --overwriteExisting is passed, regardless of why this run would otherwise set it.
+
+type Resolution =
+  | { source: 'explicit' | 'derived' | 'constant'; value: string }
+  | { source: 'undetermined'; reason: string };
+
+type Item = { name: string; kind: 'secret' | 'variable' } & Resolution;
+
+function explicitOr(
+  explicit: string | undefined,
+  derive: () => Resolution,
+): Resolution {
+  return explicit !== undefined ? { source: 'explicit', value: explicit } : derive();
+}
+
+// Two independent things a project can carry, written by different generators at different
+// times (nx-oc:sandbox vs. any nx-adsp app/service generator) -- resolving them as one combined
+// lookup would wrongly suppress a value that's genuinely already derivable (e.g. ADSP_ENV from a
+// scaffolded app) just because a different, unrelated one (OPENSHIFT_NAMESPACE from `sandbox`,
+// which may not have run yet) isn't ready. See the plan's "Sequencing" section.
+function getProjectConfigs(
+  host: Tree,
+  projectFilter: string | undefined,
+): { configs: [string, ProjectConfiguration][]; error?: string } {
+  if (projectFilter === undefined) {
+    return { configs: [...getProjects(host)] };
+  }
+  const config = [...getProjects(host)].find(([name]) => name === projectFilter);
+  return config
+    ? { configs: [config] }
+    : { configs: [], error: `project '${projectFilter}' not found in this workspace` };
+}
+
+function resolveConsistentValue(
+  candidates: { name: string; value: string | undefined }[],
+  notFoundReason: string,
+): Resolution {
+  const found = candidates.filter(
+    (c): c is { name: string; value: string } => c.value !== undefined,
+  );
+  if (found.length === 0) {
+    return { source: 'undetermined', reason: notFoundReason };
+  }
+  const distinct = [...new Set(found.map((f) => f.value))];
+  if (distinct.length === 1) {
+    return { source: 'derived', value: distinct[0] };
+  }
+  const detail = distinct
+    .map(
+      (v) =>
+        `${v} (${found
+          .filter((f) => f.value === v)
+          .map((f) => f.name)
+          .join(', ')})`,
+    )
+    .join('; ');
+  return {
+    source: 'undetermined',
+    reason: `ambiguous across projects -- ${detail} -- pass --project to pick one`,
+  };
+}
+
+export async function provisionGithubActionsSecrets(
+  host: Tree,
+  options: Schema,
+): Promise<void> {
+  if (!options.provisionSecrets) return;
+  if (!options.githubActions) {
+    console.log(
+      '[nx-agent] --provisionSecrets has no effect without --githubActions -- nothing to provision a workflow for. Skipping.',
+    );
+    return;
+  }
+
+  const nxOc = await import('@abgov/nx-oc').catch(() => {
+    throw new Error(
+      "The 'agent-delivery' generator's --provisionSecrets option requires '@abgov/nx-oc'. Install it and re-run:\n  npm i -D @abgov/nx-oc",
+    );
+  });
+
+  const items: Item[] = [];
+  const push = (name: string, kind: Item['kind'], resolution: Resolution) =>
+    items.push({ name, kind, ...resolution });
+
+  // --- project-derived values: namespace and tags are scanned independently (see above) ---
+  const { configs, error: projectError } = getProjectConfigs(host, options.project);
+
+  const namespace = explicitOr(options.openshiftNamespace, () =>
+    projectError
+      ? { source: 'undetermined', reason: projectError }
+      : resolveConsistentValue(
+          configs.map(([name, config]) => ({
+            name,
+            value: (
+              config.targets?.['sandbox']?.options as
+                | { sandboxProject?: string }
+                | undefined
+            )?.sandboxProject,
+          })),
+          "no project has run nx-oc:sandbox yet -- run it first, or pass --openshiftNamespace",
+        ),
+  );
+  push('OPENSHIFT_NAMESPACE', 'variable', namespace);
+
+  const env = explicitOr(options.adspEnv, () =>
+    projectError
+      ? { source: 'undetermined', reason: projectError }
+      : resolveConsistentValue(
+          configs.map(([name, config]) => ({
+            name,
+            value: nxOc.detectAdspEnv(config.tags),
+          })),
+          'no project carries an adsp:scaffold-env: tag yet -- scaffold an app/service first, or pass --adspEnv',
+        ),
+  );
+  push('ADSP_ENV', 'variable', env);
+
+  const tenantName = explicitOr(options.adspTenantName, () =>
+    projectError
+      ? { source: 'undetermined', reason: projectError }
+      : resolveConsistentValue(
+          configs.map(([name, config]) => ({
+            name,
+            value: nxOc.detectAdspTenant(config.tags),
+          })),
+          'no project carries an adsp:scaffold-tenant: tag yet -- scaffold an app/service first, or pass --adspTenantName',
+        ),
+  );
+  push('ADSP_TENANT_NAME', 'variable', tenantName);
+
+  // --- OpenShift server/token: independent of project state, dependent on local oc login ---
+  const wantsOcDerivation = !options.openshiftServer || !options.openshiftToken;
+  let ocReady = false;
+  if (wantsOcDerivation) {
+    ocReady = nxOc.isOcLoggedIn();
+    if (!ocReady && !nxOc.isNonInteractive()) {
+      try {
+        nxOc.ensureOcLogin();
+        ocReady = nxOc.isOcLoggedIn();
+      } catch {
+        ocReady = false;
+      }
+    }
+  }
+
+  const notLoggedInReason = (name: string) =>
+    `not logged in to OpenShift and this run can't prompt interactively -- run \`oc login --web\` first, or pass --${name}`;
+
+  push(
+    'OPENSHIFT_SERVER',
+    'secret',
+    explicitOr(options.openshiftServer, () => {
+      if (!ocReady) return { source: 'undetermined', reason: notLoggedInReason('openshiftServer') };
+      const server = nxOc.getOcServerUrl();
+      return server
+        ? { source: 'derived', value: server }
+        : {
+            source: 'undetermined',
+            reason: 'oc is logged in but reported no server URL -- check `oc config view`',
+          };
+    }),
+  );
+
+  push(
+    'OPENSHIFT_TOKEN',
+    'secret',
+    explicitOr(options.openshiftToken, () => {
+      if (!ocReady) return { source: 'undetermined', reason: notLoggedInReason('openshiftToken') };
+      if (namespace.source === 'undetermined') {
+        return { source: 'undetermined', reason: 'OPENSHIFT_NAMESPACE is undetermined -- see above' };
+      }
+      const saToken = nxOc.getSaToken('github-actions', namespace.value);
+      return saToken
+        ? { source: 'derived', value: saToken }
+        : {
+            source: 'undetermined',
+            reason: `could not get a token for the 'github-actions' service account in namespace '${namespace.value}' -- has it been provisioned? see nx-oc:setup-secrets`,
+          };
+    }),
+  );
+
+  // --- ADSP tenant realm + client secret: live ADSP/Keycloak calls, one admin token feeds both ---
+  let adspAdmin: { accessServiceUrl: string; realm: string; accessToken: string } | undefined;
+
+  const needsAdspAdminToken = !options.adspTenantRealm || !options.adspClientSecret;
+  if (needsAdspAdminToken && env.source !== 'undetermined') {
+    try {
+      const adsp = await nxOc.getAdspConfiguration(host, {
+        env: env.value as 'dev' | 'test' | 'prod',
+        tenant: tenantName.source !== 'undetermined' ? tenantName.value : undefined,
+        tenantRealm: options.adspTenantRealm,
+        accessToken: options.accessToken,
+      });
+      if (adsp.accessToken) {
+        adspAdmin = {
+          accessServiceUrl: adsp.accessServiceUrl,
+          realm: adsp.tenantRealm,
+          accessToken: adsp.accessToken,
+        };
+      }
+      if (!options.adspTenantRealm) {
+        push('ADSP_TENANT_REALM', 'variable', { source: 'derived', value: adsp.tenantRealm });
+      }
+    } catch (err) {
+      if (!options.adspTenantRealm) {
+        push('ADSP_TENANT_REALM', 'variable', {
+          source: 'undetermined',
+          reason: (err as Error)?.message ?? String(err),
+        });
+      }
+    }
+  } else if (!options.adspTenantRealm) {
+    push('ADSP_TENANT_REALM', 'variable', {
+      source: 'undetermined',
+      reason: 'ADSP_ENV is undetermined -- see above',
+    });
+  }
+  if (options.adspTenantRealm) {
+    push('ADSP_TENANT_REALM', 'variable', { source: 'explicit', value: options.adspTenantRealm });
+  }
+
+  push(
+    'ADSP_CLIENT_SECRET',
+    'secret',
+    await (async (): Promise<Resolution> => {
+      if (options.adspClientSecret) {
+        return { source: 'explicit', value: options.adspClientSecret };
+      }
+      if (!adspAdmin) {
+        return {
+          source: 'undetermined',
+          reason: 'no ADSP admin-scoped token available -- see ADSP_TENANT_REALM above',
+        };
+      }
+      try {
+        const status = await nxOc.getAdspCliCiStatus(
+          adspAdmin.accessServiceUrl,
+          adspAdmin.realm,
+          adspAdmin.accessToken,
+        );
+        if (!status.found) {
+          return {
+            source: 'undetermined',
+            reason: `the tenant's adsp-cli-ci Keycloak client was not found in realm '${adspAdmin.realm}' -- this shouldn't happen for a normal ADSP tenant; check with a tenant admin`,
+          };
+        }
+        if (!status.enabled) {
+          return {
+            source: 'undetermined',
+            reason:
+              `the tenant's adsp-cli-ci Keycloak client is disabled -- log in to the Keycloak admin console for realm '${adspAdmin.realm}' -> Clients -> adsp-cli-ci -> Settings -> enable it -> Credentials tab -> copy or regenerate the secret -> re-run with --adspClientSecret <secret>, or set it directly with \`gh secret set ADSP_CLIENT_SECRET\`.`,
+          };
+        }
+        return { source: 'derived', value: status.secret as string };
+      } catch (err) {
+        return { source: 'undetermined', reason: (err as Error)?.message ?? String(err) };
+      }
+    })(),
+  );
+
+  // ADSP_CLIENT_ID has no override option -- it's always this fixed constant, per @abgov/adsp-cli's
+  // own README ("the client ID is always adsp-cli-ci").
+  push('ADSP_CLIENT_ID', 'secret', { source: 'constant', value: 'adsp-cli-ci' });
+
+  if (options.maxIterations !== undefined) {
+    push('MAX_ITERATIONS', 'variable', { source: 'explicit', value: String(options.maxIterations) });
+  }
+
+  // --- Phase 2: write, never overwriting an existing value unless explicitly told to ---
+  console.log('\n[nx-agent] --provisionSecrets results:');
+
+  const remoteUrl = nxOc.getGitRemoteUrl();
+  const repo = remoteUrl ? nxOc.getGitHubRepo(remoteUrl) : undefined;
+  let canWrite = false;
+  let existingSecrets = new Set<string>();
+  let existingVariables = new Set<string>();
+
+  if (!repo) {
+    console.log(
+      '  ⚠  no GitHub remote found -- cannot write any secret/variable (values below are still reported).',
+    );
+  } else {
+    try {
+      nxOc.checkGhCli('repo');
+      existingSecrets = new Set(nxOc.listGhSecretNames(repo));
+      existingVariables = new Set(nxOc.listGhVariableNames(repo));
+      canWrite = true;
+    } catch (err) {
+      console.log(
+        `  ⚠  ${(err as Error)?.message ?? err} -- cannot write any secret/variable (values below are still reported).`,
+      );
+    }
+  }
+
+  for (const item of items) {
+    if (item.source === 'undetermined') {
+      console.log(`  ⚠  ${item.name}: ${item.reason}`);
+      continue;
+    }
+    if (!canWrite) {
+      console.log(`  •  ${item.name}: determined (not written -- see above)`);
+      continue;
+    }
+    const existingNames = item.kind === 'secret' ? existingSecrets : existingVariables;
+    if (existingNames.has(item.name) && !options.overwriteExisting) {
+      console.log(
+        `  •  ${item.name} already set on the repo -- left unchanged (pass --overwriteExisting to replace it)`,
+      );
+      continue;
+    }
+    const ok =
+      item.kind === 'secret'
+        ? nxOc.setGhSecret(item.name, item.value, repo as string)
+        : nxOc.setGhVariable(item.name, item.value, repo as string);
+    console.log(ok ? `  ✓  ${item.name} set` : `  ✗  failed to set ${item.name}`);
+  }
+
+  console.log(
+    '  ⚠  org-level Copilot CLI billing policy must still be enabled by hand (GitHub org admin console) -- ' +
+      'no repo secret/variable covers this, and its absence only surfaces later as a workflow permission failure.',
+  );
+}

--- a/packages/nx-agent/src/generators/agent-delivery/schema.d.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/schema.d.ts
@@ -1,3 +1,15 @@
 export interface Schema {
   githubActions?: boolean;
+  provisionSecrets?: boolean;
+  project?: string;
+  openshiftServer?: string;
+  openshiftToken?: string;
+  openshiftNamespace?: string;
+  adspEnv?: 'dev' | 'test' | 'prod';
+  adspTenantName?: string;
+  adspTenantRealm?: string;
+  adspClientSecret?: string;
+  maxIterations?: number;
+  accessToken?: string;
+  overwriteExisting?: boolean;
 }

--- a/packages/nx-agent/src/generators/agent-delivery/schema.json
+++ b/packages/nx-agent/src/generators/agent-delivery/schema.json
@@ -9,6 +9,57 @@
       "type": "boolean",
       "description": "Additionally scaffold the self-dispatching GitHub Actions iteration loop (.github/workflows/agent-delivery-iteration.yml, its harness/task-identification scripts, and a learnings.md header) — for driving the same skills autonomously across many iterations. Omit this for skills-only usage driven by a human or an orchestrating tool.",
       "default": false
+    },
+    "provisionSecrets": {
+      "type": "boolean",
+      "description": "Best-effort, non-interactive provisioning of the scaffolded workflow's GitHub repo secrets/variables (OPENSHIFT_SERVER, OPENSHIFT_TOKEN, OPENSHIFT_NAMESPACE, ADSP_ENV, ADSP_TENANT_NAME, ADSP_TENANT_REALM, ADSP_CLIENT_ID, ADSP_CLIENT_SECRET) — derives what it can from already-generated project state plus live oc/gh/ADSP calls, uses an explicit --openshift*/--adsp* option verbatim when one is given, and reports anything it couldn't determine as a warning with the exact manual next step. Never overwrites a secret/variable that already exists on the repo unless --overwriteExisting is also passed. Has no effect unless --githubActions is also true. Requires @abgov/nx-oc.",
+      "default": false
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope --provisionSecrets's project-derived values (OPENSHIFT_NAMESPACE, ADSP_ENV, ADSP_TENANT_NAME) to this project's own sandbox target/tags. Omit to auto-detect across every project in the workspace instead — works when exactly one project, or several with consistent values, are found; reported as undetermined and ambiguous otherwise."
+    },
+    "openshiftServer": {
+      "type": "string",
+      "description": "Explicit OPENSHIFT_SERVER value for --provisionSecrets — used verbatim, skipping the oc-based lookup."
+    },
+    "openshiftToken": {
+      "type": "string",
+      "description": "Explicit OPENSHIFT_TOKEN value for --provisionSecrets — used verbatim, skipping the oc-based lookup."
+    },
+    "openshiftNamespace": {
+      "type": "string",
+      "description": "Explicit OPENSHIFT_NAMESPACE value for --provisionSecrets — used verbatim, skipping the project-derived lookup."
+    },
+    "adspEnv": {
+      "type": "string",
+      "enum": ["dev", "test", "prod"],
+      "description": "Explicit ADSP_ENV value for --provisionSecrets — used verbatim, skipping the project-tag-derived lookup."
+    },
+    "adspTenantName": {
+      "type": "string",
+      "description": "Explicit ADSP_TENANT_NAME value for --provisionSecrets — used verbatim, skipping the project-tag-derived lookup."
+    },
+    "adspTenantRealm": {
+      "type": "string",
+      "description": "Explicit ADSP_TENANT_REALM value for --provisionSecrets — used verbatim, skipping the live tenant-service lookup."
+    },
+    "adspClientSecret": {
+      "type": "string",
+      "description": "Explicit ADSP_CLIENT_SECRET value for --provisionSecrets — used verbatim, skipping the Keycloak admin lookup. ADSP_CLIENT_ID has no equivalent option — it's always the fixed adsp-cli-ci client ID, never something to override."
+    },
+    "maxIterations": {
+      "type": "number",
+      "description": "Explicit MAX_ITERATIONS value for --provisionSecrets to write as a repo variable. Optional either way — the workflow already defaults to 6 when this variable is unset, so omitting this is not reported as undetermined."
+    },
+    "accessToken": {
+      "type": "string",
+      "description": "Pre-obtained ADSP admin-scoped access token for --provisionSecrets's ADSP_TENANT_REALM/ADSP_CLIENT_SECRET lookups — skips any adsp-cli login attempt entirely, matching the --accessToken option every nx-adsp app/service generator already exposes."
+    },
+    "overwriteExisting": {
+      "type": "boolean",
+      "description": "Allow --provisionSecrets to overwrite a secret/variable that already exists on the repo. Default is to always leave an existing one unchanged and report it as such, regardless of whether the new value would come from an explicit option, a derived value, or the adsp-cli-ci constant.",
+      "default": false
     }
   },
   "additionalProperties": false

--- a/packages/nx-oc/src/adsp/adsp-utils.spec.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.spec.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process';
+import axios from 'axios';
 import { getAccessToken } from '@abgov/adsp-cli';
 import { isNonInteractive } from '../utils/interactive';
 import {
@@ -6,6 +7,7 @@ import {
   detectAdspEnv,
   detectAdspTenant,
   ensureAdspToken,
+  getAdspCliCiStatus,
 } from './adsp-utils';
 
 jest.mock('child_process', () => ({
@@ -17,10 +19,12 @@ jest.mock('@abgov/adsp-cli', () => ({
   getAccessToken: jest.fn(),
 }));
 jest.mock('../utils/interactive', () => ({ isNonInteractive: jest.fn() }));
+jest.mock('axios');
 
 const mockedGetAccessToken = getAccessToken as jest.Mock;
 const mockedSpawnSync = spawnSync as jest.Mock;
 const mockedIsNonInteractive = isNonInteractive as jest.Mock;
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('adspProjectTags', () => {
   it('always includes the env tag', () => {
@@ -150,5 +154,64 @@ describe('ensureAdspToken', () => {
     ).rejects.toThrow();
 
     expect(process.env.ADSP_TENANT_REALM).toBeUndefined();
+  });
+});
+
+describe('getAdspCliCiStatus', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockReset();
+    mockedAxios.put.mockReset();
+  });
+
+  it('reports not found when no adsp-cli-ci client exists in the realm', async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: [] });
+
+    const status = await getAdspCliCiStatus(
+      'https://access.example.com',
+      'my-realm',
+      'tok',
+    );
+
+    expect(status).toEqual({ found: false, enabled: false });
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+  });
+
+  it('reports disabled without ever fetching a secret or enabling it', async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: [{ id: 'uuid-1', clientId: 'adsp-cli-ci', enabled: false }],
+    });
+
+    const status = await getAdspCliCiStatus(
+      'https://access.example.com',
+      'my-realm',
+      'tok',
+    );
+
+    expect(status).toEqual({ found: true, enabled: false });
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(mockedAxios.put).not.toHaveBeenCalled();
+  });
+
+  it('fetches and returns the secret when enabled', async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({
+        data: [{ id: 'uuid-1', clientId: 'adsp-cli-ci', enabled: true }],
+      })
+      .mockResolvedValueOnce({ data: { type: 'secret', value: 'shh' } });
+
+    const status = await getAdspCliCiStatus(
+      'https://access.example.com',
+      'my-realm',
+      'tok',
+    );
+
+    expect(status).toEqual({ found: true, enabled: true, secret: 'shh' });
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      2,
+      'https://access.example.com/auth/admin/realms/my-realm/clients/uuid-1/client-secret',
+      { headers: { Authorization: 'Bearer tok' } },
+    );
+    expect(mockedAxios.put).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -366,3 +366,52 @@ export async function addClientRedirectUris(
     );
   }
 }
+
+const ADSP_CLI_CI_CLIENT_ID = 'adsp-cli-ci';
+
+export interface AdspCliCiStatus {
+  found: boolean;
+  enabled: boolean;
+  // Only populated when found && enabled -- fetching it for a disabled client isn't attempted.
+  secret?: string;
+}
+
+/**
+ * Reports whether the tenant's `adsp-cli-ci` confidential client (bootstrapped disabled at
+ * tenant creation — see @abgov/adsp-cli's own README) exists, is enabled, and if so its current
+ * secret — using the same Keycloak Admin REST surface (and the same class of `adsp-cli-admin`-
+ * scoped token) `addClientRedirectUris`/`nx-adsp`'s `keycloak-admin.ts` already use.
+ *
+ * Deliberately narrow and read-only: never enables the client if it's disabled (a real tenant
+ * decision left to a human) and never regenerates the secret — a caller that finds
+ * `enabled: false` should surface manual next steps, not attempt to fix it here.
+ */
+export async function getAdspCliCiStatus(
+  accessServiceUrl: string,
+  realm: string,
+  accessToken: string,
+): Promise<AdspCliCiStatus> {
+  const base = new URL(`/auth/admin/realms/${realm}/clients`, accessServiceUrl)
+    .href;
+  const authHeader = { Authorization: `Bearer ${accessToken}` };
+
+  const { data: clients } = await axios.get<
+    { id: string; clientId: string; enabled: boolean }[]
+  >(base, {
+    params: { clientId: ADSP_CLI_CI_CLIENT_ID },
+    headers: authHeader,
+  });
+  const client = clients?.[0];
+  if (!client) {
+    return { found: false, enabled: false };
+  }
+  if (!client.enabled) {
+    return { found: true, enabled: false };
+  }
+
+  const { data: secretRepresentation } = await axios.get<{ value: string }>(
+    `${base}/${client.id}/client-secret`,
+    { headers: authHeader },
+  );
+  return { found: true, enabled: true, secret: secretRepresentation.value };
+}

--- a/packages/nx-oc/src/index.ts
+++ b/packages/nx-oc/src/index.ts
@@ -1,3 +1,7 @@
 export { default as deploymentGenerator } from './generators/deployment/deployment';
 export * from './adsp';
 export * from './generators';
+export * from './utils/gh-utils';
+export * from './utils/git-utils';
+export * from './utils/interactive';
+export * from './utils/oc-utils';

--- a/packages/nx-oc/src/utils/gh-utils.spec.ts
+++ b/packages/nx-oc/src/utils/gh-utils.spec.ts
@@ -1,6 +1,12 @@
 import { execFileSync, execSync } from 'child_process';
 import { mocked } from 'jest-mock';
-import { activeAccountScopes, checkGhCli, setGhSecret } from './gh-utils';
+import {
+  activeAccountScopes,
+  checkGhCli,
+  listGhSecretNames,
+  listGhVariableNames,
+  setGhSecret,
+} from './gh-utils';
 
 jest.mock('child_process');
 const mockedExecFileSync = mocked(execFileSync);
@@ -97,5 +103,51 @@ describe('setGhSecret', () => {
     expect(setGhSecret('OPENSHIFT_TOKEN', 'tok', 'GovAlta/nx-tools')).toBe(
       false,
     );
+  });
+});
+
+describe('listGhSecretNames', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('parses the JSON name list', () => {
+    mockedExecFileSync.mockReturnValue(
+      Buffer.from(JSON.stringify([{ name: 'A' }, { name: 'B' }])),
+    );
+    expect(listGhSecretNames('GovAlta/nx-tools')).toEqual(['A', 'B']);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['secret', 'list', '--repo', 'GovAlta/nx-tools', '--json', 'name'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('throws rather than returning [] on failure — a caller deciding whether a write is safe must never treat "could not check" the same as "confirmed absent"', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('gh: not found');
+    });
+    expect(() => listGhSecretNames('GovAlta/nx-tools')).toThrow();
+  });
+});
+
+describe('listGhVariableNames', () => {
+  beforeEach(() => mockedExecFileSync.mockReset());
+
+  it('parses the JSON name list', () => {
+    mockedExecFileSync.mockReturnValue(
+      Buffer.from(JSON.stringify([{ name: 'X' }])),
+    );
+    expect(listGhVariableNames('GovAlta/nx-tools')).toEqual(['X']);
+    expect(mockedExecFileSync).toHaveBeenCalledWith(
+      'gh',
+      ['variable', 'list', '--repo', 'GovAlta/nx-tools', '--json', 'name'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('throws on failure, same as listGhSecretNames', () => {
+    mockedExecFileSync.mockImplementation(() => {
+      throw new Error('gh: not found');
+    });
+    expect(() => listGhVariableNames('GovAlta/nx-tools')).toThrow();
   });
 });

--- a/packages/nx-oc/src/utils/gh-utils.ts
+++ b/packages/nx-oc/src/utils/gh-utils.ts
@@ -84,6 +84,28 @@ export function setGhVariable(
   }
 }
 
+// Existing-secret/-variable names, so a caller can decide not to overwrite one that's already
+// set — GitHub never exposes a secret's *value* once set (by design), so presence is the only
+// thing checkable either way. Deliberately throws rather than returning [] on failure: an empty
+// result is indistinguishable from "genuinely nothing set yet", and a caller using it to decide
+// whether a write is safe must never treat "couldn't check" the same as "confirmed absent" — that
+// would make an overwrite-guard fail open exactly when it matters most.
+export function listGhSecretNames(repo: string): string[] {
+  const raw = execFileSync('gh', ['secret', 'list', '--repo', repo, '--json', 'name'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).toString();
+  return JSON.parse(raw).map((s: { name: string }) => s.name);
+}
+
+export function listGhVariableNames(repo: string): string[] {
+  const raw = execFileSync(
+    'gh',
+    ['variable', 'list', '--repo', repo, '--json', 'name'],
+    { stdio: ['pipe', 'pipe', 'pipe'] },
+  ).toString();
+  return JSON.parse(raw).map((v: { name: string }) => v.name);
+}
+
 // Prompts (masked) for a GitHub PAT. Returns undefined if the prompt is
 // cancelled or left empty. Callers that already hold a PAT (e.g. the pipeline
 // generator prompting once for several steps) pass it through and skip this.

--- a/packages/nx-oc/src/utils/oc-utils.spec.ts
+++ b/packages/nx-oc/src/utils/oc-utils.spec.ts
@@ -2,6 +2,7 @@ import { execFileSync, spawnSync } from 'child_process';
 import { mocked } from 'jest-mock';
 import {
   ensureOcLogin,
+  isOcLoggedIn,
   runOcCommand,
   getOcServerUrl,
   getSaToken,
@@ -77,6 +78,44 @@ describe('runOcCommand', () => {
     const result = runOcCommand('start-build', ['my-pipeline']);
     expect(result.success).toBe(false);
     expect(result.stdout).toBeUndefined();
+  });
+});
+
+describe('isOcLoggedIn', () => {
+  beforeEach(() => {
+    mockedExecFileSync.mockReset();
+    mockedSpawnSync.mockReset();
+  });
+
+  it('returns true when already logged in, without ever spawning an interactive login', () => {
+    mockedExecFileSync.mockReturnValueOnce(
+      Buffer.from('Client Version: 4.14.0'),
+    ); // oc version --client
+    mockedExecFileSync.mockReturnValueOnce(Buffer.from('developer')); // oc whoami
+
+    expect(isOcLoggedIn()).toBe(true);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('returns false, not throw, when oc is not installed', () => {
+    mockedExecFileSync.mockImplementationOnce(() => {
+      throw new Error('oc: command not found');
+    });
+
+    expect(isOcLoggedIn()).toBe(false);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('returns false, without ever spawning an interactive login, when not logged in', () => {
+    mockedExecFileSync.mockReturnValueOnce(
+      Buffer.from('Client Version: 4.14.0'),
+    ); // oc version --client
+    mockedExecFileSync.mockImplementationOnce(() => {
+      throw new Error('not logged in');
+    }); // oc whoami
+
+    expect(isOcLoggedIn()).toBe(false);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/nx-oc/src/utils/oc-utils.ts
+++ b/packages/nx-oc/src/utils/oc-utils.ts
@@ -190,6 +190,19 @@ export function runOcCommand(
   }
 }
 
+// Same preflight checks as ensureOcLogin's own opening two try/catches, but never falls through
+// to an interactive `oc login --web` — for a caller that needs to know login status without
+// risking a block in a non-interactive run (ensureOcLogin itself is right for every other case).
+export function isOcLoggedIn(): boolean {
+  try {
+    execFileSync('oc', ['version', '--client'], { stdio: 'pipe' });
+    execFileSync('oc', ['whoami'], { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function ensureOcLogin(): void {
   try {
     execFileSync('oc', ['version', '--client'], { stdio: 'pipe' });


### PR DESCRIPTION
## Summary

`agent-delivery --githubActions` scaffolds a workflow needing 8 GitHub repo secrets/variables
(`OPENSHIFT_SERVER`, `OPENSHIFT_TOKEN`, `OPENSHIFT_NAMESPACE`, `ADSP_ENV`, `ADSP_TENANT_NAME`,
`ADSP_TENANT_REALM`, `ADSP_CLIENT_ID`, `ADSP_CLIENT_SECRET`) plus optional `MAX_ITERATIONS`, all
previously left entirely to a human. Adds `--provisionSecrets`: best-effort, non-interactive
derivation of what it can, with an explicit value always used verbatim in place of derivation, and
an existing repo secret/variable never overwritten unless `--overwriteExisting` is passed.

### What gets derived, and from where
- `OPENSHIFT_NAMESPACE` ← a project's own `sandbox` target's `sandboxProject` option.
- `ADSP_ENV`/`ADSP_TENANT_NAME` ← that project's `adsp:scaffold-env:`/`adsp:scaffold-tenant:` tags.
- `OPENSHIFT_SERVER`/`OPENSHIFT_TOKEN` ← a live local `oc` session (never blocks — a new
  `isOcLoggedIn()` check avoids `ensureOcLogin()`'s interactive fallback when non-interactive).
- `ADSP_TENANT_REALM` ← the same anonymous tenant-service lookup `getAdspConfiguration` already
  does, reused as-is — so it's guaranteed to agree with whatever `ADSP_ENV`/`ADSP_TENANT_NAME` end
  up set to, closing a "two resolution paths can disagree silently" risk.
- `ADSP_CLIENT_SECRET` ← a new `getAdspCliCiStatus()` helper in `nx-oc`'s Keycloak admin surface —
  **deliberately never enables the client if it's disabled**, per explicit instruction; reports the
  exact manual steps instead.
- `ADSP_CLIENT_ID` is never a lookup — always the fixed `adsp-cli-ci` constant.

### Safety properties
- **Never overwrites an existing value.** New `listGhSecretNames`/`listGhVariableNames` in
  `gh-utils.ts` check presence once up front; an item already on the repo is skipped by default
  regardless of whether this run would otherwise set it from an explicit option, a derived value,
  or the `adsp-cli-ci` constant. `--overwriteExisting` opts in.
- **No required generator order.** The namespace signal (`sandbox` target) and the env/tenant
  signal (scaffold tags) are two *independent* project scans — they're written by different
  generators at different times, so running this before `nx-oc:sandbox` still resolves the
  tag-derived values instead of wrongly reporting everything as undetermined.
- **Never hangs.** Every live call has a non-interactive path (a new `isOcLoggedIn()`, the existing
  `ensureAdspToken` non-interactive throw, an `--accessToken` bypass matching every `nx-adsp` app
  generator's own option) — worst case is an `undetermined` item with a real, actionable reason.

### Notable side effects
- `gh-utils`/`oc-utils`/`git-utils`/`interactive` were internal-only in `nx-oc` — now exported from
  its public entry point for this new cross-package reuse.
- `@abgov/nx-oc` is a new **optional** peer of `nx-agent` (lazy-loaded via `await import(...)`,
  matching `nx-adsp`'s own pattern for its optional framework peers) — most `nx-agent` generators
  have nothing to do with ADSP/OpenShift and shouldn't require installing it.

## Test plan
- [x] `npx nx test,lint,build nx-agent,nx-oc` (and `nx-adsp`, affected transitively) — clean, 218 +
  148 + 103 tests
- [x] Unit coverage per the approved plan: explicit-only, project-tag/sandbox-target derivation,
  the decoupled-scan/ordering case (tags resolve with no `sandbox` target yet), zero-project
  workspace, multi-project ambiguity, the disabled-`adsp-cli-ci` case (exact warning text, no
  enable attempt), non-interactive mode with nothing cached, `gh` unauthenticated, never-overwrite,
  and `--overwriteExisting`
- [x] **Real dogfood against this dev environment's actual `oc`/`gh`/ADSP state, not just mocks**:
  `OPENSHIFT_SERVER` derived for real from a live local `oc` session; a real ADSP tenant-service
  call correctly reported an unknown tenant (`Tenant 'some-tenant' not found.`); a real
  `gh secret list` 403 correctly aborted every write while still reporting everything Phase 1 had
  already determined