### PR TITLE
feat(nx-adsp): add an optional #topbar slot to AppSideMenu

### DIFF
--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -172,7 +172,7 @@ from **`<%= goaImportPath %>`**, not hand-rolled markup:
 
 | Component | Purpose |
 |---|---|
-| `AppSideMenu` | `goa-work-side-menu`. Takes `heading`/`primaryItems`/`secondaryItems`/`accountItems` props (each item: `{ label, to?, icon?, badge?, current? }`) and emits `itemClick` — it doesn't know about routing or auth, so `App.vue` computes `current`/handles the click itself. `App.vue` currently only populates `accountItems` (a single Sign in/out item); add real nav items to `primaryItems`/`secondaryItems` as routes are added. Also owns the skip-to-main-content landmark for this layout — `AppLayout` deliberately doesn't duplicate it |
+| `AppSideMenu` | `goa-work-side-menu`. Takes `heading`/`primaryItems`/`secondaryItems`/`accountItems` props (each item: `{ label, to?, icon?, badge?, current? }`) and emits `itemClick` — it doesn't know about routing or auth, so `App.vue` computes `current`/handles the click itself. `App.vue` currently only populates `accountItems` (a single Sign in/out item); add real nav items to `primaryItems`/`secondaryItems` as routes are added. Also owns the skip-to-main-content landmark for this layout — `AppLayout` deliberately doesn't duplicate it. Also takes an optional `#topbar` slot — a slim row above the routed content, for something like a notification bell; only renders when given content, unused by default |
 | `AppLayout` | The content gutter every view renders inside (see the key files table) |
 | `SessionExpiredBanner` | A `v-model:show` banner with `signIn`/`dismiss` emits. Bound to the `useSessionStore()` Pinia store (`src/stores/session.ts`), which `main.ts`'s `onAuthRefreshError` hook flips when the refresh token itself has expired |
 

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppSideMenu.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppSideMenu.vue__tmpl__
@@ -1,9 +1,20 @@
 <script setup lang="ts">
+import { useSlots } from 'vue';
+
 // The alternate top-level shell for staff-facing/internal apps (goa-work-side-menu),
 // used instead of AppHeader/AppFooter -- not together with them. Presentational only:
 // unlike the real GovAlta-Pronghorn source this is adapted from, active-route
 // highlighting and navigation are the caller's job (pass `current` on each item,
 // listen for `item-click`) so this component doesn't need vue-router as a dependency.
+//
+// The real reference source also has a slim in-content "topbar" row for
+// module-registered header actions (e.g. a notification bell) -- there's no
+// AppHeader/utilities slot in this layout to hold that kind of thing. Exposed
+// here as a plain named slot (`#topbar`), not a module-registration system --
+// that's app-specific plumbing, not something a shared, presentational
+// component should own.
+const slots = useSlots();
+
 interface AppSideMenuItem {
   label: string;
   to?: string;
@@ -63,6 +74,9 @@ const emit = defineEmits<{ itemClick: [item: AppSideMenuItem] }>();
       />
     </goa-work-side-menu>
     <main id="main-content" class="app-side-menu-content">
+      <div v-if="slots.topbar" class="app-side-menu-topbar">
+        <slot name="topbar" />
+      </div>
       <slot />
     </main>
   </div>
@@ -78,6 +92,15 @@ const emit = defineEmits<{ itemClick: [item: AppSideMenuItem] }>();
   flex: 1;
   min-width: 0;
   overflow-y: auto;
+}
+
+.app-side-menu-topbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--goa-space-s, 0.75rem);
+  padding: var(--goa-space-xs, 0.5rem) var(--goa-space-m, 1rem);
+  border-bottom: 1px solid var(--goa-color-greyscale-100, #f1f1f1);
 }
 
 .skip-link {

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -76,6 +76,19 @@ describe('Vue Components Generator', () => {
     expect(agents).toContain('defineModel<boolean>');
   }, 30000);
 
+  it('AppSideMenu exposes an optional #topbar slot for header-action-style content', async () => {
+    await generator(host);
+
+    const sideMenu = host
+      .read('libs/vue-components/src/lib/patterns/AppSideMenu.vue')
+      .toString();
+    // Named slot, only rendered when actually given content -- no empty bar
+    // shows by default, matching the "unused by default" doc claim.
+    expect(sideMenu).toContain('<slot name="topbar" />');
+    expect(sideMenu).toContain('v-if="slots.topbar"');
+    expect(sideMenu).toContain('useSlots');
+  }, 30000);
+
   it('disables vue/no-deprecated-slot-attribute in flat config too, not just .eslintrc.json', async () => {
     // useFlatConfig() (from @nx/eslint) treats a root flat-config file's
     // presence as authoritative, regardless of the installed ESLint version —


### PR DESCRIPTION
## Summary
- Checked the real GovAlta-Pronghorn source `AppSideMenu` was adapted from (both the canonical `template` repo and an independent, actively-developed production app — `cfs-emergency-family-violence-services-funding-request-portal`): the internal-layout shell has a slim in-content row for module-registered header actions (e.g. a notification bell), since there's no `AppHeader`/`utilities` slot in this layout to hold one. Confirmed via real source, not assumption.
- Exposed as a plain named `#topbar` slot on `AppSideMenu` rather than porting the real module-registration system — that's app-specific plumbing (feature modules registering components into a shared list), not something a shared, presentational pattern component should own.
- Only renders when given content (`v-if="slots.topbar"`) — a no-op for every app that doesn't use it, matching the component's existing "unused by default" props.
- Documented on `AppSideMenu`'s row in `vue-app`'s generated `AGENTS.md`.

## Test plan
- [x] `npx nx test nx-adsp --skip-nx-cache -- --testPathPattern="vue-components.spec"` — new test + 163 existing pass (164 total)
- [x] `npx nx affected -t lint,test,build --base=origin/beta` — lint, test, build all pass
- [x] Real end-to-end verification: generated a real `--layout=internal` vue-app locally, put a `goa-icon-button` in the `#topbar` slot, confirmed via Playwright it renders in the expected position (slim row, right-aligned, above the routed content) with zero console errors — then removed it and confirmed the slot correctly renders nothing when unused (no empty bar)