### PR TITLE
fix(nx-adsp): correct react-app's AGENTS.md event-handling pattern

### DIFF
--- a/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/react-app/files/AGENTS.md__tmpl__
@@ -64,14 +64,15 @@ from `@abgov/react-components` over those components:
 import { GoabButton, GoabAppHeader, GoabButtonGroup } from '@abgov/react-components';
 ```
 
-**Events**: GoA React components use `onGoab*` handlers (not standard React synthetic
-events); the payload is on `e.detail`:
+**Events**: GoA React components use plain `onClick`/`onChange` handlers, not the
+`onGoab*`/`e.detail` pattern some other GoA framework wrappers use. `onChange` receives its
+detail object directly as the callback's sole argument — never wrapped in a synthetic event:
 
 ```tsx
-<GoabButton onGoabClick={handleSave}>Save</GoabButton>
-<GoabInput onGoabChange={(e) => setValue(e.detail.value)} />
-<GoabDropdown onGoabChange={(e) => setSelected(e.detail.value)} />
-<GoabCheckbox onGoabChange={(e) => setChecked(e.detail.checked)} />
+<GoabButton onClick={handleSave}>Save</GoabButton>
+<GoabInput onChange={(detail) => setValue(detail.value)} />
+<GoabDropdown onChange={(detail) => setSelected(detail.value)} />
+<GoabCheckbox onChange={(detail) => setChecked(detail.checked)} />
 ```
 
 Event `detail` shapes vary by component — check the component's gallery page or the

--- a/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.spec.ts
@@ -99,6 +99,20 @@ describe('React App Generator', () => {
     expect(agents).not.toContain('ui-components.alberta.ca');
   }, 30000);
 
+  it('AGENTS.md documents the real onClick/onChange event pattern, not the never-real onGoab*/e.detail one', async () => {
+    // @abgov/react-components has never exposed onGoab*-prefixed handlers or wrapped a
+    // callback's payload in e.detail -- onChange receives its detail object directly. Regression
+    // guard: this doc text drifted from the real API without the generated app code ever being
+    // affected (app.tsx has always used plain onClick), so nothing else would have caught it.
+    const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    await generator(host, options);
+    const agents = host.read('apps/test/AGENTS.md').toString();
+    expect(agents).not.toContain('onGoabClick');
+    expect(agents).not.toContain('onGoabChange');
+    expect(agents).not.toMatch(/e\.detail\.(value|checked)/);
+    expect(agents).toContain('onChange={(detail) => setValue(detail.value)}');
+  }, 30000);
+
   it('can add nginx proxy', async () => {
     const host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     await generator(host, {


### PR DESCRIPTION
## Summary

`react-app`'s generated `AGENTS.md`'s "GoA design system" section documented an event-handling
pattern that never matched the real, installed `@abgov/react-components` API: `onGoab*`-prefixed
handlers (`onGoabClick`, `onGoabChange`) with the payload on `e.detail`. Confirmed directly against
the real package's own `.d.ts`: every component (`GoabButton`, `GoabInput`, `GoabDropdown`,
`GoabCheckbox`) uses plain `onClick`/`onChange`, and `onChange` receives its detail object
directly as the callback's sole argument — never wrapped in a synthetic event.

The generated app code itself was never affected — `app.tsx__tmpl__` has always used plain
`onClick` — this was purely a documentation-accuracy gap. The real risk was downstream: a
developer or coding agent writing *new* event-handling code in a generated app, trusting this
doc, would write a prop that doesn't exist on any installed component.

Rewrote the section and its example to the real `onClick`/`onChange` pattern.

**Checked the sibling generators for the same class of bug** — `angular-app`'s and `vue-app`'s own
`AGENTS.md__tmpl__` templates each already document their own, differently-shaped, correct event
patterns:
- `angular-app`: `(onClick)`/`(onChange)` output bindings — confirmed against the real
  `@abgov/angular-components@5.3.0` `.d.ts` (`GoabButton.onClick: EventEmitter<any>`, alias
  `"onClick"`, etc.).
- `vue-app`: documents two real, distinct layers accurately — raw `goa-*` web components
  genuinely do use `_`-prefixed events with `.detail.value`/`.detail.checked` (a true description
  of the actual custom element), and the `Goab*` convenience wrappers normalize that into real
  `v-model` — confirmed against `GoabInput.vue__tmpl__`'s actual source, which really does consume
  `.detail.value` internally and expose `v-model` externally, exactly as documented.

So this bug is isolated to `react-app`.

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — clean, 104 tests (1 new)
- [x] New regression guard: generated `AGENTS.md` must not contain `onGoabClick`/`onGoabChange`/
  `e.detail.value`/`e.detail.checked`, and must contain the corrected
  `onChange={(detail) => setValue(detail.value)}` example
- [x] Verified the real event API directly against the installed `@abgov/react-components`,
  `@abgov/angular-components`, and the `vue-components` wrapper templates' own source — not taken
  on faith