### PR TITLE
chore(nx-agent): disable agent-delivery workflow until Copilot CLI is enabled in org

### DIFF
--- a/.github/workflows/agent-delivery-iteration.yml
+++ b/.github/workflows/agent-delivery-iteration.yml
@@ -18,11 +18,8 @@ name: Agent Delivery Iteration (Copilot CLI)
 # self-dispatch -- any other push (starting the branch, or a human pushing mid-sequence) resets to
 # iteration 1 by construction. That's intentional: a human push means supervised, ongoing work,
 # not a runaway loop, so it earns a fresh MAX_ITERATIONS budget.
+# Disabled: Copilot CLI is not yet enabled in this org. Re-add the push trigger below to activate.
 on:
-  push:
-    branches:
-      - "fix/**"
-      - "feature/**"
   workflow_dispatch:
     inputs:
       iteration:


### PR DESCRIPTION
## Summary

- Removes the `push` trigger from `agent-delivery-iteration.yml`, leaving only `workflow_dispatch`
- The workflow will no longer fire automatically on `feature/**` or `fix/**` branch pushes
- Re-enabling is a one-line change — the comment in the file marks exactly where to add the trigger back

## Test plan

- [ ] Confirm no Actions run triggers on push after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)