### PR TITLE
feat(nx-adsp): add vue-intake-view generator (Tier 3, second half)

### DIFF
--- a/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
+++ b/e2e/nx-adsp-e2e/tests/nx-adsp.spec.ts
@@ -381,6 +381,34 @@ describe('nx-adsp e2e', () => {
     }, 240000);
   });
 
+  describe('vue intake view', () => {
+    it('retrofits a multi-step intake wizard into an existing vue-app and builds', async () => {
+      const plugin = uniq('vue-app');
+      await runNxCommandAsync(
+        `generate @abgov/nx-adsp:vue-app ${plugin} dev --tenant=test --accessToken=mock-token --skipAgent`,
+      );
+      await runNxCommandAsync(
+        `generate @abgov/nx-adsp:vue-intake-view ${plugin} application --resource=applications --route=/applications --steps='[{"key":"personal-info","label":"Personal information","fields":[{"key":"fullName","label":"Full name"}]},{"key":"contact-info","label":"Contact information","fields":[{"key":"email","label":"Email"}]}]'`,
+      );
+      checkFilesExist(
+        `${plugin}/src/views/PersonalInfoStepView.vue`,
+        `${plugin}/src/views/ContactInfoStepView.vue`,
+        `${plugin}/src/views/ApplicationReviewView.vue`,
+        `${plugin}/src/views/ApplicationConfirmationView.vue`,
+      );
+      const routerTs = readFileSync(
+        join(tmpProjPath(), `${plugin}/src/router/index.ts`),
+        'utf-8',
+      );
+      expect(routerTs).toContain("path: '/applications/:id/personal-info'");
+      expect(routerTs).toContain("path: '/applications/:id/review'");
+      expect(routerTs).toContain("path: '/applications/:id/confirmation'");
+
+      const result = await runNxCommandAsync(`build ${plugin}`);
+      expect(result.stdout).toContain('Successfully ran target');
+    }, 240000);
+  });
+
   it('should generate angular app and build', async () => {
     const plugin = uniq('angular-app');
     await runNxCommandAsync(

--- a/packages/nx-adsp/generators.json
+++ b/packages/nx-adsp/generators.json
@@ -75,6 +75,11 @@
       "schema": "./src/generators/vue-admin-crud/schema.json",
       "description": "Generator that adds a simple admin CRUD screen pair (WorkspaceTable list + create/update Edit view) to an existing vue-app project."
     },
+    "vue-intake-view": {
+      "factory": "./src/generators/vue-intake-view/vue-intake-view",
+      "schema": "./src/generators/vue-intake-view/schema.json",
+      "description": "Generator that adds a route-per-step intake wizard (Stepper + a required review/confirmation flow, from a --steps spec) to an existing vue-app project."
+    },
     "mean": {
       "factory": "./src/generators/mean/mean",
       "schema": "./src/generators/mean/schema.json",

--- a/packages/nx-adsp/src/generators/vue-components/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/AGENTS.md__tmpl__
@@ -7,7 +7,7 @@ app in this workspace imports both instead of carrying its own copy. Generated b
 | Folder | Contains | Lifespan |
 |---|---|---|
 | `src/lib/primitives/` | Thin `v-model`/idiomatic-event wrappers over individual `goa-*` elements (`GoabInput`, `GoabButton`, …) | **Interim** — see below |
-| `src/lib/patterns/` | Composite, app-shell components (`AppLayout`, `AppHeader`, `AppFooter`, `AppSideMenu`, `SessionExpiredBanner`, `RecordDetailShell`, `WorkspaceTable`) | **Permanent** |
+| `src/lib/patterns/` | Composite, app-shell components (`AppLayout`, `AppHeader`, `AppFooter`, `AppSideMenu`, `SessionExpiredBanner`, `RecordDetailShell`, `WorkspaceTable`, `Stepper`, `StepErrorSummary`) | **Permanent** |
 
 > **⚠️ `primitives/` is interim — do not invest in it as permanent.** It exists
 > only because GoA DS has not yet published an official Vue wrapper package. When
@@ -142,7 +142,8 @@ detail); just leave it to fall through from the caller.
 
 A pattern component is app-shell composition — layout, header/footer chrome,
 banners — not a single-element wrapper. Existing examples: `AppLayout`,
-`AppHeader`, `AppFooter`, `AppSideMenu`, `SessionExpiredBanner`, `RecordDetailShell`, `WorkspaceTable`.
+`AppHeader`, `AppFooter`, `AppSideMenu`, `SessionExpiredBanner`, `RecordDetailShell`, `WorkspaceTable`,
+`Stepper`, `StepErrorSummary`.
 
 - It's fine to compose `primitives/` wrappers inside a pattern component (e.g.
   `SessionExpiredBanner` uses `GoabButton`) — import them with a relative path

--- a/packages/nx-adsp/src/generators/vue-components/files/src/index.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/index.ts__tmpl__
@@ -24,3 +24,5 @@ export { default as AppSideMenu } from './lib/patterns/AppSideMenu.vue';
 export { default as SessionExpiredBanner } from './lib/patterns/SessionExpiredBanner.vue';
 export { default as RecordDetailShell } from './lib/patterns/RecordDetailShell.vue';
 export { default as WorkspaceTable } from './lib/patterns/WorkspaceTable.vue';
+export { default as Stepper } from './lib/patterns/Stepper.vue';
+export { default as StepErrorSummary } from './lib/patterns/StepErrorSummary.vue';

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/StepErrorSummary.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/StepErrorSummary.vue__tmpl__
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+// Hand-rolled, not a wrapper -- checked the real, currently-installed
+// @abgov/web-components (grepped the compiled index.js for "error-summary"):
+// no such element exists, only CSS tokens for error *styling* on other
+// components (input, checkbox, radio, ...). Built from goa-callout instead,
+// matching the standard error-summary a11y pattern (a list of links jumping to
+// each invalid field) rather than inventing something with no real precedent.
+export interface StepError {
+  message: string;
+  /** e.g. '#field-email' -- an id on the invalid field's goa-form-item. */
+  anchor?: string;
+}
+
+defineProps<{ errors: StepError[] }>();
+</script>
+
+<template>
+  <goa-callout v-if="errors.length" type="emergency" heading="There is a problem">
+    <ul>
+      <li v-for="(error, index) in errors" :key="index">
+        <a v-if="error.anchor" :href="error.anchor">{{ error.message }}</a>
+        <span v-else>{{ error.message }}</span>
+      </li>
+    </ul>
+  </goa-callout>
+</template>

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/Stepper.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/Stepper.vue__tmpl__
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+// Wraps the real, native goa-form-stepper/goa-form-step pair (confirmed via
+// design.alberta.ca/components/form-stepper -- there wasn't one when the spec
+// this is based on was written, hence "nobody used a native GoA stepper"; that
+// gap has since closed, so this wraps the real thing rather than hand-rolling
+// custom step icons/connectors like older reference implementations did).
+//
+// goa-form-step's own status enum is only complete/incomplete/not-started --
+// there's no "current" value, so the caller decides what "current" looks like
+// (typically: incomplete). Its docs also say "Don't use FormStepper for
+// non-sequential navigation" -- this component just re-emits every step's
+// click as `select`; which clicks are actually honoured (e.g. only completed
+// steps, plus a review step) is the consuming view's job, not this one's.
+export interface StepperStep {
+  key: string;
+  label: string;
+  status: 'complete' | 'incomplete' | 'not-started';
+}
+
+const props = defineProps<{ steps: StepperStep[] }>();
+const emit = defineEmits<{ select: [key: string] }>();
+</script>
+
+<template>
+  <goa-form-stepper>
+    <goa-form-step
+      v-for="(step, index) in props.steps"
+      :key="step.key"
+      :text="step.label"
+      :status="step.status"
+      :last="index === props.steps.length - 1"
+      @_click="emit('select', step.key)"
+    />
+  </goa-form-stepper>
+</template>

--- a/packages/nx-adsp/src/generators/vue-components/files/src/vue-components.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/vue-components.spec.ts__tmpl__
@@ -28,6 +28,8 @@ describe('vue-components', () => {
       'SessionExpiredBanner',
       'RecordDetailShell',
       'WorkspaceTable',
+      'Stepper',
+      'StepErrorSummary',
     ]) {
       expect(lib[name as keyof typeof lib]).toBeTruthy();
     }

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -45,6 +45,8 @@ describe('Vue Components Generator', () => {
       'SessionExpiredBanner',
       'RecordDetailShell',
       'WorkspaceTable',
+      'Stepper',
+      'StepErrorSummary',
     ]) {
       expect(host.exists(`${patterns}/${name}.vue`)).toBeTruthy();
     }

--- a/packages/nx-adsp/src/generators/vue-intake-view/files/shared/src/views/__confirmationViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-intake-view/files/shared/src/views/__confirmationViewFileName__.vue__tmpl__
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+</script>
+
+<template>
+  <div>
+    <goa-callout type="success" heading="Submitted">
+      <p>
+        Your reference number is <strong>{{ route.params.id }}</strong>. Keep this for your
+        records.
+      </p>
+    </goa-callout>
+
+    <goa-spacer vspacing="m" />
+
+    <p>You'll be notified of any updates. No further action is needed right now.</p>
+  </div>
+</template>

--- a/packages/nx-adsp/src/generators/vue-intake-view/files/shared/src/views/__reviewViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-intake-view/files/shared/src/views/__reviewViewFileName__.vue__tmpl__
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { GoabCheckbox } from '<%= goaImportPath %>';
+
+const route = useRoute();
+const router = useRouter();
+
+const idParam = computed(() => String(route.params.id ?? ''));
+
+// The fetched record's shape isn't known to this generator -- read fields
+// defensively rather than declaring (and likely getting wrong) a fake interface.
+const record = ref<Record<string, unknown> | null>(null);
+const loading = ref(true);
+const loadError = ref<string | null>(null);
+const declared = ref(false);
+const submitting = ref(false);
+const submitError = ref<string | null>(null);
+
+async function load() {
+  loading.value = true;
+  loadError.value = null;
+  try {
+    const res = await fetch(`/api/<%= resource %>/${idParam.value}`);
+    if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+    record.value = await res.json();
+  } catch (e) {
+    loadError.value = e instanceof Error ? e.message : 'Failed to load.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+
+function editStep(key: string) {
+  router.push(`<%= route %>/${idParam.value}/${key}`);
+}
+
+async function onSubmit() {
+  if (!declared.value) return;
+  submitting.value = true;
+  submitError.value = null;
+  try {
+    const res = await fetch(`/api/<%= resource %>/${idParam.value}/submit`, {
+      method: 'POST',
+    });
+    if (!res.ok) throw new Error(`Failed to submit (${res.status})`);
+    router.push(`<%= route %>/${idParam.value}/confirmation`);
+  } catch (e) {
+    submitError.value = e instanceof Error ? e.message : 'Failed to submit.';
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<template>
+  <div>
+    <h1>Review your <%= baseName %></h1>
+
+    <div v-if="loading" aria-label="Loading">
+      <goa-skeleton type="text" size="3" />
+    </div>
+
+    <goa-callout v-else-if="loadError" type="emergency" heading="Unable to load">
+      <p>{{ loadError }}</p>
+    </goa-callout>
+
+    <template v-else-if="record">
+<% steps.forEach(function (step) { -%>
+      <goa-container accent="thin">
+        <div class="review-section-header">
+          <h2><%- step.label %></h2>
+          <goa-button type="tertiary" size="compact" @_click="editStep('<%- step.key %>')">
+            Edit
+          </goa-button>
+        </div>
+        <dl>
+<% step.fields.forEach(function (field) { -%>
+          <dt><%- field.label %></dt>
+          <dd>{{ record['<%- field.key %>'] ?? '—' }}</dd>
+<% }); -%>
+        </dl>
+      </goa-container>
+      <goa-spacer vspacing="m" />
+<% }); -%>
+
+      <GoabCheckbox
+        v-model="declared"
+        name="declaration"
+        text="I confirm the information above is accurate and complete."
+      />
+
+      <goa-callout v-if="submitError" type="emergency" heading="Submit failed">
+        <p>{{ submitError }}</p>
+      </goa-callout>
+
+      <goa-spacer vspacing="l" />
+
+      <goa-button-group gap="relaxed">
+        <goa-button
+          type="primary"
+          :disabled="!declared || submitting || undefined"
+          @_click="onSubmit"
+        >
+          Submit
+        </goa-button>
+      </goa-button-group>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.review-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--goa-space-m);
+}
+</style>

--- a/packages/nx-adsp/src/generators/vue-intake-view/files/steps/src/views/__stepViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-intake-view/files/steps/src/views/__stepViewFileName__.vue__tmpl__
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { reactive, ref, computed, onMounted } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { Stepper, StepErrorSummary, GoabInput } from '<%= goaImportPath %>';
+
+const STEPS = [
+<% stepperSteps.forEach(function (step) { -%>
+  { key: '<%- step.key %>', label: '<%- step.label %>' },
+<% }); -%>
+];
+
+const route = useRoute();
+const router = useRouter();
+
+const idParam = computed(() => String(route.params.id ?? ''));
+const isNew = computed(() => idParam.value === 'new' || idParam.value === '');
+
+const form = reactive({
+<% stepFields.forEach(function (field) { -%>
+  <%- field.key %>: '',
+<% }); -%>
+});
+
+const errors = ref<{ message: string; anchor?: string }[]>([]);
+const completedSteps = ref<string[]>([]);
+const loading = ref(!isNew.value);
+const saving = ref(false);
+const loadError = ref<string | null>(null);
+const saveError = ref<string | null>(null);
+
+// completedSteps drives the stepper's status per step. This assumes the API
+// persists and returns a `completedSteps: string[]` field on the resource --
+// document that contract if your backend doesn't have it yet.
+const stepperSteps = computed(() =>
+  STEPS.map((step) => ({
+    key: step.key,
+    label: step.label,
+    status: completedSteps.value.includes(step.key)
+      ? ('complete' as const)
+      : step.key === '<%- stepKey %>'
+        ? ('incomplete' as const)
+        : ('not-started' as const),
+  })),
+);
+
+async function load() {
+  if (isNew.value) return;
+  loading.value = true;
+  loadError.value = null;
+  try {
+    const res = await fetch(`/api/<%= resource %>/${idParam.value}`);
+    if (!res.ok) throw new Error(`Failed to load (${res.status})`);
+    const data = await res.json();
+    completedSteps.value = Array.isArray(data.completedSteps) ? data.completedSteps : [];
+<% stepFields.forEach(function (field) { -%>
+    if (data['<%- field.key %>'] !== undefined) form.<%- field.key %> = data['<%- field.key %>'];
+<% }); -%>
+  } catch (e) {
+    loadError.value = e instanceof Error ? e.message : 'Failed to load.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(load);
+
+function validate(): boolean {
+  const found: { message: string; anchor?: string }[] = [];
+<% stepFields.forEach(function (field) { -%>
+<% if (field.required !== false) { -%>
+  if (!form.<%- field.key %> || !form.<%- field.key %>.trim()) {
+    found.push({ message: '<%- field.label %> is required.', anchor: '#field-<%- field.key %>' });
+  }
+<% } -%>
+<% }); -%>
+  errors.value = found;
+  return found.length === 0;
+}
+
+// goa-form-stepper's own docs say not to use it for non-sequential navigation
+// -- only already-complete steps and the review step are honoured here, not
+// an arbitrary future step.
+function onStepperSelect(key: string) {
+  if (key === '<%- stepKey %>') return;
+  if (completedSteps.value.includes(key) || key === 'review') {
+    router.push(`<%= route %>/${idParam.value}/${key}`);
+  }
+}
+
+async function onSaveAndContinue() {
+  if (!validate()) return;
+  saving.value = true;
+  saveError.value = null;
+  try {
+    const body = {
+      ...form,
+      completedSteps: [...new Set([...completedSteps.value, '<%- stepKey %>'])],
+    };
+    const res = await fetch(
+      isNew.value ? '/api/<%= resource %>' : `/api/<%= resource %>/${idParam.value}`,
+      {
+        method: isNew.value ? 'POST' : 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!res.ok) throw new Error(`Failed to save (${res.status})`);
+    const saved = await res.json();
+    const nextId = isNew.value ? saved.id : idParam.value;
+    router.push(`<%= route %>/${nextId}/<%- nextStepKey %>`);
+  } catch (e) {
+    saveError.value = e instanceof Error ? e.message : 'Failed to save.';
+  } finally {
+    saving.value = false;
+  }
+}
+
+function goBack() {
+  router.back();
+}
+</script>
+
+<template>
+  <div>
+    <Stepper :steps="stepperSteps" @select="onStepperSelect" />
+
+    <goa-spacer vspacing="l" />
+
+    <h1><%- stepLabel %></h1>
+
+    <div v-if="loading" aria-label="Loading">
+      <goa-skeleton type="text" size="3" />
+    </div>
+
+    <goa-callout v-else-if="loadError" type="emergency" heading="Unable to load">
+      <p>{{ loadError }}</p>
+    </goa-callout>
+
+    <template v-else>
+      <StepErrorSummary :errors="errors" />
+
+<% stepFields.forEach(function (field) { -%>
+      <goa-form-item id="field-<%- field.key %>" label="<%- field.label %>"<% if (field.required !== false) { %> requirement="required"<% } %>>
+        <GoabInput v-model="form.<%- field.key %>" name="<%- field.key %>" type="text" />
+      </goa-form-item>
+<% }); -%>
+
+      <goa-callout v-if="saveError" type="emergency" heading="Save failed">
+        <p>{{ saveError }}</p>
+      </goa-callout>
+
+      <goa-spacer vspacing="l" />
+
+      <goa-button-group gap="relaxed">
+        <goa-button type="primary" :disabled="saving || undefined" @_click="onSaveAndContinue">
+          Save and continue
+        </goa-button>
+        <goa-button type="secondary" @_click="goBack">Back</goa-button>
+      </goa-button-group>
+    </template>
+  </div>
+</template>

--- a/packages/nx-adsp/src/generators/vue-intake-view/schema.d.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/schema.d.ts
@@ -1,0 +1,33 @@
+export interface IntakeViewField {
+  key: string;
+  label: string;
+  required?: boolean;
+}
+
+export interface IntakeViewStep {
+  key: string;
+  label: string;
+  fields: IntakeViewField[];
+}
+
+export interface Schema {
+  project: string;
+  name: string;
+  resource: string;
+  route: string;
+  /**
+   * JSON string on the real CLI (Nx's array-typed CLI coercion only supports
+   * comma-separated primitives, not JSON). A real array is also accepted for
+   * programmatic callers (e.g. tests).
+   */
+  steps: string | IntakeViewStep[];
+  requiresAuth?: boolean;
+}
+
+export interface NormalizedSchema extends Omit<Schema, 'steps'> {
+  projectRoot: string;
+  steps: IntakeViewStep[];
+  requiresAuth: boolean;
+  /** PascalCase base name, e.g. "Application" for --name application. */
+  baseName: string;
+}

--- a/packages/nx-adsp/src/generators/vue-intake-view/schema.json
+++ b/packages/nx-adsp/src/generators/vue-intake-view/schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAdspVueIntakeView",
+  "title": "Vue Multi-Step Intake View",
+  "description": "Generates a route-per-step intake wizard (Stepper + StepErrorSummary, a required read-only review step, and a confirmation page) into an existing vue-app project. Cross-step state is server-persisted -- each step PUTs/POSTs to /api/<resource>/:id and refetches on mount; there's no client-side draft caching.",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The vue-app project to add the views to.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      },
+      "x-prompt": "Which project should the intake view be added to?"
+    },
+    "name": {
+      "type": "string",
+      "description": "Base name for the generated views, e.g. 'application' generates <Step>StepView.vue per step plus ApplicationReviewView.vue and ApplicationConfirmationView.vue.",
+      "$default": {
+        "$source": "argv",
+        "index": 1
+      },
+      "x-prompt": "What should the intake flow be called?"
+    },
+    "resource": {
+      "type": "string",
+      "description": "API resource path segment. Each step fetches/saves /api/<resource>/:id; the review step's Submit posts /api/<resource>/:id/submit."
+    },
+    "route": {
+      "type": "string",
+      "description": "Base route, e.g. /applications. Steps become /applications/:id/<step-key>, plus /applications/:id/review and /applications/:id/confirmation. Start a new intake at /applications/new/<first-step-key>."
+    },
+    "steps": {
+      "type": "string",
+      "description": "JSON array of steps, in order -- e.g. '[{\"key\":\"personal-info\",\"label\":\"Personal information\",\"fields\":[{\"key\":\"fullName\",\"label\":\"Full name\"}]}]'. Each item: { key, label, fields: [{ key, label, required?: boolean (default true) }] }. A plain array is also accepted when this generator is invoked programmatically. Every field is currently a plain text input -- see the generated AGENTS.md note for other field types."
+    },
+    "requiresAuth": {
+      "type": "boolean",
+      "description": "Whether the generated routes require authentication.",
+      "default": true
+    }
+  },
+  "required": ["project", "name", "resource", "route", "steps"],
+  "additionalProperties": false
+}

--- a/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.spec.ts
@@ -1,0 +1,194 @@
+import {
+  addProjectConfiguration,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import generator from './vue-intake-view';
+import { Schema } from './schema';
+
+// Mirrors the shape vue-app's own template generates -- vue-intake-view retrofits
+// into this file, so the fixture must match what it actually looks for.
+const ROUTER_FIXTURE = `import { createRouter, createWebHistory } from 'vue-router';
+import HomeView from '../views/HomeView.vue';
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL),
+  routes: [
+    { path: '/', component: HomeView },
+  ],
+});
+
+export default router;
+`;
+
+describe('Vue Intake View Generator', () => {
+  let host: Tree;
+  const baseOptions: Schema = {
+    project: 'test',
+    name: 'application',
+    resource: 'applications',
+    route: '/applications',
+    steps: [
+      {
+        key: 'personal-info',
+        label: 'Personal information',
+        fields: [{ key: 'fullName', label: 'Full name' }],
+      },
+      {
+        key: 'contact-info',
+        label: 'Contact information',
+        fields: [
+          { key: 'email', label: 'Email' },
+          { key: 'phone', label: 'Phone', required: false },
+        ],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    addProjectConfiguration(host, 'test', { root: 'apps/test' });
+    host.write('apps/test/src/router/index.ts', ROUTER_FIXTURE);
+  });
+
+  it('throws when --project does not exist', async () => {
+    await expect(
+      generator(host, { ...baseOptions, project: 'no-such-app' }),
+    ).rejects.toThrow();
+  });
+
+  it("throws a clear error when the project isn't a vue-app (no router/index.ts)", async () => {
+    addProjectConfiguration(host, 'not-vue', { root: 'apps/not-vue' });
+    await expect(
+      generator(host, { ...baseOptions, project: 'not-vue' }),
+    ).rejects.toThrow(/router\/index\.ts/);
+  });
+
+  it('throws a clear error on a duplicate step key', async () => {
+    await expect(
+      generator(host, {
+        ...baseOptions,
+        steps: [
+          { key: 'a', label: 'A', fields: [] },
+          { key: 'a', label: 'A again', fields: [] },
+        ],
+      }),
+    ).rejects.toThrow(/duplicate step key/);
+  });
+
+  it('throws a clear error when --steps parses to an empty array', async () => {
+    await expect(
+      generator(host, { ...baseOptions, steps: '[]' }),
+    ).rejects.toThrow(/non-empty/);
+  });
+
+  it('generates one view per step, using the shared Stepper/StepErrorSummary and the real goa-form-stepper status enum', async () => {
+    await generator(host, baseOptions);
+
+    const step1 = host
+      .read('apps/test/src/views/PersonalInfoStepView.vue')
+      .toString();
+    expect(step1).toContain(
+      "import { Stepper, StepErrorSummary, GoabInput } from '@proj/vue-components';",
+    );
+    expect(step1).toContain("{ key: 'personal-info', label: 'Personal information' }");
+    expect(step1).toContain("{ key: 'contact-info', label: 'Contact information' }");
+    // Own step is 'incomplete' when active and not yet completed, per the real
+    // goa-form-step status enum (complete/incomplete/not-started -- no "current").
+    expect(step1).toContain("step.key === 'personal-info'");
+    expect(step1).toContain("('incomplete' as const)");
+    expect(step1).toContain("('not-started' as const)");
+    // Moves to the next step's key on save.
+    expect(step1).toContain('/applications/${nextId}/contact-info');
+
+    const step2 = host
+      .read('apps/test/src/views/ContactInfoStepView.vue')
+      .toString();
+    // Last step in the list moves to review, not another step.
+    expect(step2).toContain('/applications/${nextId}/review');
+    // A required field gets a validation block + requirement="required"; an
+    // explicitly non-required one gets neither.
+    expect(step2).toContain("found.push({ message: 'Email is required.'");
+    expect(step2).toContain('requirement="required"');
+    expect(step2).not.toContain('Phone is required');
+  }, 30000);
+
+  it('generates a review view listing every step with an Edit link, and a declaration gate on Submit', async () => {
+    await generator(host, baseOptions);
+
+    const review = host.read('apps/test/src/views/ApplicationReviewView.vue').toString();
+    expect(review).toContain("editStep('personal-info')");
+    expect(review).toContain("editStep('contact-info')");
+    expect(review).toContain("record['fullName'] ?? '—'");
+    expect(review).toContain("record['email'] ?? '—'");
+    expect(review).toContain(':disabled="!declared || submitting || undefined"');
+    expect(review).toContain("fetch(`/api/applications/${idParam.value}/submit`");
+    expect(review).toContain('/applications/${idParam.value}/confirmation');
+  }, 30000);
+
+  it('generates a confirmation view showing the reference number', async () => {
+    await generator(host, baseOptions);
+    const confirmation = host
+      .read('apps/test/src/views/ApplicationConfirmationView.vue')
+      .toString();
+    expect(confirmation).toContain('{{ route.params.id }}');
+  }, 30000);
+
+  it('inserts a route for every step plus review and confirmation, requiring auth by default', async () => {
+    await generator(host, baseOptions);
+
+    const routerTs = host.read('apps/test/src/router/index.ts').toString();
+    expect(routerTs).toContain("path: '/applications/:id/personal-info'");
+    expect(routerTs).toContain("path: '/applications/:id/contact-info'");
+    expect(routerTs).toContain("path: '/applications/:id/review'");
+    expect(routerTs).toContain("path: '/applications/:id/confirmation'");
+    expect(routerTs).toContain(
+      "component: () => import('../views/PersonalInfoStepView.vue')",
+    );
+    expect(routerTs).toContain(
+      "component: () => import('../views/ApplicationReviewView.vue')",
+    );
+    expect(routerTs).toContain(
+      "component: () => import('../views/ApplicationConfirmationView.vue')",
+    );
+    expect(
+      routerTs.split('meta: { requiresAuth: true }').length - 1,
+    ).toBe(4);
+    // The existing route is untouched, not replaced.
+    expect(routerTs).toContain("{ path: '/', component: HomeView }");
+  }, 30000);
+
+  it('omits the requiresAuth meta on every generated route when --requiresAuth=false', async () => {
+    await generator(host, { ...baseOptions, requiresAuth: false });
+    const routerTs = host.read('apps/test/src/router/index.ts').toString();
+    expect(routerTs).not.toContain('requiresAuth');
+  }, 30000);
+
+  it('accepts --steps as a JSON string, the form the real CLI produces', async () => {
+    await generator(host, {
+      ...baseOptions,
+      steps: JSON.stringify(baseOptions.steps),
+    });
+    expect(
+      host.exists('apps/test/src/views/PersonalInfoStepView.vue'),
+    ).toBeTruthy();
+  }, 30000);
+
+  it('ensures the shared Stepper and StepErrorSummary pattern components exist', async () => {
+    await generator(host, baseOptions);
+    expect(
+      host.exists('libs/vue-components/src/lib/patterns/Stepper.vue'),
+    ).toBeTruthy();
+    expect(
+      host.exists('libs/vue-components/src/lib/patterns/StepErrorSummary.vue'),
+    ).toBeTruthy();
+  }, 30000);
+
+  it('does not touch the target project configuration', async () => {
+    const before = readProjectConfiguration(host, 'test');
+    await generator(host, baseOptions);
+    const after = readProjectConfiguration(host, 'test');
+    expect(after).toEqual(before);
+  }, 30000);
+});

--- a/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.ts
@@ -1,0 +1,125 @@
+import {
+  formatFiles,
+  generateFiles,
+  names,
+  readProjectConfiguration,
+  Tree,
+} from '@nx/devkit';
+import * as path from 'path';
+import { insertVueRoute } from '../../utils/vue-router';
+import vueComponentsGenerator, {
+  vueComponentsImportPath,
+} from '../vue-components/vue-components';
+import { IntakeViewStep, NormalizedSchema, Schema } from './schema';
+
+// Nx's own CLI option coercion (coerceTypesInOptions in nx/src/utils/params)
+// only knows how to split an array-typed option on commas -- it has no JSON
+// support, so a real `"type": "array"` schema for --steps silently mangles a
+// JSON array into garbage fragments when invoked from the actual CLI (only
+// programmatic callers, like this generator's own unit tests, ever pass a
+// real array). --steps is `"type": "string"` in schema.json specifically so
+// Nx leaves it alone, and this generator parses the JSON itself.
+function parseSteps(steps: Schema['steps']): IntakeViewStep[] {
+  const parsed = typeof steps === 'string' ? JSON.parse(steps) : steps;
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(
+      '--steps must be a non-empty JSON array of { key, label, fields } objects.',
+    );
+  }
+  const keys = new Set<string>();
+  for (const step of parsed) {
+    if (keys.has(step.key)) {
+      throw new Error(`--steps has a duplicate step key: "${step.key}".`);
+    }
+    keys.add(step.key);
+  }
+  return parsed;
+}
+
+function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
+  const { root: projectRoot } = readProjectConfiguration(host, options.project);
+  return {
+    ...options,
+    projectRoot,
+    steps: parseSteps(options.steps),
+    requiresAuth: options.requiresAuth ?? true,
+    baseName: names(options.name).className,
+  };
+}
+
+// PascalCase view name for a step, e.g. "personal-info" -> "PersonalInfoStepView".
+function stepViewFileName(stepKey: string): string {
+  return `${names(stepKey).className}StepView`;
+}
+
+export default async function (host: Tree, options: Schema) {
+  const normalizedOptions = normalizeOptions(host, options);
+  const { projectRoot, steps, baseName } = normalizedOptions;
+
+  // Idempotent -- ensures Stepper/StepErrorSummary exist even in a project
+  // scaffolded before vue-components carried them.
+  await vueComponentsGenerator(host);
+
+  const goaImportPath = vueComponentsImportPath(host);
+  const reviewViewFileName = `${baseName}ReviewView`;
+  const confirmationViewFileName = `${baseName}ConfirmationView`;
+
+  const stepperSteps = steps.map((step) => ({
+    key: step.key,
+    label: step.label,
+  }));
+
+  steps.forEach((step, index) => {
+    const nextStepKey =
+      index === steps.length - 1 ? 'review' : steps[index + 1].key;
+
+    generateFiles(
+      host,
+      path.join(__dirname, 'files/steps'),
+      projectRoot,
+      {
+        ...normalizedOptions,
+        goaImportPath,
+        stepViewFileName: stepViewFileName(step.key),
+        stepKey: step.key,
+        stepLabel: step.label,
+        stepFields: step.fields,
+        stepperSteps,
+        nextStepKey,
+        tmpl: '',
+      },
+    );
+  });
+
+  generateFiles(host, path.join(__dirname, 'files/shared'), projectRoot, {
+    ...normalizedOptions,
+    goaImportPath,
+    reviewViewFileName,
+    confirmationViewFileName,
+    tmpl: '',
+  });
+
+  // Registered in reverse so the final router file lists steps in forward
+  // order (each insertVueRoute call adds right after `routes: [`, pushing
+  // earlier insertions down).
+  insertVueRoute(host, projectRoot, options.project, {
+    path: `${normalizedOptions.route}/:id/confirmation`,
+    componentImportPath: `../views/${confirmationViewFileName}.vue`,
+    requiresAuth: normalizedOptions.requiresAuth,
+  });
+  insertVueRoute(host, projectRoot, options.project, {
+    path: `${normalizedOptions.route}/:id/review`,
+    componentImportPath: `../views/${reviewViewFileName}.vue`,
+    requiresAuth: normalizedOptions.requiresAuth,
+  });
+  for (let i = steps.length - 1; i >= 0; i--) {
+    const step = steps[i];
+    insertVueRoute(host, projectRoot, options.project, {
+      path: `${normalizedOptions.route}/:id/${step.key}`,
+      componentImportPath: `../views/${stepViewFileName(step.key)}.vue`,
+      requiresAuth: normalizedOptions.requiresAuth,
+    });
+  }
+
+  await formatFiles(host);
+}


### PR DESCRIPTION
## Summary
Second of Tier 3's two generators from the Vue UX-pattern proposal — a route-per-step intake wizard with a required review step and confirmation page.

Checked the real, currently-installed `@abgov/web-components` before building the two new shared components, rather than trusting the original spec's assumptions:
- A real, documented `goa-form-stepper`/`goa-form-step` pair now exists (design.alberta.ca/components/form-stepper) — the "nobody used a native GoA stepper" gap that originally motivated a shared `Stepper` component has since closed. `Stepper.vue` wraps the real element instead of hand-rolling custom step icons/connectors like the real reference implementation this was modeled on (`SectionStepper.vue`) did. `goa-form-step`'s `status` enum is only `complete`/`incomplete`/`not-started` — no "current" value — and its own docs say not to use it for non-sequential navigation, so `Stepper` just re-emits every click; which ones the consuming view actually honours (only already-complete steps, plus review) is its job.
- **No `goa-error-summary` component exists at all** (grepped the real compiled `index.js` — zero matches beyond CSS tokens for error styling on other components). `StepErrorSummary.vue` is hand-rolled from `goa-callout`, correcting the original proposal's "wrapping goa-error-summary" framing.

`vue-intake-view` generates one view per `--steps` entry (route-per-step, not a monolithic component, per the spec) via `generateFiles` called once per step with per-step template options, plus a shared review view (per-section Edit links, a declaration checkbox gating Submit) and a confirmation view (reference number). Cross-step state is server-persisted (PUT/POST per step, refetch on mount, no client-side draft caching). Registers N+2 routes via the shared `insertVueRoute` util.

**Scoped down deliberately**: field types are text-only for this pass, matching the same scope-narrowing already applied to the three earlier Tier 2/3 generators — documented in the schema as a follow-up.

## Test plan
- [x] `npx nx test,lint,build nx-adsp` — green (150 tests)
- [x] Unit coverage: missing `--project`, non-vue-app project, duplicate step keys, empty `--steps`, per-step view content (stepper list, own-step status, next-step navigation, required vs. non-required field validation), review view (per-section Edit links, declaration gate, submit endpoint), confirmation view, all N+2 routes inserted in the right order with `requiresAuth` on/off, JSON-string `--steps`, idempotent `Stepper`/`StepErrorSummary` provisioning, target project config untouched
- [x] Manually printed all 4 generated view files + the router edit via a throwaway script (not committed) and read them — clean output, no templating artifacts
- [x] New e2e test: generates a real `vue-app`, retrofits a 2-step intake wizard into it, and runs `build` (a real Vite/Vue SFC compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)