### PR TITLE
fix(nx-adsp): stop AppLayout duplicating the skip-link/main landmark

### DIFF
--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -172,8 +172,8 @@ from **`<%= goaImportPath %>`**, not hand-rolled markup:
 
 | Component | Purpose |
 |---|---|
-| `AppSideMenu` | `goa-work-side-menu`. Takes `heading`/`primaryItems`/`secondaryItems`/`accountItems` props (each item: `{ label, to?, icon?, badge?, current? }`) and emits `itemClick` — it doesn't know about routing or auth, so `App.vue` computes `current`/handles the click itself. `App.vue` currently only populates `accountItems` (a single Sign in/out item); add real nav items to `primaryItems`/`secondaryItems` as routes are added |
-| `AppLayout` | The content gutter every view renders inside (see the key files table). Also renders the skip-to-main-content link |
+| `AppSideMenu` | `goa-work-side-menu`. Takes `heading`/`primaryItems`/`secondaryItems`/`accountItems` props (each item: `{ label, to?, icon?, badge?, current? }`) and emits `itemClick` — it doesn't know about routing or auth, so `App.vue` computes `current`/handles the click itself. `App.vue` currently only populates `accountItems` (a single Sign in/out item); add real nav items to `primaryItems`/`secondaryItems` as routes are added. Also owns the skip-to-main-content landmark for this layout — `AppLayout` deliberately doesn't duplicate it |
+| `AppLayout` | The content gutter every view renders inside (see the key files table) |
 | `SessionExpiredBanner` | A `v-model:show` banner with `signIn`/`dismiss` emits. Bound to the `useSessionStore()` Pinia store (`src/stores/session.ts`), which `main.ts`'s `onAuthRefreshError` hook flips when the refresh token itself has expired |
 
 There's no `AppHeader`/`AppFooter`/hero banner in this layout — `AppSideMenu` is the
@@ -186,7 +186,7 @@ marketing chrome around a staff tool).
 | Component | Purpose |
 |---|---|
 | `AppHeader` | `goa-microsite-header` + `goa-app-header`. Takes a `heading` prop; put account/sign-in actions in its `utilities` slot (a bare child with no slot is silently dropped by `goa-app-header`) |
-| `AppLayout` | The content gutter every view renders inside (see the key files table). Also renders the skip-to-main-content link |
+| `AppLayout` | The content gutter every view renders inside (see the key files table). `App.vue` itself owns the skip-to-main-content landmark for this layout — `AppLayout` deliberately doesn't duplicate it |
 | `AppFooter` | `goa-app-footer` with the standard GoA nav/meta links (Services/Contact/Terms of Use, Privacy/Disclaimer/Accessibility) |
 | `SessionExpiredBanner` | A `v-model:show` banner with `signIn`/`dismiss` emits. Bound to the `useSessionStore()` Pinia store (`src/stores/session.ts`), which `main.ts`'s `onAuthRefreshError` hook flips when the refresh token itself has expired |
 <% } %>

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -64,6 +64,7 @@ function onAccountItemClick() {
     </AppLayout>
   </AppSideMenu>
 <% } else { %>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
   <AppHeader heading="<%= projectName %>">
     <template #utilities>
       <goa-button-group alignment="end">
@@ -86,13 +87,34 @@ function onAccountItemClick() {
     @dismiss="session.dismiss"
   />
   <goa-hero-banner heading="<%= projectName %>" backgroundurl="/assets/banner.jpg" />
-  <AppLayout :variant="contentWidth">
-    <RouterView />
-  </AppLayout>
+  <main id="main-content">
+    <AppLayout :variant="contentWidth">
+      <RouterView />
+    </AppLayout>
+  </main>
   <AppFooter />
 <% } %>
 </template>
 
 <style>
 body { margin: 0; }
+<% if (layout !== 'internal') { %>
+/* Visually hidden until focused (e.g. via Tab from the top of the page) — lets
+   keyboard/screen-reader users jump past the header straight to the content.
+   The internal/side-menu shell has its own scoped copy of this; this layout
+   has no equivalent shell component, so App.vue owns it directly here. */
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 100;
+  padding: var(--goa-space-s, 0.5rem) var(--goa-space-m, 1rem);
+  background: var(--goa-color-interactive-default, #0070c4);
+  color: #fff;
+}
+
+.skip-link:focus {
+  left: var(--goa-space-m, 1rem);
+}
+<% } %>
 </style>

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -124,14 +124,21 @@ describe('Vue App Generator', () => {
     expect(layout).toContain('form-content');
     expect(layout).toContain('wide-content');
     expect(layout).toContain('--goa-space');
-    // Skip-to-main-content link for keyboard/screen-reader users.
-    expect(layout).toContain('href="#main-content"');
+    // AppLayout must NOT own the skip-to-main-content landmark itself: it nests
+    // inside AppSideMenu for --layout=internal, which already provides one, and
+    // a second <main id="main-content"> would duplicate the landmark/id.
+    expect(layout).not.toContain('id="main-content"');
+    expect(layout).not.toContain('skip-link');
 
     // App.vue uses AppLayout and no longer relies on the `main > section` gutter
     // (which silently failed when a view's top-level tag wasn't <section>).
+    // For --layout=header (the default), App.vue itself owns the skip-link
+    // landmark instead, since there's no shell component to hold it.
     const app = host.read('apps/test/src/App.vue').toString();
     expect(app).toContain('AppLayout');
     expect(app).not.toContain('main > section');
+    expect(app).toContain('href="#main-content"');
+    expect(app).toContain('id="main-content"');
   });
 
   it('provisions the shared GoA wrapper library and points the app at it', async () => {
@@ -202,6 +209,11 @@ describe('Vue App Generator', () => {
     expect(app).toContain('@item-click="onAccountItemClick"');
     // The content gutter is shared regardless of shell choice.
     expect(app).toContain('<AppLayout');
+    // App.vue itself must not add a second skip-to-main-content landmark —
+    // AppSideMenu (imported, not inlined) already owns the one and only
+    // #main-content for this layout.
+    expect(app).not.toContain('id="main-content"');
+    expect(app).not.toContain('skip-link');
 
     const agents = host.read('apps/test/AGENTS.md').toString();
     expect(agents).toContain('--layout=internal');

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppLayout.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppLayout.vue__tmpl__
@@ -8,37 +8,24 @@
 //   meta: { layout: 'form' }   // single-column forms      → 640px
 //   (default)                  // general content          → 1000px
 //   meta: { layout: 'wide' }   // data-heavy pages / tables → 1200px
+//
+// Deliberately not a landmark/skip-target itself: this component nests inside
+// AppSideMenu for --layout=internal, which already provides one, and a second
+// copy would duplicate the anchor screen readers/keyboard nav jump to. The
+// top-level shell (App.vue for --layout=header, AppSideMenu for --layout=internal)
+// owns that landmark instead.
 withDefaults(defineProps<{ variant?: 'page' | 'wide' | 'form' }>(), {
   variant: 'page',
 });
 </script>
 
 <template>
-  <a class="skip-link" href="#main-content">Skip to main content</a>
-  <main id="main-content">
-    <div :class="`${variant}-content`">
-      <slot />
-    </div>
-  </main>
+  <div :class="`${variant}-content`">
+    <slot />
+  </div>
 </template>
 
 <style scoped>
-/* Visually hidden until focused (e.g. via Tab from the top of the page) — lets
-   keyboard/screen-reader users jump past the header straight to the content. */
-.skip-link {
-  position: absolute;
-  left: -9999px;
-  top: 0;
-  z-index: 100;
-  padding: var(--goa-space-s, 0.5rem) var(--goa-space-m, 1rem);
-  background: var(--goa-color-interactive-default, #0070c4);
-  color: #fff;
-}
-
-.skip-link:focus {
-  left: var(--goa-space-m, 1rem);
-}
-
 .page-content,
 .wide-content,
 .form-content {


### PR DESCRIPTION
## Summary
- Found while building a real prototype (a staff-facing case-management app) on `--layout=internal` to evaluate the Vue pattern components in practice, then inspecting the actual rendered DOM with Playwright rather than trusting source review or unit-test string assertions.
- `AppLayout` independently rendered its own `<a class="skip-link">` + `<main id="main-content">`. Harmless when used standalone (`--layout=header`), but `AppSideMenu` already provides that exact landmark for `--layout=internal`, and `App.vue` nests `AppLayout` inside `AppSideMenu`'s slot — producing **two** `<main id="main-content">` elements and two skip links in the rendered DOM (confirmed via a headless-browser DOM query, not just template review).
- `AppLayout` is now a pure width-variant wrapper with no landmark of its own. The top-level shell owns it instead: `App.vue` for `--layout=header` (added its own skip-link + `<main id="main-content">`), `AppSideMenu` for `--layout=internal` (already had one, unchanged) — exactly one per layout, no gap.
- Updated `vue-app`'s generated `AGENTS.md` app-shell-components tables to reflect the new ownership, and updated/extended the relevant `vue-app.spec.ts` assertions (including new regression coverage asserting `AppLayout` never contains the landmark, and that `--layout=internal`'s `App.vue` doesn't add a second one).

## Test plan
- [x] `npx nx test nx-adsp --skip-nx-cache -- --testPathPattern="vue-app.spec|vue-components.spec"` — 163 tests pass
- [x] `npx nx affected -t lint,test,build --base=origin/beta` — lint, test, build all pass
- [x] Real end-to-end verification: generated a real `--layout=internal` vue-app locally (against a local mock ADSP server, no real tenant), built it, ran the dev server, and used Playwright to confirm exactly one `<main id="main-content">` and one `.skip-link` render (was two, before the fix) across `/cases`, `/cases/:id`, `/admin/programs`, `/admin/programs/:id`, and the intake wizard's step/review routes — no console errors on any route