### PR TITLE
fix(nx-agent): skip stall-detection history write when no work is found

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -1,5 +1,9 @@
 import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import generator from './agent-delivery';
 
 const SKILL_PATHS = [
@@ -86,18 +90,43 @@ describe('nx-agent agent-delivery generator', () => {
     expect(taskIdentification).not.toContain('is not. If you reach Deploy');
   });
 
-  it('task-identification does not push a none key on no-work runs', async () => {
+  it('task-identification does not write history.json when no signals exist', async () => {
     await generator(host, { githubActions: true });
 
-    // The template must guard the history write behind `if (topSignal)` — a
-    // bare `topSignal?.key ?? 'none'` push causes a spurious history.json
-    // commit on every no-work run and corrupts stall detection when a real
-    // signal recurs across a no-work gap.
-    const taskIdentification = host
-      .read('scripts/task-identification.mjs')
-      .toString();
-    expect(taskIdentification).not.toContain("?? 'none'");
-    expect(taskIdentification).toContain('if (topSignal)');
+    const script = host.read('scripts/task-identification.mjs').toString();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'nx-agent-task-id-test-'));
+    try {
+      writeFileSync(join(tmpDir, 'task-identification.mjs'), script);
+      symlinkSync(join(process.cwd(), 'node_modules'), join(tmpDir, 'node_modules'));
+
+      mkdirSync(join(tmpDir, '.nx-agent'));
+      writeFileSync(
+        join(tmpDir, '.nx-agent', 'lineage.json'),
+        JSON.stringify({
+          registry: {},
+          index: {},
+          violations: {
+            brokenRefs: [],
+            unscoped: [],
+            orphans: [],
+            resolutionStatus: { open: [], resolved: [] },
+          },
+        }),
+      );
+
+      const outputFile = join(tmpDir, 'github-output');
+      writeFileSync(outputFile, '');
+      execSync('node task-identification.mjs', {
+        cwd: tmpDir,
+        env: { ...process.env, GITHUB_OUTPUT: outputFile, GITHUB_REF_NAME: 'feature/test' },
+      });
+
+      expect(
+        existsSync(join(tmpDir, '.github', 'agent-delivery-iteration', 'history.json')),
+      ).toBe(false);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
   });
 
   it('never overwrites a file a team has already edited', async () => {

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -86,6 +86,20 @@ describe('nx-agent agent-delivery generator', () => {
     expect(taskIdentification).not.toContain('is not. If you reach Deploy');
   });
 
+  it('task-identification does not push a none key on no-work runs', async () => {
+    await generator(host, { githubActions: true });
+
+    // The template must guard the history write behind `if (topSignal)` — a
+    // bare `topSignal?.key ?? 'none'` push causes a spurious history.json
+    // commit on every no-work run and corrupts stall detection when a real
+    // signal recurs across a no-work gap.
+    const taskIdentification = host
+      .read('scripts/task-identification.mjs')
+      .toString();
+    expect(taskIdentification).not.toContain("?? 'none'");
+    expect(taskIdentification).toContain('if (topSignal)');
+  });
+
   it('never overwrites a file a team has already edited', async () => {
     await generator(host, { githubActions: true });
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -329,10 +329,15 @@ if (process.env.PEEK_ONLY !== 'true') {
     }
   }
 
-  const lineageFingerprint = JSON.stringify(violations);
-  history.push({ key: topSignal?.key ?? 'none', lineageFingerprint });
-  history = history.slice(-HISTORY_KEEP);
-  writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2) + '\n');
+  // Only record history when there is a real eligible signal — no-work runs have
+  // nothing to stall on, and 'none' entries corrupt the stall-detection window when
+  // a real signal recurs across a no-work gap.
+  if (topSignal) {
+    const lineageFingerprint = JSON.stringify(violations);
+    history.push({ key: topSignal.key, lineageFingerprint });
+    history = history.slice(-HISTORY_KEEP);
+    writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2) + '\n');
+  }
 
   if (topSignal && history.length >= STALL_THRESHOLD) {
     const recent = history.slice(-STALL_THRESHOLD);

--- a/project-docs/artifact-schema.json
+++ b/project-docs/artifact-schema.json
@@ -1,0 +1,10 @@
+{
+  "bugs": {
+    "expectedAncestorTypes": [],
+    "tracksResolution": true
+  },
+  "iteration-retrospectives": {
+    "expectedAncestorTypes": [],
+    "terminal": true
+  }
+}

--- a/project-docs/bugs/README.md
+++ b/project-docs/bugs/README.md
@@ -1,0 +1,35 @@
+# Bugs
+
+Something already built isn't behaving as designed — reported from outside the DDDD (Discover/
+Design/Develop/Deploy) workflow (a user, QA, support), not raised internally by a later pipeline
+stage the way a `blocker` is. One file per bug, so listing this folder
+(cheap — just filenames) is enough to see what's currently wrong.
+
+Add one with `nx g @abgov/nx-agent:bug "<what's wrong>" [--project-docs-ancestors <path to the
+implicated requirement/design, if already known>]` — don't hand-author files here, so the
+frontmatter shape stays consistent. Each file:
+
+    ---
+    project-docs-ancestors: []
+    resolves: []
+    ---
+
+    Submitting the collision report form on a slow connection appears to do nothing — no error, no
+    confirmation. Expected: either a success confirmation or a visible error.
+
+- `project-docs-ancestors` — the requirement/design this bug's behavior traces to, if already known.
+  Genuinely, often left empty: a bug reported from outside the system frequently doesn't know which
+  artifact (if any) is at fault until Develop investigates it — resolved from an existing artifact's
+  path via `--project-docs-ancestors <path>` when it is known, never typed by hand.
+- `resolves` — always present, empty here. A `bug` doesn't resolve other artifacts (see
+  `open-question`/`blocker`'s own convention — same shape, same reasoning).
+
+**Not the same thing as a `blocker`.** A `blocker` is raised internally, by a later pipeline stage
+that's already working inside a specific artifact's context, and is resolved by _revising that
+artifact_. A bug is often a pure implementation defect where nothing about the design is wrong at
+all — resolved by a code fix, via an `iteration-retrospective`'s own `--resolves` once that fix
+lands, not by revising an upstream artifact. Investigation _can_ conclude the spec itself was wrong,
+in which case file a real `blocker` against the implicated artifact — but filing that blocker does
+not itself resolve the bug; the bug stays open until the actual fix's retrospective resolves it.
+
+Run `nx g @abgov/nx-agent:project-docs-lineage` to see which bugs are still open versus resolved.

--- a/project-docs/bugs/stall-detection-history-none-entries-on-no-work-runs.md
+++ b/project-docs/bugs/stall-detection-history-none-entries-on-no-work-runs.md
@@ -1,0 +1,17 @@
+---
+project-docs-ancestors: []
+resolves: []
+---
+
+Observed: when task-identification finds no eligible signals, it still pushes `{ key: 'none',
+lineageFingerprint }` to history.json and the workflow commits it — a spurious commit on every
+no-work run.
+
+Expected: history.json is only written when a real signal is present. A no-work run has nothing
+to stall on and nothing to record.
+
+Secondary: 'none' entries corrupt stall detection. A real signal recurring across runs that
+include a no-work gap never reaches the stall threshold because the recent window contains
+mismatched keys.
+
+Affected file: `packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs`

--- a/project-docs/iteration-retrospectives/README.md
+++ b/project-docs/iteration-retrospectives/README.md
@@ -1,0 +1,35 @@
+# Iteration retrospectives
+
+A close-out record for a single iteration's pass — what it did, what was found and fixed along the
+way, and an explicit status when "deployment succeeded" and "verified working end-to-end"
+diverge. One file per pass, so listing this folder (cheap — just filenames) is
+enough to see what's already been closed out.
+
+Not the same thing as a periodic, cross-iteration review that reads back across many of these to
+find drift a single pass can't see on its own — that's a separate, standing process a team runs on
+its own cadence. This folder holds the per-iteration records that process would read, not the
+process itself.
+
+Add one with `nx g @abgov/nx-agent:iteration-retrospective "<title>" --project-docs-ancestors <path>
+...` — don't hand-author files here, so the frontmatter shape stays consistent. Each file:
+
+    ---
+    title: Submit Minor Collision Report
+    project-docs-ancestors: [requirements:submit-minor-collision-report]
+    resolves: []
+    ---
+
+    Implemented the submit-minor-collision-report flow end to end. Revised
+    domain-models:collision-report-lifecycle with invariants 5-7 while doing so. Deployed and
+    verified working against a real sandbox.
+
+- `project-docs-ancestors` — every artifact this pass substantively created, revised, or touched —
+  not just the requirement it nominally closes out. Resolved from an existing artifact's path via
+  `--project-docs-ancestors <path>`, not typed by hand; name domain models and designs the pass
+  actually changed here too, not only the requirement.
+- `resolves` — any open-question/blocker this pass settled, via `--resolves <path>` on the same
+  invocation. Always present, empty if nothing was resolved.
+
+A correctly-closed-out retrospective has zero descendants forever — nothing is ever expected to
+build on a close-out record — so it's excluded from `project-docs-lineage`'s orphan report rather
+than flagged alongside a genuine dead-end.

--- a/project-docs/iteration-retrospectives/fix-stall-detection-none-entries-on-no-work-runs.md
+++ b/project-docs/iteration-retrospectives/fix-stall-detection-none-entries-on-no-work-runs.md
@@ -1,0 +1,16 @@
+---
+title: fix stall-detection none entries on no-work runs
+project-docs-ancestors: [bugs:stall-detection-history-none-entries-on-no-work-runs]
+resolves: [bugs:stall-detection-history-none-entries-on-no-work-runs]
+---
+
+The bug was confirmed in the template file only: the live `scripts/task-identification.mjs`
+had already been patched by hand on the branch, but
+`packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs`
+still contained the original `topSignal?.key ?? 'none'` fallback at the history-write site.
+
+Fix applied: wrapped the history push + writeFileSync in `if (topSignal)`, matching the live
+script, and added a regression test in `agent-delivery.spec.ts` asserting the template does
+not contain `?? 'none'` and does contain the `if (topSignal)` guard.
+
+All 219 unit tests pass; build and lint clean (pre-existing warnings only).


### PR DESCRIPTION
## Summary

- Guards the `history.push` in the agent-delivery generator template's `task-identification.mjs` behind `if (topSignal)`, matching the fix already applied to the live `scripts/` copy
- Adds a regression test asserting the generated file contains the guard and not the `?? 'none'` fallback

**Two bugs fixed:**
1. A no-work run always dirtied `history.json`, triggering a spurious commit on every branch push where no `project-docs/` signals existed yet
2. `'none'` entries corrupted stall detection — a real signal recurring across runs with a no-work gap never accumulated consecutive identical entries and never reached the stall threshold

## Test plan

- [ ] 219/219 tests pass (includes new regression test)
- [ ] Verify generated `task-identification.mjs` no longer contains `?? 'none'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)