### PR TITLE
fix(nx-adsp): move --layout=header's hero banner from App.vue to HomeView

### DIFF
--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -34,11 +34,15 @@ executors read options from `project.json` and do not prompt.
 <% if (layout === 'internal') { %>
 | `src/App.vue` | Shell — `AppSideMenu` (side-menu shell, Sign in/out as an account item), `SessionExpiredBanner`, `<RouterView>` wrapped in `AppLayout` |
 <% } else { %>
-| `src/App.vue` | Shell — `AppHeader` with sign-in/out in its `utilities` slot, `SessionExpiredBanner`, hero banner, `<RouterView>` wrapped in `AppLayout`, `AppFooter` |
+| `src/App.vue` | Shell — `AppHeader` with sign-in/out in its `utilities` slot, `SessionExpiredBanner`, `<RouterView>` wrapped in `AppLayout`, `AppFooter` |
 <% } %>
 | `src/stores/session.ts` | Pinia store — `expired` flag behind `SessionExpiredBanner`, set from `main.ts`'s `onAuthRefreshError` hook |
 | `src/router/index.ts` | Routes — `/protected` guarded with `requiresAuth` meta |
+<% if (layout === 'internal') { %>
 | `src/views/HomeView.vue` | Public page — calls public and private APIs |
+<% } else { %>
+| `src/views/HomeView.vue` | Public page — hero banner (page content, not app-shell — real GoA services show it once on the landing page, not on every route) + calls public and private APIs |
+<% } %>
 | `src/views/ProtectedView.vue` | Authenticated page — shows user info from token |
 | `src/environments/environment.ts` | Access URL, realm, client ID — pre-set from ADSP tenant |
 | `vite.config.ts` | Vite config — `isCustomElement` marks `goa-*` as web components |

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -86,7 +86,6 @@ function onAccountItemClick() {
     @sign-in="signInAgain"
     @dismiss="session.dismiss"
   />
-  <goa-hero-banner heading="<%= projectName %>" backgroundurl="/assets/banner.jpg" />
   <main id="main-content">
     <AppLayout :variant="contentWidth">
       <RouterView />

--- a/packages/nx-adsp/src/generators/vue-app/files/src/views/HomeView.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/views/HomeView.vue__tmpl__
@@ -42,6 +42,10 @@ watch(
 
 <template>
   <section>
+    <% if (layout !== 'internal') { %>
+    <goa-hero-banner heading="<%= projectName %>" backgroundurl="/assets/banner.jpg" />
+    <goa-spacer vspacing="l" />
+    <% } %>
     <h2>Welcome to <%= projectName %>!</h2>
     <p>Don't panic. Start editing the project to build your digital service.</p>
     <h3>A few things you might want to do next:</h3>

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -313,15 +313,33 @@ describe('Vue App Generator', () => {
 
   it('static assets live in public/ so Vite serves them at the referenced URLs', async () => {
     await generator(host, options);
-    // App.vue's <goa-hero-banner backgroundurl="/assets/banner.jpg"> and
+    // HomeView's <goa-hero-banner backgroundurl="/assets/banner.jpg"> and
     // index.html's favicon.ico are absolute-URL string refs, so they must be in
     // the Vite publicDir (public/) — a src/assets file is not served at /assets.
-    const appVue = host.read('apps/test/src/App.vue').toString();
-    const bannerUrl = appVue.match(/backgroundurl="([^"]+)"/)?.[1];
+    const homeView = host.read('apps/test/src/views/HomeView.vue').toString();
+    const bannerUrl = homeView.match(/backgroundurl="([^"]+)"/)?.[1];
     expect(bannerUrl).toBe('/assets/banner.jpg');
     expect(host.exists('apps/test/public/assets/banner.jpg')).toBeTruthy();
     expect(host.exists('apps/test/src/assets/banner.jpg')).toBeFalsy();
     expect(host.exists('apps/test/public/favicon.ico')).toBeTruthy();
+  }, 30000);
+
+  it('the hero banner is home-page content, not part of the persistent app shell', async () => {
+    // Real GovAlta-Pronghorn source (both the canonical template and an
+    // independently-evolved production app) puts goa-hero-banner only inside
+    // HomeView -- never in App.vue/AppLayout -- so it shows once on the
+    // landing page, not repeated on every interior route.
+    await generator(host, options);
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).not.toContain('goa-hero-banner');
+    const homeView = host.read('apps/test/src/views/HomeView.vue').toString();
+    expect(homeView).toContain('goa-hero-banner');
+  }, 30000);
+
+  it('--layout=internal has no hero banner anywhere, including on HomeView', async () => {
+    await generator(host, { ...options, layout: 'internal' });
+    const homeView = host.read('apps/test/src/views/HomeView.vue').toString();
+    expect(homeView).not.toContain('goa-hero-banner');
   }, 30000);
 
   it('vite.config.ts marks goa-* elements as custom elements', async () => {


### PR DESCRIPTION
## Summary
- `App.vue` rendered `<goa-hero-banner>` unconditionally as part of the persistent shell, so it repeated on every route (forms, wizards, detail views), not just the landing page.
- Checked the real GovAlta-Pronghorn source (the canonical `template` repo's `apps/web/src/views/HomeView.vue` + `apps/web/src/components/layout/AppLayout.vue`): the hero banner lives only inside `HomeView.vue` as page content — never in `App.vue`/`AppLayout` — so it shows exactly once.
- Moved it to `HomeView.vue`'s own template, gated out for `--layout=internal` (which has no hero banner at all in the real reference either).
- Side effect, not a regression: the banner is now width-constrained to the page gutter instead of full-bleed, since it moved from shell chrome (outside `AppLayout`) to page content (inside it) — this actually matches the real reference more closely, which also renders it inside `AppLayout`'s content wrapper.

## Test plan
- [x] `npx nx test nx-adsp --skip-nx-cache -- --testPathPattern="vue-app.spec"` — 2 new tests + existing pass (165 total)
- [x] `npx nx affected -t lint,test,build --base=origin/beta` — lint, test, build all pass
- [x] Real end-to-end verification: built a public-facing (`--layout=header`) prototype app with a referral intake wizard retrofitted into it, confirmed via Playwright the hero banner renders exactly once on the home route and zero times on an interior form route (was 1-per-route everywhere before this fix)