### PR TITLE
feat(nx-agent): add open-scope (*) mode to agent-delivery harness; harden artifact scope interface

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts
@@ -81,8 +81,11 @@ function addGithubActionsFiles(host: Tree): void {
   );
 }
 
-function readGuidance(): string {
-  return readFileSync(join(FILES_DIR, 'AGENTS.guidance.md'), 'utf-8').trim();
+function readGuidance(githubActions: boolean): string {
+  const skills = readFileSync(join(FILES_DIR, 'AGENTS.guidance.md'), 'utf-8').trim();
+  if (!githubActions) return skills;
+  const harness = readFileSync(join(FILES_DIR, 'AGENTS.ci-harness.md'), 'utf-8').trim();
+  return `${skills}\n\n${harness}`;
 }
 
 export default async function (host: Tree, options: Schema) {
@@ -97,7 +100,7 @@ export default async function (host: Tree, options: Schema) {
     addGithubActionsFiles(host);
   }
 
-  mergeManagedSection(host, AGENTS_MD_SECTION_ID, readGuidance());
+  mergeManagedSection(host, AGENTS_MD_SECTION_ID, readGuidance(options.githubActions ?? false));
 
   // Last, and independent of everything above: file scaffolding always succeeds regardless of
   // what live oc/gh/ADSP calls this finds. No-ops entirely unless both --githubActions and

--- a/packages/nx-agent/src/generators/agent-delivery/files/AGENTS.ci-harness.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/AGENTS.ci-harness.md
@@ -1,0 +1,32 @@
+## CI harness
+
+`.github/workflows/agent-delivery-iteration.yml` drives the DDDD loop automatically. On each
+push to a `feature/**` or `fix/**` branch it identifies the highest-priority signal, runs a
+Copilot CLI agent session to advance it, then self-dispatches the next iteration until nothing
+is left or the `MAX_ITERATIONS` cap is hit.
+
+### Branch conventions
+
+| Branch prefix | Signal types eligible | Typical use |
+|---|---|---|
+| `feature/**` | All (discover → design → develop → deploy) | Advancing a new capability from a `features:` artifact through to Deploy |
+| `fix/**` | Resolution only (`broken:` and `open:`) | Resolving a specific blocker, open question, or broken reference |
+
+Both branch types derive artifact scope from the first commit (see below). The `fix/**`
+restriction is enforced independently of scope — a scoped fix branch only sees resolution
+signals within its scoped artifacts; a `feature/**` branch sees all signal types within scope.
+
+### Artifact scope
+
+Controls which artifacts' signals are eligible each iteration. Set via the `artifact_scope`
+input on the GitHub Actions manual dispatch UI, or left blank to auto-derive on first push.
+
+| Value | Behaviour |
+|---|---|
+| Blank | Scope derived from the project-docs files the branch's first commit touched. Forwarded unchanged to all subsequent iterations — the first commit's scope is stable for the life of the branch. |
+| `project-docs/features/my-feature.md` (or a comma-separated list of paths) | Explicit scope: only signals whose artifact is, or descends from, the named artifact(s). Use this on a manual trigger when you want to re-run the loop focused on a specific artifact without relying on the first commit having touched it. |
+| `*` | Open scope. No artifact filtering: the agent picks the globally highest-priority signal. Use for a broad sweep of the whole backlog. |
+
+When task-identification finds no eligible signals after filtering it emits a diagnostic naming
+which filter(s) fired and how many signals each matched, so a human or agent debugging a stalled
+loop can tell whether the branch type, artifact scope, or their combination is the constraint.

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -229,24 +229,39 @@ for (const path of mdFilesIn('project-docs/requirements')) {
 // fix/** branches are scoped to resolving something already flagged wrong (a broken reference or
 // open blocker/question), never to starting new work.
 //
-// ARTIFACT_SCOPE narrows eligible signals further: the workflow's "Resolve artifact scope" step
-// derives a comma-separated list of project-docs/ paths from the first commit on the branch and
-// forwards it unchanged across every self-dispatched iteration. When set, only signals whose
-// artifact is the same as, or a descendant of, those initial artifacts are eligible -- preventing
-// the loop from drifting to unrelated work across iterations.
+// ARTIFACT_SCOPE narrows eligible signals further: set to '*' to run across all available work
+// (open scope), or to a comma-separated list of project-docs/ paths derived from the first commit
+// on the branch (forwarded unchanged across every self-dispatched iteration). When set to a path
+// list, only signals whose artifact is the same as, or a descendant of, those initial artifacts
+// are eligible -- preventing the loop from drifting to unrelated work across iterations.
 const branchName = process.env.GITHUB_REF_NAME ?? '';
 const isFixBranch = branchName.startsWith('fix/');
 const RESOLUTION_PREFIXES = ['broken:', 'open:'];
 
-const scopedPaths = (process.env.ARTIFACT_SCOPE ?? '').split(',').filter(Boolean);
+// '*' is an explicit opt-in to open scope — no artifact filtering at all, not the same as
+// "first commit touched no project-docs files." When set, scopedKeys stays empty (so
+// isInArtifactScope returns true for everything), but the composePrompt note is explicit.
+const rawScope = process.env.ARTIFACT_SCOPE ?? '';
+const openScope = rawScope === '*';
+const scopedPaths = openScope ? [] : rawScope.split(',').filter(Boolean);
 const scopedKeys = new Set(
   scopedPaths
     .map((p) => Object.keys(registry).find((k) => registry[k].path === p))
     .filter(Boolean),
 );
 
+// Warn if paths were specified but none resolved — this means the scope is silently inoperative.
+// Common cause: a file was renamed since the first commit ran, or a path is not yet in the registry.
+if (scopedPaths.length > 0 && scopedKeys.size === 0) {
+  console.warn(
+    `[task-identification] WARNING: ARTIFACT_SCOPE is set [${scopedPaths.join(', ')}] but none of ` +
+    `these paths resolved to a registry key — running unfiltered. ` +
+    `Check whether the scoped files were renamed or are not yet registered in project-docs/.`,
+  );
+}
+
 function isInArtifactScope(signalKey) {
-  if (scopedKeys.size === 0) return true; // no scope → unfiltered
+  if (scopedKeys.size === 0) return true; // open scope (*), no scope derived, or unresolvable paths → unfiltered
   // Signal keys look like 'open:features:x', 'unrefined:requirements:x', etc. -- the artifact
   // registry key is everything after the first colon-prefix segment.
   const artifactKey = signalKey.includes(':') ? signalKey.replace(/^[^:]+:/, '') : signalKey;
@@ -268,6 +283,30 @@ const eligibleSignals = isFixBranch
     )
   : signals.filter((s) => isInArtifactScope(s.key));
 const excludedCount = signals.length - eligibleSignals.length;
+
+// Diagnostic breakdown — computed only when filtering produced nothing, so the log doesn't
+// just say "nothing to do" when the real answer is "scope and branch type disagree."
+let noEligibleNote = null;
+if (eligibleSignals.length === 0 && signals.length > 0) {
+  const inScope = scopedKeys.size > 0 ? signals.filter((s) => isInArtifactScope(s.key)) : signals;
+  const inBranchType = isFixBranch
+    ? signals.filter((s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)))
+    : signals;
+  if (isFixBranch && scopedKeys.size > 0) {
+    // Both filters active — name the intersection explicitly.
+    const inBoth = inScope.filter((s) => inBranchType.includes(s));
+    noEligibleNote =
+      `fix/** branch (broken:/open: only) AND artifact scope [${scopedPaths.join(', ')}]: ` +
+      `${inScope.length} signal(s) in scope, ${inBranchType.length} resolution-type total, ` +
+      `${inBoth.length} satisfy both — no eligible signals on this branch.`;
+  } else if (scopedKeys.size > 0) {
+    noEligibleNote =
+      `artifact scope [${scopedPaths.join(', ')}] matches ${inScope.length} of ${signals.length} signal(s) — nothing in scope yet.`;
+  } else if (isFixBranch) {
+    noEligibleNote =
+      `fix/** branch restricts to broken:/open: signals only — ${inBranchType.length} such signal(s) currently exist.`;
+  }
+}
 
 // --- Non-progress detection -------------------------------------------------------------------
 
@@ -317,8 +356,9 @@ fresh, and follow each one's own selection logic (Discover's "which mode," Desig
 siblings," Develop's "which artifact") to decide what to actually do. If that logic points at
 something other than this hint, follow the skill, not the hint.`;
 
-  const scopeNote =
-    scopedPaths.length > 0
+  const scopeNote = openScope
+    ? `\nThis run is in open scope (explicitly requested) — all available artifacts are eligible, not just those from the first commit.\n`
+    : scopedPaths.length > 0
       ? `\nThis run is scoped to the artifact(s) introduced in the first commit on this branch:\n` +
         scopedPaths.map((p) => `  - ${p}`).join('\n') +
         `\nDon't pick up unrelated signals even if they appear ready -- file them separately.\n`
@@ -386,15 +426,17 @@ Discover/Design/Develop/Deploy session would hit, not particular to this CI envi
 Stop once you've done the above. Do not push — the workflow pushes once, after this session ends.`;
 }
 
-function emit({ ready, signals, stalled: stalledFlag, promptOverride, excludedCount = 0 }) {
+function emit({ ready, signals, stalled: stalledFlag, promptOverride, excludedCount = 0, noEligibleNote = null }) {
   const top = signals[0];
   const summary = stalledFlag
     ? `Stalled: "${top?.key}" has repeated ${STALL_THRESHOLD}+ times with no lineage-graph movement — stopping rather than looping uninformatively.`
     : top
       ? `${signals.length} signal(s) found; top: ${top.reason}`
-      : excludedCount > 0
-        ? `Nothing eligible on this branch (${excludedCount} other signal(s) exist but are out of scope — filtered by branch type or artifact scope).`
-        : 'No plausible next ddd action found — every requirement is refined, designed, implemented, and deployed, with no unresolved open-question/blocker.';
+      : noEligibleNote
+        ? `Nothing eligible on this branch — ${noEligibleNote}`
+        : excludedCount > 0
+          ? `Nothing eligible on this branch (${excludedCount} other signal(s) exist but are out of scope — filtered by branch type or artifact scope).`
+          : 'No plausible next ddd action found — every requirement is refined, designed, implemented, and deployed, with no unresolved open-question/blocker.';
 
   console.log(JSON.stringify({ ready, stalled: !!stalledFlag, signals, summary }, null, 2));
 
@@ -418,4 +460,4 @@ function emit({ ready, signals, stalled: stalledFlag, promptOverride, excludedCo
   );
 }
 
-emit({ ready, signals: eligibleSignals, stalled, excludedCount });
+emit({ ready, signals: eligibleSignals, stalled, excludedCount, noEligibleNote });

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
@@ -30,7 +30,11 @@ on:
         required: false
         type: string
       artifact_scope:
-        description: Comma-separated project-docs paths from the first commit on this branch -- set only by the loop's own self-dispatch; blank on first push (derived automatically)
+        description: >-
+          Comma-separated project-docs paths scoping this run to a specific set of artifacts.
+          Set to '*' to run across all available work with no artifact filtering (open scope).
+          Leave blank to auto-derive scope from the first commit on this branch (push-triggered
+          or manual); forwarded unchanged by the loop's own self-dispatch on subsequent iterations.
         required: false
         type: string
 
@@ -139,11 +143,16 @@ jobs:
 
       - name: Resolve artifact scope
         id: scope
-        # inputs.artifact_scope only ever has a value on the loop's own self-dispatch -- blank on
-        # a push-triggered run, where it's derived from the first commit on this branch instead.
-        # Forwarded unchanged across every self-dispatch so task-identification sees the same scope.
+        # Three cases:
+        #   '*'       -- explicit open scope; no derivation, task-identification runs unfiltered.
+        #   non-empty -- forwarded unchanged from a prior self-dispatch; no re-derivation.
+        #   blank     -- first push or manual trigger with no scope; derived from the first commit.
+        # inputs.artifact_scope is moved to an env var before the script runs to avoid shell
+        # injection — a direct ${{ }} expression in a run: body is a command-injection vector.
+        env:
+          ARTIFACT_SCOPE_INPUT: ${{ inputs.artifact_scope }}
         run: |
-          scope="${{ inputs.artifact_scope }}"
+          scope="$ARTIFACT_SCOPE_INPUT"
           if [[ -z "$scope" ]]; then
             first_sha=$(git log --reverse --format="%H" "origin/main..HEAD" 2>/dev/null | head -1)
             if [[ -n "$first_sha" ]]; then


### PR DESCRIPTION
## Summary

- **Open-scope mode**: `artifact_scope=*` is now a recognised sentinel — triggers unfiltered runs across all artifacts, forwarded unchanged to every self-dispatched iteration. Visible as a checkbox/text input in the GitHub Actions manual dispatch UI; the input description explains the behaviour.
- **Shell injection fix**: the "Resolve artifact scope" step was interpolating `${{ inputs.artifact_scope }}` directly into a `run:` body; moved to `env: ARTIFACT_SCOPE_INPUT` and referenced as `"$ARTIFACT_SCOPE_INPUT"`.
- **Silent-bypass warning**: when `ARTIFACT_SCOPE` contains paths but none resolve to a registry key (e.g. a file was renamed between the first commit and a later iteration), a warning is now emitted rather than silently running unfiltered with the prompt still claiming a scope.
- **Per-filter diagnostics**: the "nothing eligible" summary now names which filter(s) fired and how many signals each matched, rather than a single generic message.
- **Documentation**: `AGENTS.guidance.md` gains a "CI harness" section covering `artifact_scope`, the `*` sentinel, fix-branch interaction, and the diagnostic output.

## Test plan

- [ ] Manual dispatch with `artifact_scope=*` → task-identification prompt says "open scope (explicitly requested)"
- [ ] Manual dispatch with blank `artifact_scope` → scope derived from first commit as before (no regression)
- [ ] Pass a path that exists in the first commit but rename the file → warning appears in step log, run continues unfiltered
- [ ] `fix/**` branch with `artifact_scope=*` → only broken:/open: signals; prompt shows open scope note inside the fix-branch note
- [ ] `fix/**` branch with a scoped path and no matching broken/open signals → diagnostic names both filters and their per-filter counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)