### PR TITLE
fix(nx-agent): fix Discover allowed-tools bug; broaden DDDD review prompts; slim skills

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/deploy/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/deploy/SKILL.md
@@ -52,18 +52,9 @@ backend track is ready to deploy doesn't wait on its frontend track, and vice ve
    target name. Can take several minutes (build, push, import, rollout) — expect it to move to the
    background rather than blocking the session.
 
-4. **A failed rollout-status wait doesn't necessarily mean the deploy failed.** A first-time
-   deploy can end up with a redundant second rollout racing the first one's database migration —
-   one pod healthy, a second stuck `Init:CrashLoopBackOff` on a migration "already exists" error.
-   `oc rollout status` then times out even though the service is actually up. Check `oc get pods
-   -n <namespace> -l name=<project>` and `curl` the route's `/health` before assuming the deploy
-   is broken. If it's this pattern: `oc scale deployment/<project> --replicas=0`, wait for pods to
-   clear, `--replicas=1` for one clean single-pod rollout.
-
-5. **A shared sandbox Postgres instance can carry stale state from unrelated prior exploration.**
-   If a table/migration record predates this deploy by more than a few minutes (check `created_at`
-   in `drizzle.__drizzle_migrations`), it's stale data, not this deploy's bug. Drop it and redeploy
-   clean.
+4. **A failed rollout-status wait doesn't always mean the deploy failed** — stale Postgres
+   migration state is a common false positive. Consult `.openshift/<project>/SANDBOX.md`'s
+   troubleshooting section for diagnosis and fix commands.
 
 ## Sandbox is the default; graduating to a real pipeline is a separate, deliberate step
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -136,14 +136,19 @@ npx nx g @abgov/nx-agent:project-docs-lineage --dry-run
 - **`unscoped`** (an artifact missing one of its kind's expected ancestors) blocks the
   Design→Develop transition — advisory while still mid-pass.
 
-### Independent review — vocabulary drift, every domain model
+### Independent review — every pass
 
-Run every time a domain model is created or revised, not just founding ones. Dispatch one isolated
-reviewer subagent via `Task`, giving it *only* the domain model and the existing domain-term files
-it should be consistent with — never this pass's own reasoning. Ask it: does the model use an
-established term inconsistently with its definition, or silently redefine one? Does it lean on a
-recurring concept in prose that should be its own domain term instead? Always advisory — act on a
-real finding by fixing the inconsistency or adding the missing term, don't just log it.
+Give the reviewer only the requirement, domain model, domain-term files, and any UX/API designs
+produced this pass — not this pass's own reasoning. Ask it:
+
+1. Does the domain model use an established term inconsistently with its definition, or lean on a recurring concept in prose that should be its own domain term instead?
+2. Does every rule in the requirement have a corresponding endpoint or screen in the UX/API design?
+3. Is the API design consistent with existing API designs in the workspace (naming, status codes, auth patterns)?
+4. Are auth and authorization requirements explicitly addressed, or silently assumed?
+5. Does the API design actually satisfy what the UX design says its screens need?
+
+Always advisory — act on a real finding by fixing the inconsistency or missing coverage, don't
+just log it.
 
 ### Commit before ending this skill
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: develop
-description: Implement an api-design/ux-design against real code, following the project's own generated recipe (its own AGENTS.md — the exact steps vary by stack), with a project-docs-ancestors code comment tying every new file back to the design it implements. Runs an inline gate battery — audit, secret scan, build, test, always blocking — plus an isolated code-review subagent, every pass, advisory.
+description: Implement an api-design/ux-design against real code, following the project's own generated recipe (its own AGENTS.md — the exact steps vary by stack), with a project-docs-ancestors code comment tying every new file back to the design it implements. Runs an inline gate battery — audit, secret scan, build, test, always blocking — plus an independent code review, every pass, advisory.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 argument-hint: "<api-design or ux-design slug to implement>"
 ---
@@ -29,10 +29,8 @@ argument-hint: "<api-design or ux-design slug to implement>"
 
 ## Bug fixing
 
-A `bugs:<slug>` is not a design gap — it's something already built not behaving as designed,
-reported from outside the workflow rather than raised internally by a stage that already has a
-target artifact to name (that's what `blocker` is for; see Discover's "Open questions and
-blockers"). Investigate and fix directly, without a new Design pass:
+A `bugs:<slug>` is an as-built behavior defect, not a design gap — investigate and fix directly,
+no Design pass needed:
 
 1. **Read the bug's own body** (observed vs. expected behavior) and, if `project-docs-ancestors`
    names one, the requirement/design it's already believed to implicate. If it names none, find
@@ -48,10 +46,8 @@ blockers"). Investigate and fix directly, without a new Design pass:
 4. **Escalate to a real `blocker` only if the spec itself is wrong** — the design never covered this
    case, or covered it incorrectly. Run `nx g @abgov/nx-agent:blocker "<what's wrong>"
    --projectDocsAncestors=<implicated artifact> --projectDocsAncestors=<this bug, for traceability>`
-   (blocker accepts more than one ancestor), then fix the artifact for real, the same as any other
-   blocker. **This does not resolve the bug** — `resolutionStatus` reads a `resolves:` field, not an
-   ancestor reference, so the bug stays `open` until step 5 actually closes it, even once the
-   blocker itself is resolved.
+   (blocker accepts more than one ancestor), then fix the artifact for real before continuing.
+   The bug stays `open` until step 5 resolves it — the blocker being resolved doesn't close the bug.
 5. **Resolve the bug once the fix (code-only or design-plus-code) is verified**: run
    `nx g @abgov/nx-agent:iteration-retrospective "<title>" --projectDocsAncestors <path> [...]
    --resolves=<this bug's path>` at Deploy, naming it the same way any other resolution is recorded
@@ -124,24 +120,14 @@ blocking status depends on whether this project has a CI backstop yet — see be
   (see Deploy's Gate — the same `e2e` target, not a separate one, once
   `global-setup.ts`/`global-teardown.ts` guard on `BASE_URL`).
 
-  **Whether a failure here blocks this pass from ending depends on whether anything else would
-  actually catch a regression.** Check whether `.openshift/<project>/<project>.yml` exists (written
-  by `@abgov/nx-oc:deployment`, distinct from `sandbox`'s own `<project>.sandbox.yml` — see Deploy's
-  "Sandbox is the default" section) — that's the per-project signal for whether this resource has
-  graduated to the real, multi-environment pipeline, whose own generated CI already runs this exact
-  e2e target as a real gate before anything merges.
-  - **Not graduated yet (sandbox-only, the default)**: blocking, no exception — there's no other
-    check that will ever run this suite, so skipping it here means skipping it entirely.
-  - **Already graduated**: advisory — still run it (a slow feedback loop beats none, and catching a
-    real break here is cheaper than catching it in CI), but a failure doesn't have to hold up ending
-    this pass on its own. Say so explicitly if committing past a failing e2e run this way, so it's a
-    stated decision, not a silently skipped check — and don't let this become the default reason to
-    stop running it locally at all; CI is a backstop for what a fast local loop missed, not a
-    replacement for checking your own work before pushing it.
-  - Either way, a large/slow e2e suite doesn't need a full untargeted run for every small edit
-    within a pass: start `nx serve`/equivalent once in the background, run the spec directly against
-    it (or scoped to just the rule(s) this edit touches, e.g. Playwright's own `--grep`) for fast
-    in-pass iteration, and reserve one full, untargeted run as the actual check this Gate refers to.
+  **Blocking status depends on graduation.** `.openshift/<project>/<project>.yml` (written by
+  `@abgov/nx-oc:deployment`) signals the project is in the real pipeline, whose CI already runs
+  this as a hard gate before merging.
+  - **Not graduated (sandbox-only, the default)**: blocking — nothing else will ever run this suite.
+  - **Graduated**: advisory — still run it, but a failure doesn't have to hold up ending the pass;
+    say so explicitly when committing past one.
+  - Either way: scope early in-pass runs to just the rule(s) touched (Playwright `--grep`, jest
+    `--testNamePattern`); reserve a full untargeted run for this Gate.
 - **Unit-test coverage** is a real, additional guard — check the project's own `jest.config.cts`
   for `coverageThreshold`; if `collectCoverage` is on but no `coverageReporters` prints a summary
   by default, make it visible, not just enforced.
@@ -154,7 +140,7 @@ blocking status depends on whether this project has a CI backstop yet — see be
 
 ### Independent code review — every pass
 
-Dispatch one isolated reviewer subagent via `Task`, giving it *only* the api-design/ux-design, the
+Give the reviewer only the api-design/ux-design, the
 domain terms it should be consistent with, and the new/changed code — never this pass's own
 reasoning. Ask it: does the code use a term inconsistently with the domain vocabulary (naming
 included — a generic implementation-layer word standing in for a domain noun is drift too)? Is

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discover
 description: Frame a feature request into a service description and requirements with IDs seeded at birth. Two modes — intake (decompose a features:<slug> artifact) and refinement (example-map one requirement to closure) — same skill, branches on what it's given.
-allowed-tools: Read, Write, Bash, Grep, Glob
+allowed-tools: Read, Write, Bash, Grep, Glob, Task
 argument-hint: "<feature slug to decompose, or a requirement slug to refine>"
 ---
 
@@ -158,13 +158,14 @@ These check different things:
 
 ### Independent review
 
-Run every time a requirement finishes refinement, not just founding ones. Dispatch one isolated
-reviewer subagent via `Task`, giving it *only* the finished requirement file and its
-service-description ancestor — never this pass's own notes, reasoning, or the raw input. Ask it
-exactly two things:
+Run every time a requirement finishes refinement, not just founding ones. Give the reviewer only
+the finished requirement and its service-description ancestor — not this pass's notes, reasoning,
+or raw input. Ask it:
 
 1. Does the service description imply a rule this requirement doesn't cover?
-2. Is any Example technically Given/When/Then-shaped but still too vague to actually test against?
+2. Is any example Given/When/Then-shaped but testing the wrong behavior — or vague enough that "pass" and "fail" would be indistinguishable in a real test run?
+3. Does the requirement bundle two distinct behaviors that should be separate requirements?
+4. Are there security, privacy, or authorization implications not surfaced as rules or open questions?
 
 Always advisory — report its findings alongside the gate checks, plain language, before ending
 the skill.

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -93,6 +93,9 @@ oc get pods -n <%= sandboxProject %> -l name=<%= projectName %>
 - **Pod `CrashLoopBackOff`** — `oc logs -n <%= sandboxProject %> <pod> -c <%= projectName %>`.<% if (appType === 'node' && database && database !== 'none') { %>
   For the DB migration, also check the init container:
   `oc logs -n <%= sandboxProject %> <pod> -c <%= projectName %>-migrate`.<% } %>
+- **Stale migration state on a shared Postgres instance** — if a table or migration record predates
+  this deploy by more than a few minutes, it's leftover state from prior exploration, not a bug in
+  this deploy. Check `created_at` in `drizzle.__drizzle_migrations`; drop stale entries and redeploy.
 <% if (appType === 'frontend') { %>- **Sign-in returns `Invalid redirect_uri`** — the sandbox Route wasn't
   registered on the Keycloak public client (the generator does this when it can
   resolve the cluster ingress domain). Add `https://<%= projectName %>-<%= sandboxProject %>.<ingress-domain>/*`


### PR DESCRIPTION
## Summary

- **Bug fix**: `Task` was missing from Discover's `allowed-tools`, so its documented independent review step couldn't execute
- **Broader review prompts** (skeleton fixes from `DDDD-HARNESS-EXTENSION-POINTS-PROPOSAL.md`):
  - Discover: 2 → 4 questions; now catches misdirected examples, requirements that bundle two behaviors, and security/privacy/auth implications not surfaced as rules
  - Design: review promoted from domain-model-only to pass-level; input set expanded to include the requirement and any UX/API designs; 2 → 5 questions covering coverage gaps, API consistency, auth assumptions, and UX↔API contract
- **Skill slimming** (Gap 4 from the same proposal): Develop's e2e blocking section compressed ~18 → 7 lines; bug-fixing intro tightened; Deploy steps 4+5 collapsed to a SANDBOX.md pointer
- **SANDBOX.md**: stale-Postgres troubleshooting entry added (content moved from the Deploy skill where it was the main source of verbosity); the dual-migration race scenario was deliberately not added — the advisory lock in `migrate.ts` already serializes concurrent init containers and makes Drizzle's migrate() a safe no-op for the loser, so no troubleshooting entry is needed

## Test plan

- [ ] Confirm Discover's independent review can now actually dispatch a `Task` subagent
- [ ] Review the expanded question sets in Discover and Design for correctness
- [ ] Verify Deploy skill step count reads cleanly (4 main steps, then the graduation subsection)
- [ ] Check that SANDBOX.md's new stale-Postgres entry renders correctly in a generated workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)