### PR TITLE
feat(nx-adsp): add --layout=internal (side-menu shell) to vue-app

### DIFF
--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -266,6 +266,19 @@ describe('nx-adsp e2e', () => {
       expect(result.stdout).toContain('Successfully ran target');
     }, 240000);
 
+    // --layout=internal is a distinct EJS branch in App.vue's template, not just
+    // a prop value -- only a real build (real Vue SFC compile) can catch a
+    // template/script error in that branch that tree-content unit tests can't see.
+    it('--layout=internal should generate and build', async () => {
+      const plugin = uniq('vue-app');
+      await runNxCommandAsync(
+        `generate @abgov/nx-adsp:vue-app ${plugin} dev --tenant=test --accessToken=mock-token --skipAgent --layout=internal`,
+      );
+      checkFilesExist(`${plugin}/src/App.vue`, `${plugin}/src/stores/session.ts`);
+      const result = await runNxCommandAsync(`build ${plugin}`);
+      expect(result.stdout).toContain('Successfully ran target');
+    }, 240000);
+
     // vue-app co-generates the shared vue-components wrapper lib. Guard the real
     // out-of-the-box breakages tree-content unit tests can't see.
     // Not exercised here (both need a different workspace flavour than this legacy
@@ -281,6 +294,7 @@ describe('nx-adsp e2e', () => {
         'vue-components/src/index.ts',
         'vue-components/src/lib/primitives/GoabModal.vue',
         'vue-components/src/lib/patterns/AppHeader.vue',
+        'vue-components/src/lib/patterns/AppSideMenu.vue',
         'vue-components/src/vue-components.spec.ts',
       );
 

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -31,7 +31,11 @@ executors read options from `project.json` and do not prompt.
 | File | Purpose |
 |------|---------|
 | `src/main.ts` | Entry — registers Pinia, Router, and Keycloak plugin (incl. `onAuthRefreshError`, which flags the session store as expired) |
+<% if (layout === 'internal') { %>
+| `src/App.vue` | Shell — `AppSideMenu` (side-menu shell, Sign in/out as an account item), `SessionExpiredBanner`, `<RouterView>` wrapped in `AppLayout` |
+<% } else { %>
 | `src/App.vue` | Shell — `AppHeader` with sign-in/out in its `utilities` slot, `SessionExpiredBanner`, hero banner, `<RouterView>` wrapped in `AppLayout`, `AppFooter` |
+<% } %>
 | `src/stores/session.ts` | Pinia store — `expired` flag behind `SessionExpiredBanner`, set from `main.ts`'s `onAuthRefreshError` hook |
 | `src/router/index.ts` | Routes — `/protected` guarded with `requiresAuth` meta |
 | `src/views/HomeView.vue` | Public page — calls public and private APIs |
@@ -155,12 +159,27 @@ across every Vue app in this workspace — fix or extend a wrapper once in
 > stopgap until GoA DS ships an official `@abgov/vue-components`. When it lands,
 > delete `primitives/` and repoint imports at that package — the names/props are
 > intended to match, so it's a scope swap. This does **not** apply to the
-> `AppHeader`/`AppLayout`/`AppFooter`/`SessionExpiredBanner` shell components
-> below — those live in the same library's `patterns/` folder and are permanent
-> (app-shell composition has no equivalent in a design-system package).
+> `AppHeader`/`AppLayout`/`AppFooter`/`AppSideMenu`/`SessionExpiredBanner` shell
+> components below — those live in the same library's `patterns/` folder and are
+> permanent (app-shell composition has no equivalent in a design-system package).
 
 ### App shell components
 
+This app was generated with **`--layout=<%= layout %>`**.
+<% if (layout === 'internal') { %>
+`App.vue` is a staff-facing, side-menu shell built from shared components imported
+from **`<%= goaImportPath %>`**, not hand-rolled markup:
+
+| Component | Purpose |
+|---|---|
+| `AppSideMenu` | `goa-work-side-menu`. Takes `heading`/`primaryItems`/`secondaryItems`/`accountItems` props (each item: `{ label, to?, icon?, badge?, current? }`) and emits `itemClick` — it doesn't know about routing or auth, so `App.vue` computes `current`/handles the click itself. `App.vue` currently only populates `accountItems` (a single Sign in/out item); add real nav items to `primaryItems`/`secondaryItems` as routes are added |
+| `AppLayout` | The content gutter every view renders inside (see the key files table). Also renders the skip-to-main-content link |
+| `SessionExpiredBanner` | A `v-model:show` banner with `signIn`/`dismiss` emits. Bound to the `useSessionStore()` Pinia store (`src/stores/session.ts`), which `main.ts`'s `onAuthRefreshError` hook flips when the refresh token itself has expired |
+
+There's no `AppHeader`/`AppFooter`/hero banner in this layout — `AppSideMenu` is the
+whole top-level shell, matching the real GoA "internal portal" pattern (no public
+marketing chrome around a staff tool).
+<% } else { %>
 `App.vue` is built from four shared components imported from
 **`<%= goaImportPath %>`**, not hand-rolled markup:
 
@@ -170,9 +189,15 @@ across every Vue app in this workspace — fix or extend a wrapper once in
 | `AppLayout` | The content gutter every view renders inside (see the key files table). Also renders the skip-to-main-content link |
 | `AppFooter` | `goa-app-footer` with the standard GoA nav/meta links (Services/Contact/Terms of Use, Privacy/Disclaimer/Accessibility) |
 | `SessionExpiredBanner` | A `v-model:show` banner with `signIn`/`dismiss` emits. Bound to the `useSessionStore()` Pinia store (`src/stores/session.ts`), which `main.ts`'s `onAuthRefreshError` hook flips when the refresh token itself has expired |
-
+<% } %>
 These are shared across every Vue app in this workspace — fix or extend one once
 in `libs/vue-components/src/lib/patterns/`, the same way as the `Goab*` wrappers.
+
+A second, **`--layout=<%= layout === 'internal' ? 'header' : 'internal' %>`** frontend
+can be scaffolded against the same backend with `nx g @abgov/nx-adsp:vue-app <name>
+--pairedProject <%= pairedProject || 'your-backend-project' %> --layout=<%= layout === 'internal' ? 'header' : 'internal' %>`
+— a public-facing app and a staff-facing one sharing one API, without a separate
+composite generator.
 
 ## Adding a view
 

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.spec.ts__tmpl__
@@ -34,7 +34,32 @@ const router = createRouter({
   history: createMemoryHistory(),
   routes: [{ path: '/', component: { template: '<div />' } }],
 });
+<% if (layout === 'internal') { %>
+describe('App shell (internal / side-menu)', () => {
+  it('shows a Sign in account item when unauthenticated', () => {
+    const wrapper = mount(App, {
+      global: { plugins: [router, createPinia()], stubs: { RouterView: true } },
+    });
+    const item = wrapper.find('goa-work-side-menu-item[label="Sign in"]');
+    expect(item.exists()).toBe(true);
+  });
 
+  it('clicking the account item calls keycloak.login (guards against lost reactivity)', async () => {
+    // Same bug class as the header shell: destructuring useKeycloak() would
+    // freeze `keycloak` at undefined, so login() would be a permanent no-op.
+    const kc = useKeycloak();
+    const wrapper = mount(App, {
+      global: { plugins: [router, createPinia()], stubs: { RouterView: true } },
+    });
+    // AppSideMenu binds @click.prevent directly on goa-work-side-menu-item (not
+    // an underscore-prefixed event, unlike the goa-* form elements) -- trigger
+    // a plain 'click'.
+    const item = wrapper.find('goa-work-side-menu-item[label="Sign in"]');
+    await item.trigger('click');
+    expect(kc.keycloak?.login).toHaveBeenCalled();
+  });
+});
+<% } else { %>
 describe('App shell header', () => {
   it('shows Sign in when unauthenticated', () => {
     const wrapper = mount(App, {
@@ -57,7 +82,7 @@ describe('App shell header', () => {
     expect(kc.keycloak?.login).toHaveBeenCalled();
   });
 });
-
+<% } %>
 describe('App shell session-expired banner', () => {
   it('is hidden until the session store flags an expired session', async () => {
     const pinia = createPinia();

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -2,7 +2,11 @@
 import { computed } from 'vue';
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
 import { RouterView, useRoute } from 'vue-router';
+<% if (layout === 'internal') { %>
+import { AppLayout, AppSideMenu, SessionExpiredBanner } from '<%= goaImportPath %>';
+<% } else { %>
 import { AppHeader, AppLayout, AppFooter, SessionExpiredBanner } from '<%= goaImportPath %>';
+<% } %>
 import { useSessionStore } from './stores/session';
 
 // Keep the reactive instance — do NOT destructure. useKeycloak() returns a
@@ -15,7 +19,7 @@ const session = useSessionStore();
 // Content width per view, from route meta (default 'page'). Views opt into a
 // different width with `meta: { layout: 'wide' | 'form' }` in the router.
 const route = useRoute();
-const layout = computed(
+const contentWidth = computed(
   () => (route.meta.layout as 'page' | 'wide' | 'form' | undefined) ?? 'page'
 );
 
@@ -26,9 +30,40 @@ function signInAgain() {
   session.dismiss();
   kc.keycloak?.login();
 }
+<% if (layout === 'internal') { %>
+
+// AppSideMenu's account items are presentational -- it doesn't know about
+// Keycloak, it just renders whatever's passed and emits itemClick on click.
+const accountItems = computed(() => [
+  kc.authenticated
+    ? { label: kc.fullName ? `Sign out (${kc.fullName})` : 'Sign out' }
+    : { label: 'Sign in' },
+]);
+
+function onAccountItemClick() {
+  if (kc.authenticated) logout();
+  else login();
+}
+<% } %>
 </script>
 
 <template>
+<% if (layout === 'internal') { %>
+  <AppSideMenu
+    heading="<%= projectName %>"
+    :account-items="accountItems"
+    @item-click="onAccountItemClick"
+  >
+    <SessionExpiredBanner
+      v-model:show="session.expired"
+      @sign-in="signInAgain"
+      @dismiss="session.dismiss"
+    />
+    <AppLayout :variant="contentWidth">
+      <RouterView />
+    </AppLayout>
+  </AppSideMenu>
+<% } else { %>
   <AppHeader heading="<%= projectName %>">
     <template #utilities>
       <goa-button-group alignment="end">
@@ -51,10 +86,11 @@ function signInAgain() {
     @dismiss="session.dismiss"
   />
   <goa-hero-banner heading="<%= projectName %>" backgroundurl="/assets/banner.jpg" />
-  <AppLayout :variant="layout">
+  <AppLayout :variant="contentWidth">
     <RouterView />
   </AppLayout>
   <AppFooter />
+<% } %>
 </template>
 
 <style>

--- a/packages/nx-adsp/src/generators/vue-app/schema.d.ts
+++ b/packages/nx-adsp/src/generators/vue-app/schema.d.ts
@@ -13,6 +13,8 @@ export interface Schema {
   skipAgent?: boolean;
   /** Name of an existing backend service project to derive the nginx/dev-server proxy and the adsp:proxy-service: sandbox tag from. */
   pairedProject?: string;
+  /** Top-level app shell: 'header' (default, public-facing) or 'internal' (staff-facing side menu, no header/banner/footer). */
+  layout?: 'header' | 'internal';
 }
 
 export interface NormalizedSchema extends Schema {

--- a/packages/nx-adsp/src/generators/vue-app/schema.json
+++ b/packages/nx-adsp/src/generators/vue-app/schema.json
@@ -83,6 +83,12 @@
       "type": "boolean",
       "description": "Skip the consultAgent interaction and generate base scaffolding only.",
       "default": false
+    },
+    "layout": {
+      "type": "string",
+      "description": "Top-level app shell: 'header' is a goa-app-header + hero banner + footer (public-facing). 'internal' is a goa-work-side-menu shell with no header/banner/footer (staff-facing). Both wrap views in the same AppLayout content gutter. Pair two vue-app runs against the same --pairedProject (once each) for a public+internal frontend pairing over one backend.",
+      "enum": ["header", "internal"],
+      "default": "header"
     }
   },
   "required": ["name", "env"],

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -172,6 +172,7 @@ describe('Vue App Generator', () => {
       'AppLayout',
       'AppHeader',
       'AppFooter',
+      'AppSideMenu',
       'SessionExpiredBanner',
     ]) {
       expect(host.exists(`${patterns}/${name}.vue`)).toBeTruthy();
@@ -183,6 +184,35 @@ describe('Vue App Generator', () => {
     );
     expect(app).toContain('<AppHeader heading="test">');
     expect(app).toContain('<AppFooter />');
+  }, 30000);
+
+  it('--layout=internal generates an AppSideMenu shell instead of AppHeader/AppFooter', async () => {
+    await generator(host, { ...options, layout: 'internal' });
+
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).toContain(
+      "import { AppLayout, AppSideMenu, SessionExpiredBanner } from '@proj/vue-components';",
+    );
+    expect(app).not.toContain('AppHeader');
+    expect(app).not.toContain('AppFooter');
+    expect(app).not.toContain('goa-hero-banner');
+    expect(app).toContain('<AppSideMenu');
+    expect(app).toContain('heading="test"');
+    expect(app).toContain(':account-items="accountItems"');
+    expect(app).toContain('@item-click="onAccountItemClick"');
+    // The content gutter is shared regardless of shell choice.
+    expect(app).toContain('<AppLayout');
+
+    const agents = host.read('apps/test/AGENTS.md').toString();
+    expect(agents).toContain('--layout=internal');
+    expect(agents).toContain('AppSideMenu');
+  }, 30000);
+
+  it('defaults --layout to header when omitted', async () => {
+    await generator(host, options);
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).toContain('AppHeader');
+    expect(app).not.toContain('AppSideMenu');
   }, 30000);
 
   it('wires SessionExpiredBanner to a session store fed by onAuthRefreshError (not onAuthLogout)', async () => {

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -71,6 +71,7 @@ async function normalizeOptions(
     adsp,
     nginxProxies,
     pairedProjectTag: paired?.tag,
+    layout: options.layout ?? 'header',
   };
 }
 

--- a/packages/nx-adsp/src/generators/vue-components/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/AGENTS.md__tmpl__
@@ -7,7 +7,7 @@ app in this workspace imports both instead of carrying its own copy. Generated b
 | Folder | Contains | Lifespan |
 |---|---|---|
 | `src/lib/primitives/` | Thin `v-model`/idiomatic-event wrappers over individual `goa-*` elements (`GoabInput`, `GoabButton`, …) | **Interim** — see below |
-| `src/lib/patterns/` | Composite, app-shell components (`AppLayout`, `AppHeader`, `AppFooter`, `SessionExpiredBanner`) | **Permanent** |
+| `src/lib/patterns/` | Composite, app-shell components (`AppLayout`, `AppHeader`, `AppFooter`, `AppSideMenu`, `SessionExpiredBanner`) | **Permanent** |
 
 > **⚠️ `primitives/` is interim — do not invest in it as permanent.** It exists
 > only because GoA DS has not yet published an official Vue wrapper package. When
@@ -142,7 +142,7 @@ detail); just leave it to fall through from the caller.
 
 A pattern component is app-shell composition — layout, header/footer chrome,
 banners — not a single-element wrapper. Existing examples: `AppLayout`,
-`AppHeader`, `AppFooter`, `SessionExpiredBanner`.
+`AppHeader`, `AppFooter`, `AppSideMenu`, `SessionExpiredBanner`.
 
 - It's fine to compose `primitives/` wrappers inside a pattern component (e.g.
   `SessionExpiredBanner` uses `GoabButton`) — import them with a relative path

--- a/packages/nx-adsp/src/generators/vue-components/files/src/index.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/index.ts__tmpl__
@@ -20,4 +20,5 @@ export { default as GoabModal } from './lib/primitives/GoabModal.vue';
 export { default as AppLayout } from './lib/patterns/AppLayout.vue';
 export { default as AppHeader } from './lib/patterns/AppHeader.vue';
 export { default as AppFooter } from './lib/patterns/AppFooter.vue';
+export { default as AppSideMenu } from './lib/patterns/AppSideMenu.vue';
 export { default as SessionExpiredBanner } from './lib/patterns/SessionExpiredBanner.vue';

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppSideMenu.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppSideMenu.vue__tmpl__
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+// The alternate top-level shell for staff-facing/internal apps (goa-work-side-menu),
+// used instead of AppHeader/AppFooter -- not together with them. Presentational only:
+// unlike the real GovAlta-Pronghorn source this is adapted from, active-route
+// highlighting and navigation are the caller's job (pass `current` on each item,
+// listen for `item-click`) so this component doesn't need vue-router as a dependency.
+interface AppSideMenuItem {
+  label: string;
+  to?: string;
+  icon?: string;
+  badge?: string;
+  current?: boolean;
+}
+
+withDefaults(
+  defineProps<{
+    heading?: string;
+    userName?: string;
+    primaryItems?: AppSideMenuItem[];
+    secondaryItems?: AppSideMenuItem[];
+    accountItems?: AppSideMenuItem[];
+  }>(),
+  {
+    primaryItems: () => [],
+    secondaryItems: () => [],
+    accountItems: () => [],
+  },
+);
+
+const emit = defineEmits<{ itemClick: [item: AppSideMenuItem] }>();
+</script>
+
+<template>
+  <div class="app-side-menu">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <goa-work-side-menu :heading="heading" :user-name="userName">
+      <goa-work-side-menu-item
+        v-for="item in primaryItems"
+        :key="item.label"
+        slot="primary"
+        :icon="item.icon"
+        :label="item.label"
+        :url="item.to"
+        :current="item.current"
+        @click.prevent="emit('itemClick', item)"
+      />
+      <goa-work-side-menu-item
+        v-for="item in secondaryItems"
+        :key="item.label"
+        slot="secondary"
+        :icon="item.icon"
+        :label="item.label"
+        :badge="item.badge"
+        @click.prevent="emit('itemClick', item)"
+      />
+      <goa-work-side-menu-item
+        v-for="item in accountItems"
+        :key="item.label"
+        slot="account"
+        :label="item.label"
+        :url="item.to"
+        @click.prevent="emit('itemClick', item)"
+      />
+    </goa-work-side-menu>
+    <main id="main-content" class="app-side-menu-content">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.app-side-menu {
+  min-height: 100vh;
+  display: flex;
+}
+
+.app-side-menu-content {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 100;
+  padding: var(--goa-space-s, 0.5rem) var(--goa-space-m, 1rem);
+  background: var(--goa-color-interactive-default, #0070c4);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: var(--goa-space-m, 1rem);
+}
+</style>

--- a/packages/nx-adsp/src/generators/vue-components/files/src/vue-components.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/vue-components.spec.ts__tmpl__
@@ -24,6 +24,7 @@ describe('vue-components', () => {
       'AppLayout',
       'AppHeader',
       'AppFooter',
+      'AppSideMenu',
       'SessionExpiredBanner',
     ]) {
       expect(lib[name as keyof typeof lib]).toBeTruthy();

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -41,6 +41,7 @@ describe('Vue Components Generator', () => {
       'AppLayout',
       'AppHeader',
       'AppFooter',
+      'AppSideMenu',
       'SessionExpiredBanner',
     ]) {
       expect(host.exists(`${patterns}/${name}.vue`)).toBeTruthy();


### PR DESCRIPTION
## Summary
Tier 1 of the Vue UX-pattern proposal: a `goa-work-side-menu` shell as an alternative to the `goa-app-header` shell.

- New `AppSideMenu` pattern component in `vue-components`, adapted from real GovAlta-Pronghorn source (`goa-work-side-menu` with primary/secondary/account item slots) but kept presentational — routing and active-route highlighting are the caller's job via props/`itemClick` emit, so it doesn't pull in `vue-router` as a dependency (unlike the real source it's based on).
- `--layout=header|internal` (default `header`) on `vue-app`, resolved at **generation time** via an EJS conditional in `App.vue`'s template — not a runtime prop. The original proposal assumed reusing `AppLayout`'s `variant` prop for this, but that prop already means content-width (`page`/`wide`/`form`); I caught that naming collision before writing any code and designed around it instead. `AppLayout` itself is completely unchanged and still provides the content gutter inside either shell.
- `router/index.ts`, the views, and `main.ts` are identical regardless of `--layout` — only `App.vue`'s shell markup/imports differ. `--pairedProject` already covers pairing a second, opposite-layout frontend against the same backend (run `vue-app` twice) — no new composite generator needed.

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — green (108 tests)
- [x] New Jest coverage: `--layout=internal` generates the right imports/template and omits `AppHeader`/`AppFooter`/hero banner; `--layout` defaults to `header` when omitted; both branches' generated `App.spec.ts` variant is layout-aware
- [x] New e2e test (`nx-adsp-e2e`) generates a real `--layout=internal` app and runs `build` — a real Vite/Vue SFC compile of the EJS-branched template, not just string assertions
- [x] Manually printed both branches' real generated `App.vue`/`App.spec.ts`/`AGENTS.md` output via a throwaway script (not committed) and read them — caught and fixed one real bug this way: EJS's `<%= %>` HTML-escapes its output, so a `<backend-project>` placeholder inside an interpolated fallback rendered as literal `&lt;backend-project&gt;` in the generated `AGENTS.md`; fixed by dropping the angle brackets from the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)