### PR TITLE
feat(nx-agent): scope agent-delivery loop to first-commit artifact; fix premature completion PR

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/dispatch-next-iteration.sh
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/dispatch-next-iteration.sh
@@ -7,4 +7,5 @@ set -euo pipefail
 NEXT_ITERATION="$(( "${ITERATION:?}" + 1 ))"
 echo "[agent-delivery-iteration] dispatching iteration $NEXT_ITERATION on ${GITHUB_REF_NAME:?}"
 gh workflow run "${WORKFLOW_FILE:-agent-delivery-iteration.yml}" --repo "${GITHUB_REPOSITORY:?}" --ref "${GITHUB_REF_NAME:?}" \
-  -f iteration="$NEXT_ITERATION"
+  -f iteration="$NEXT_ITERATION" \
+  -f artifact_scope="${ARTIFACT_SCOPE:-}"

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/ensure-completion-pr.sh
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/ensure-completion-pr.sh
@@ -14,6 +14,17 @@ SUMMARY="${SUMMARY:?SUMMARY env var required}"
 BRANCH_NAME="${GITHUB_REF_NAME:?}"
 WORKFLOW_NAME="${GITHUB_WORKFLOW:?}"
 
+# Only open a PR if the loop itself made substantive commits. Filtering by author isolates the
+# harness's own work from any unrelated commits a human may have pushed to the same branch --
+# the workflow sets git config user.name to "agent-delivery-iteration[bot]" before the iteration
+# runs, so Copilot's commits carry that identity. Bookkeeping writes are excluded via pathspec.
+loop_commits=$(git log --oneline --author="agent-delivery-iteration\[bot\]" \
+  "origin/main..HEAD" -- ':!.github/agent-delivery-iteration/' 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$loop_commits" -eq 0 ]]; then
+  echo "no substantive loop commits on $BRANCH_NAME -- skipping completion PR"
+  exit 0
+fi
+
 existing=$(gh pr list --head "$BRANCH_NAME" --base main --json number --jq '.[0].number // empty')
 if [[ -z "$existing" ]]; then
   body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' "$WORKFLOW_NAME" "$SUMMARY")

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -224,17 +224,49 @@ for (const path of mdFilesIn('project-docs/requirements')) {
   }
 }
 
-// --- Branch-nature filtering -----------------------------------------------------------------
+// --- Branch-nature + artifact-scope filtering ------------------------------------------------
 
 // fix/** branches are scoped to resolving something already flagged wrong (a broken reference or
-// open blocker/question), never to starting new work. feature/** branches, and anything run
-// outside that naming convention, get the unfiltered signal set.
+// open blocker/question), never to starting new work.
+//
+// ARTIFACT_SCOPE narrows eligible signals further: the workflow's "Resolve artifact scope" step
+// derives a comma-separated list of project-docs/ paths from the first commit on the branch and
+// forwards it unchanged across every self-dispatched iteration. When set, only signals whose
+// artifact is the same as, or a descendant of, those initial artifacts are eligible -- preventing
+// the loop from drifting to unrelated work across iterations.
 const branchName = process.env.GITHUB_REF_NAME ?? '';
 const isFixBranch = branchName.startsWith('fix/');
 const RESOLUTION_PREFIXES = ['broken:', 'open:'];
+
+const scopedPaths = (process.env.ARTIFACT_SCOPE ?? '').split(',').filter(Boolean);
+const scopedKeys = new Set(
+  scopedPaths
+    .map((p) => Object.keys(registry).find((k) => registry[k].path === p))
+    .filter(Boolean),
+);
+
+function isInArtifactScope(signalKey) {
+  if (scopedKeys.size === 0) return true; // no scope → unfiltered
+  // Signal keys look like 'open:features:x', 'unrefined:requirements:x', etc. -- the artifact
+  // registry key is everything after the first colon-prefix segment.
+  const artifactKey = signalKey.includes(':') ? signalKey.replace(/^[^:]+:/, '') : signalKey;
+  function ancestorInScope(key, visited = new Set()) {
+    if (visited.has(key)) return false;
+    visited.add(key);
+    if (scopedKeys.has(key)) return true;
+    for (const anc of registry[key]?.ancestorRefs ?? []) {
+      if (ancestorInScope(anc, visited)) return true;
+    }
+    return false;
+  }
+  return ancestorInScope(artifactKey);
+}
+
 const eligibleSignals = isFixBranch
-  ? signals.filter((s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)))
-  : signals;
+  ? signals.filter(
+      (s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)) && isInArtifactScope(s.key),
+    )
+  : signals.filter((s) => isInArtifactScope(s.key));
 const excludedCount = signals.length - eligibleSignals.length;
 
 // --- Non-progress detection -------------------------------------------------------------------
@@ -285,11 +317,18 @@ fresh, and follow each one's own selection logic (Discover's "which mode," Desig
 siblings," Develop's "which artifact") to decide what to actually do. If that logic points at
 something other than this hint, follow the skill, not the hint.`;
 
+  const scopeNote =
+    scopedPaths.length > 0
+      ? `\nThis run is scoped to the artifact(s) introduced in the first commit on this branch:\n` +
+        scopedPaths.map((p) => `  - ${p}`).join('\n') +
+        `\nDon't pick up unrelated signals even if they appear ready -- file them separately.\n`
+      : '';
+
   const branchScopeNote = isFixBranch
     ? `\nThis is a fix/** branch: stay scoped to resolving the signal below. Don't pick up an
 unrelated requirement or start new Discover/Design work even if you notice it along the way --
-file it as its own blocker/open-question instead, for a feature/** branch to pick up later.\n`
-    : '';
+file it as its own blocker/open-question instead, for a feature/** branch to pick up later.${scopeNote}`
+    : scopeNote;
 
   return `You are GitHub Copilot CLI, working in this Nx workspace as one continuous session for one ddd (Discover/Design/Develop/Deploy) iteration.
 ${branchScopeNote}
@@ -354,7 +393,7 @@ function emit({ ready, signals, stalled: stalledFlag, promptOverride, excludedCo
     : top
       ? `${signals.length} signal(s) found; top: ${top.reason}`
       : excludedCount > 0
-        ? `Nothing left to resolve on this branch (${excludedCount} other signal(s) exist but would start new work — not eligible on a fix/** branch).`
+        ? `Nothing eligible on this branch (${excludedCount} other signal(s) exist but are out of scope — filtered by branch type or artifact scope).`
         : 'No plausible next ddd action found — every requirement is refined, designed, implemented, and deployed, with no unresolved open-question/blocker.';
 
   console.log(JSON.stringify({ ready, stalled: !!stalledFlag, signals, summary }, null, 2));

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
@@ -29,6 +29,10 @@ on:
         description: Iteration number to resume at -- set only by the loop's own self-dispatch; leave blank to start fresh
         required: false
         type: string
+      artifact_scope:
+        description: Comma-separated project-docs paths from the first commit on this branch -- set only by the loop's own self-dispatch; blank on first push (derived automatically)
+        required: false
+        type: string
 
 concurrency:
   # Deliberately workspace-wide, not per-branch (no `${{ github.ref }}`): Deploy's own target
@@ -133,6 +137,23 @@ jobs:
         # the job outright.
         run: npx nx g @abgov/nx-agent:project-docs-lineage || true
 
+      - name: Resolve artifact scope
+        id: scope
+        # inputs.artifact_scope only ever has a value on the loop's own self-dispatch -- blank on
+        # a push-triggered run, where it's derived from the first commit on this branch instead.
+        # Forwarded unchanged across every self-dispatch so task-identification sees the same scope.
+        run: |
+          scope="${{ inputs.artifact_scope }}"
+          if [[ -z "$scope" ]]; then
+            first_sha=$(git log --reverse --format="%H" "origin/main..HEAD" 2>/dev/null | head -1)
+            if [[ -n "$first_sha" ]]; then
+              scope=$(git diff-tree --no-commit-id -r --name-only "$first_sha" \
+                | grep '^project-docs/' | paste -sd ',' - || true)
+            fi
+          fi
+          echo "ARTIFACT_SCOPE=${scope}" >> "$GITHUB_ENV"
+          echo "artifact_scope=${scope}" >> "$GITHUB_OUTPUT"
+
       - name: Identify next task
         id: readiness
         run: node scripts/task-identification.mjs
@@ -164,11 +185,11 @@ jobs:
           SUMMARY: ${{ steps.readiness.outputs.summary }}
         run: echo "$SUMMARY"
 
-      - name: Ensure completion PR exists
+      - name: Ensure completion PR exists (max-iterations cap reached)
         # SUMMARY comes from a flow's own generated text -- routed through env: rather than
         # interpolated directly into the script's command text, so untrusted content can't get
         # re-parsed as shell syntax (see the script's own header for how it's used).
-        if: steps.readiness.outputs.ready != 'true' || env.STOP_REASON == 'max-iterations'
+        if: env.STOP_REASON == 'max-iterations'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SUMMARY: ${{ steps.readiness.outputs.summary }}


### PR DESCRIPTION
## Summary

- **Premature completion PR fix**: removes the pre-iteration `Ensure completion PR exists` path that fired on `ready != 'true'` alone, before the loop had done any work. Only the `max-iterations` stop (a genuine harness conclusion) still opens a PR pre-iteration. The post-iteration path is unchanged.
- **Artifact scoping**: new `Resolve artifact scope` step derives `project-docs/` paths from the **first commit on the branch** (`git diff-tree`) on push-triggered runs; on self-dispatch it reads the forwarded `inputs.artifact_scope` input. `task-identification.mjs` uses this to filter eligible signals to only those whose artifact is the same as, or a descendant of, those initial paths — preventing the loop from drifting to unrelated work across iterations.
- **Scope propagation**: `dispatch-next-iteration.sh` forwards `artifact_scope` as a `-f` field so the derived scope is stable across all self-dispatched iterations without re-running git.
- **Belt-and-suspenders guard**: `ensure-completion-pr.sh` skips PR creation when the only branch commits are harness bookkeeping writes.

## Test plan

- [ ] Push a brand-new `fix/**` branch with only a bookkeeping commit → no PR opens; "no substantive commits" message in log
- [ ] Push a `feature/**` branch whose first commit creates a `project-docs/features/` file → only signals related to that artifact and its descendants appear as eligible
- [ ] Confirm `artifact_scope` value is visible in the Actions UI for a self-dispatch run (iteration 2+)
- [ ] Hit the `max-iterations` cap → completion PR still opens
- [ ] Complete a real iteration (`made_commits == 'true'`, `ready_after == 'false'`) → post-iteration PR opens as before
- [ ] Push a branch whose first commit has no `project-docs/` files → `ARTIFACT_SCOPE` is empty → eligible signals unfiltered (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)