### PR TITLE
feat(nx-agent): require implementation plan commitment in develop skill step 1

### DIFF
--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -3,6 +3,7 @@ name: develop
 description: Implement an api-design/ux-design against real code, following the project's own generated recipe (its own AGENTS.md — the exact steps vary by stack), with a project-docs-ancestors code comment tying every new file back to the design it implements. Runs an inline gate battery — audit, secret scan, build, test, always blocking — plus an independent code review, every pass, advisory.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 argument-hint: "<api-design or ux-design slug to implement>"
+project-docs-ancestors: [skill-designs:develop-skill-lineage-plan-step]
 ---
 
 ## Which artifact
@@ -60,7 +61,10 @@ no Design pass needed:
    run `npx nx g @abgov/nx-agent:project-docs-lineage` (without `--dry-run`) and read
    `.nx-agent/lineage.json`'s `index` entry for that domain-model (or its bounded-context ancestor)
    to see what other code already exists building on the same domain concepts — a sibling resource
-   may have already implemented shared logic this pass should reuse.
+   may have already implemented shared logic this pass should reuse. Before moving on, state your
+   implementation plan in one short block: which sibling resources you found and will reuse, what
+   you are implementing fresh, and which domain invariants belong in the service vs. orchestration
+   layer. This makes the lineage read a commitment, not a note.
 
 2. **Follow the project's own recipe end to end** — check its `AGENTS.md` for its exact "Recipe:
    add a resource"/"Adding a new route" section (naming varies by stack — an `express-service`'s
@@ -140,14 +144,14 @@ blocking status depends on whether this project has a CI backstop yet — see be
 
 ### Independent code review — every pass
 
-Give the reviewer only the api-design/ux-design, the
-domain terms it should be consistent with, and the new/changed code — never this pass's own
-reasoning. Ask it: does the code use a term inconsistently with the domain vocabulary (naming
-included — a generic implementation-layer word standing in for a domain noun is drift too)? Is
-anything more elaborate than the design calls for? Is anything unclear? Does the code implement
-everything the design specifies, and nothing it doesn't? Always advisory — act on a real finding
-by fixing it or by updating the design doc when the code's approach is the better one, don't just
-log it.
+Give the reviewer the api-design/ux-design, the domain terms it should be consistent with, the
+implementation plan from step 1, and the new/changed code — never this pass's own reasoning.
+Ask it: does the code match what the plan said it would reuse and build fresh? Does the code use
+a term inconsistently with the domain vocabulary (naming included — a generic implementation-layer
+word standing in for a domain noun is drift too)? Is anything more elaborate than the design calls
+for? Is anything unclear? Does the code implement everything the design specifies, and nothing it
+doesn't? Always advisory — act on a real finding by fixing it or by updating the design doc when
+the code's approach is the better one, don't just log it.
 
 ### Commit before ending this skill
 

--- a/.github/agent-delivery-iteration/history.json
+++ b/.github/agent-delivery-iteration/history.json
@@ -10,5 +10,9 @@
   {
     "key": "unprocessed-feature:features:develop-skill-lineage-plan-step",
     "lineageFingerprint": "{\"brokenRefs\":[],\"orphans\":[\"features:develop-skill-lineage-plan-step\"],\"unscoped\":[],\"resolutionStatus\":{\"open\":[],\"resolved\":[]}}"
+  },
+  {
+    "key": "undesigned-design:domain-models:develop-skill-commitment-pattern",
+    "lineageFingerprint": "{\"brokenRefs\":[],\"orphans\":[],\"unscoped\":[],\"resolutionStatus\":{\"open\":[],\"resolved\":[]}}"
   }
 ]

--- a/.github/agent-delivery-iteration/history.json
+++ b/.github/agent-delivery-iteration/history.json
@@ -6,5 +6,9 @@
   {
     "key": "none",
     "lineageFingerprint": "{\"brokenRefs\":[],\"orphans\":[],\"unscoped\":[],\"resolutionStatus\":{\"open\":[],\"resolved\":[]}}"
+  },
+  {
+    "key": "unprocessed-feature:features:develop-skill-lineage-plan-step",
+    "lineageFingerprint": "{\"brokenRefs\":[],\"orphans\":[\"features:develop-skill-lineage-plan-step\"],\"unscoped\":[],\"resolutionStatus\":{\"open\":[],\"resolved\":[]}}"
   }
 ]

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -3,6 +3,7 @@ name: develop
 description: Implement an api-design/ux-design against real code, following the project's own generated recipe (its own AGENTS.md — the exact steps vary by stack), with a project-docs-ancestors code comment tying every new file back to the design it implements. Runs an inline gate battery — audit, secret scan, build, test, always blocking — plus an independent code review, every pass, advisory.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
 argument-hint: "<api-design or ux-design slug to implement>"
+project-docs-ancestors: [skill-designs:develop-skill-lineage-plan-step]
 ---
 
 ## Which artifact
@@ -60,7 +61,10 @@ no Design pass needed:
    run `npx nx g @abgov/nx-agent:project-docs-lineage` (without `--dry-run`) and read
    `.nx-agent/lineage.json`'s `index` entry for that domain-model (or its bounded-context ancestor)
    to see what other code already exists building on the same domain concepts — a sibling resource
-   may have already implemented shared logic this pass should reuse.
+   may have already implemented shared logic this pass should reuse. Before moving on, state your
+   implementation plan in one short block: which sibling resources you found and will reuse, what
+   you are implementing fresh, and which domain invariants belong in the service vs. orchestration
+   layer. This makes the lineage read a commitment, not a note.
 
 2. **Follow the project's own recipe end to end** — check its `AGENTS.md` for its exact "Recipe:
    add a resource"/"Adding a new route" section (naming varies by stack — an `express-service`'s
@@ -140,14 +144,14 @@ blocking status depends on whether this project has a CI backstop yet — see be
 
 ### Independent code review — every pass
 
-Give the reviewer only the api-design/ux-design, the
-domain terms it should be consistent with, and the new/changed code — never this pass's own
-reasoning. Ask it: does the code use a term inconsistently with the domain vocabulary (naming
-included — a generic implementation-layer word standing in for a domain noun is drift too)? Is
-anything more elaborate than the design calls for? Is anything unclear? Does the code implement
-everything the design specifies, and nothing it doesn't? Always advisory — act on a real finding
-by fixing it or by updating the design doc when the code's approach is the better one, don't just
-log it.
+Give the reviewer the api-design/ux-design, the domain terms it should be consistent with, the
+implementation plan from step 1, and the new/changed code — never this pass's own reasoning.
+Ask it: does the code match what the plan said it would reuse and build fresh? Does the code use
+a term inconsistently with the domain vocabulary (naming included — a generic implementation-layer
+word standing in for a domain noun is drift too)? Is anything more elaborate than the design calls
+for? Is anything unclear? Does the code implement everything the design specifies, and nothing it
+doesn't? Always advisory — act on a real finding by fixing it or by updating the design doc when
+the code's approach is the better one, don't just log it.
 
 ### Commit before ending this skill
 

--- a/project-docs/artifact-schema.json
+++ b/project-docs/artifact-schema.json
@@ -3,6 +3,9 @@
     "expectedAncestorTypes": [],
     "tracksResolution": true
   },
+  "features": {
+    "expectedAncestorTypes": []
+  },
   "iteration-retrospectives": {
     "expectedAncestorTypes": [],
     "terminal": true

--- a/project-docs/artifact-schema.json
+++ b/project-docs/artifact-schema.json
@@ -6,6 +6,12 @@
   "features": {
     "expectedAncestorTypes": []
   },
+  "service-descriptions": {
+    "expectedAncestorTypes": ["features"]
+  },
+  "requirements": {
+    "expectedAncestorTypes": ["service-descriptions"]
+  },
   "iteration-retrospectives": {
     "expectedAncestorTypes": [],
     "terminal": true

--- a/project-docs/artifact-schema.json
+++ b/project-docs/artifact-schema.json
@@ -12,6 +12,18 @@
   "requirements": {
     "expectedAncestorTypes": ["service-descriptions"]
   },
+  "bounded-contexts": {
+    "expectedAncestorTypes": []
+  },
+  "domain-terms": {
+    "expectedAncestorTypes": ["bounded-contexts"]
+  },
+  "domain-models": {
+    "expectedAncestorTypes": ["bounded-contexts", "domain-terms"]
+  },
+  "skill-designs": {
+    "expectedAncestorTypes": ["domain-models"]
+  },
   "iteration-retrospectives": {
     "expectedAncestorTypes": [],
     "terminal": true

--- a/project-docs/bounded-contexts/README.md
+++ b/project-docs/bounded-contexts/README.md
@@ -1,0 +1,31 @@
+# Bounded contexts
+
+The boundaries within which this project's domain vocabulary and model apply — the same word can
+mean something different once you cross into another context, so keeping each one's boundary
+explicit is what keeps a domain term's meaning unambiguous. One file per
+context, so listing this folder (cheap — just filenames) is enough to see the whole map before
+adding a new one.
+
+Add a context with `nx g @abgov/nx-agent:bounded-context <name>` — don't hand-author files here, so
+the frontmatter shape stays consistent. Each file:
+
+    ---
+    name: Collision Reporting
+    aliases: []
+    not_confused_with:
+      - term: Case Management
+        reason: Case Management spans multiple contexts; Collision Reporting is one narrow slice of it.
+    ---
+
+    Everything from intake of a collision report through its initial triage. Excludes the
+    downstream investigation and resolution workflow, which belongs to Case Management.
+
+- `name` — the canonical name, matching the filename.
+- `aliases` — other words or abbreviations that mean the _same_ context.
+- `not_confused_with` — similarly-named contexts this one is deliberately distinct from, and why.
+  Leave it empty if there's no real ambiguity to guard against.
+
+The body is free text — describe what's inside the boundary and, just as importantly, what's
+explicitly outside it and belongs to a different context instead. A domain term
+(`nx g @abgov/nx-agent:domain-term ... --project-docs-ancestors <this-file>`) should normally derive
+from the bounded context its meaning depends on.

--- a/project-docs/bounded-contexts/agent-delivery-harness.md
+++ b/project-docs/bounded-contexts/agent-delivery-harness.md
@@ -1,0 +1,17 @@
+---
+name: Agent Delivery Harness
+aliases: []
+not_confused_with: []
+project-docs-ancestors: []
+resolves: []
+---
+
+**Inside**: the four DDDD skills (Discover, Design, Develop, Deploy), the gate checks each skill
+runs, the commit conventions each skill specifies, and the supporting scripts and tooling generated
+by `@abgov/nx-agent:agent-delivery` into a consuming workspace. The step-by-step instructions
+each skill gives an agent — including how the agent reads the lineage graph and what it must state
+before proceeding — are inside this boundary.
+
+**Outside**: the business domain being delivered (its requirements, domain models, API designs,
+and UX designs), the code the agent writes for a consuming service, and the infrastructure
+(OpenShift, ADSP) the consuming service deploys to.

--- a/project-docs/domain-models/README.md
+++ b/project-docs/domain-models/README.md
@@ -1,0 +1,26 @@
+# Domain models
+
+The actual design — aggregates, entities, value objects, invariants — built from the vocabulary and
+boundaries this project has already established. One file per model, so
+listing this folder (cheap — just filenames) is enough to see what's been designed before adding to
+it.
+
+Add a model with `nx g @abgov/nx-agent:domain-model <name> --project-docs-ancestors <path> ...` —
+don't hand-author files here, so the frontmatter shape stays consistent. Each file:
+
+    ---
+    name: Collision Report Lifecycle
+    project-docs-ancestors: [bounded-contexts:collision-reporting, domain-terms:collision-report]
+    ---
+
+    A CollisionReport aggregate, keyed by its report id, moving through Intake -> Triage ->
+    Closed. Triage requires an assigned reviewer; Closed requires a resolution code.
+
+- `name` — the canonical name, matching the filename.
+- `project-docs-ancestors` — the bounded context this model belongs to and the domain terms it's
+  composed from. Set with `--project-docs-ancestors <path>` at creation time, not by hand — see
+  `nx g @abgov/nx-agent:project-docs-lineage`'s own guidance for the full reference convention.
+
+The body is free text — the actual design. Keep it current: when the model changes (a new
+invariant, a renamed aggregate), update its file rather than letting the answer live only in the
+code that happens to implement it today.

--- a/project-docs/domain-models/develop-skill-commitment-pattern.md
+++ b/project-docs/domain-models/develop-skill-commitment-pattern.md
@@ -1,0 +1,36 @@
+---
+name: Develop Skill Commitment Pattern
+project-docs-ancestors: [bounded-contexts:agent-delivery-harness, domain-terms:implementation-plan, requirements:develop-skill-lineage-read-must-commit-before-write]
+resolves: []
+---
+
+## Lineage Read Phase
+
+The develop skill's step 1 instructs the agent to run `project-docs-lineage` and read the `index`
+entry for the domain model being implemented. This produces a list of sibling files that share the
+same domain-model ancestor.
+
+**Invariant**: the lineage read is only meaningful if it shapes what is built. Reading sibling
+resources without committing to what was found is structurally identical to not reading them. The
+commitment is what makes the read actionable.
+
+## Implementation Plan
+
+The Implementation Plan (see domain term) is the artifact of the commitment. It is stated in-session
+before the agent writes the first file. It is not a new project-docs artifact — it lives in context
+and is passed to the independent reviewer.
+
+**Invariant**: the plan must cover three axes before any code is written:
+1. Which sibling resources will be reused (named explicitly, not just acknowledged)
+2. What is being implemented fresh, and why no sibling covers it
+3. Where domain invariants from the domain model belong (service layer vs. orchestration layer)
+
+## Independent Review
+
+The independent reviewer checks the code against the design artifacts. Adding the Implementation
+Plan to the reviewer's context enables a checkable question: "Does the code match what the plan
+said it would reuse and build fresh?" Without the plan, the reviewer can only compare code to design
+— it cannot check whether a reuse decision was followed through.
+
+**Invariant**: the Implementation Plan is passed to the reviewer alongside (not instead of) the
+design artifacts and domain terms. It is never this pass's own reasoning — it is a prior commitment.

--- a/project-docs/domain-terms/README.md
+++ b/project-docs/domain-terms/README.md
@@ -1,0 +1,35 @@
+# Domain terms
+
+The ubiquitous language for this project — domain terms as the business actually uses them, not
+translated into technical jargon. One file per term, so each stays
+independently reviewable, and so listing this folder (cheap — just filenames) is enough to check
+the existing vocabulary before coining a new name; only open a file when you need its full
+definition.
+
+Add a term with `nx g @abgov/nx-agent:domain-term <name>` — don't hand-author files here, so the
+frontmatter shape stays consistent. Each file:
+
+    ---
+    term: Case
+    aliases: []
+    not_confused_with:
+      - term: File
+        reason: File is the underlying record storage; Case is the workflow around it.
+    project-docs-ancestors: []
+    ---
+
+    A single citizen-facing request being tracked from intake through resolution.
+
+- `term` — the canonical name, matching the filename.
+- `aliases` — other words that mean the _same_ thing; recording them here heads off a synonym
+  drifting into use unchecked elsewhere.
+- `not_confused_with` — similar-sounding terms this one is deliberately distinct from, and why.
+  Leave it empty if there's no real ambiguity to guard against.
+- `project-docs-ancestors` — other `project-docs/` artifacts this term derives from (e.g. a bounded
+  context it belongs to). Set with `--project-docs-ancestors <path>` at creation time, not by hand —
+  see `nx g @abgov/nx-agent:project-docs-lineage`'s own guidance for the full reference convention.
+
+The body is free text — the actual definition, in domain language, with as much nuance as the
+term needs. Keep it current: when a term gets clarified (with a domain expert, in a requirements
+doc, in conversation), update its file rather than letting the answer live only in one commit
+message or one person's memory.

--- a/project-docs/domain-terms/implementation-plan.md
+++ b/project-docs/domain-terms/implementation-plan.md
@@ -1,0 +1,18 @@
+---
+term: Implementation Plan
+aliases: []
+not_confused_with: []
+project-docs-ancestors: [bounded-contexts:agent-delivery-harness]
+resolves: []
+---
+
+A structured statement an agent makes after reading the lineage graph in develop skill step 1,
+before writing any code. It specifies:
+
+- which sibling resources it found and will reuse (naming them explicitly)
+- what it is implementing fresh (and why no sibling already covers it)
+- which domain invariants belong in the service layer vs. the orchestration layer
+
+The Implementation Plan is what transforms the lineage read from a note into a commitment — it
+forces a decision to be stated before it can be assumed. It is passed to the independent code
+reviewer alongside the code diff, so the reviewer can ask whether the diff matches it.

--- a/project-docs/features/README.md
+++ b/project-docs/features/README.md
@@ -1,0 +1,32 @@
+# Features
+
+How new work enters the DDDD (Discover/Design/Develop/Deploy) workflow — a capability someone wants,
+written down before anyone's decided what it actually requires. One file per
+feature request, so listing this folder (cheap — just filenames) is enough to see what's been asked
+for.
+
+Add one with `nx g @abgov/nx-agent:feature "<title>" [--project-docs-ancestors <path> ...]
+[--resolves <path> ...]` — don't hand-author files here, so the frontmatter shape stays consistent.
+Each file:
+
+    ---
+    title: Submit Minor Collision Report
+    project-docs-ancestors: []
+    resolves: []
+    ---
+
+    Drivers need a lightweight way to report a minor collision (no injuries, both parties agree on
+    fault) without going through the full incident-report flow meant for serious collisions.
+
+- `project-docs-ancestors` — an existing artifact this feature relates to, typically the
+  service-description it extends if one already exists for this initiative. Omit entirely for a
+  brand-new initiative with nothing yet to reference — resolved from an existing artifact's path via
+  `--project-docs-ancestors <path>`, never typed by hand.
+- `resolves` — which of those ancestors (typically an `open-question`/`blocker`) this feature
+  specifically _resolves_, not just builds on — set via `--resolves`, a distinct flag from
+  `--project-docs-ancestors` even though the same ref also lands there.
+
+The body is free text — the capability wanted, written the way it was actually asked for, not
+pre-structured. Discover's own "which mode" logic picks this up (a feature with no
+requirement/service-description descendant yet) and decomposes it from there — this file is the
+input to that process, not the output.

--- a/project-docs/features/develop-skill-lineage-plan-step.md
+++ b/project-docs/features/develop-skill-lineage-plan-step.md
@@ -1,0 +1,17 @@
+---
+title: develop skill: require implementation plan commitment before first write
+project-docs-ancestors: []
+resolves: []
+---
+
+The develop skill's step 1 reads the lineage graph and notes that a sibling resource may have
+already implemented shared logic this pass should reuse. No subsequent step requires the agent
+to commit to what it found before writing code. The lineage read is therefore structurally
+identical whether it shapes the implementation or is noted and set aside.
+
+Append a commitment sentence to step 1 requiring the agent to state its implementation plan —
+which sibling resources it found and will reuse, what it is implementing fresh, and which domain
+invariants belong in the service vs. orchestration layer — before writing anything. Also update
+the independent review section to receive the plan and check the diff against it.
+
+See `DEVELOP-SKILL-LINEAGE-PLAN-STEP-PROPOSAL.md` for the full evidence and exact change wording.

--- a/project-docs/iteration-retrospectives/add-implementation-plan-commitment-to-develop-skill-step-1.md
+++ b/project-docs/iteration-retrospectives/add-implementation-plan-commitment-to-develop-skill-step-1.md
@@ -1,0 +1,27 @@
+---
+title: add implementation plan commitment to develop skill step 1
+project-docs-ancestors: [requirements:develop-skill-lineage-read-must-commit-before-write, domain-models:develop-skill-commitment-pattern, skill-designs:develop-skill-lineage-plan-step]
+resolves: []
+---
+
+## What this pass did
+
+Appended an implementation plan commitment sentence to step 1 of the develop skill
+(`packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md` and the
+installed copy at `.claude/skills/develop/SKILL.md`). Also updated the independent review
+section to pass the plan to the reviewer and added "Does the code match what the plan said it
+would reuse and build fresh?" as the first reviewer question.
+
+Both files are identical; the generator template is the canonical source.
+
+## What was found along the way
+
+Nothing unexpected. The agent-delivery generator tests do not snapshot SKILL.md content, so no
+snapshot updates were needed. The 7 lint warnings (non-null assertions in an unrelated file) and
+the 44 npm audit findings pre-existed this pass — none were introduced by these changes.
+
+## Deployment status
+
+The `release-ci.yml` workflow exists. Semantic-release dry-run confirmed SSH-only failure in
+this local non-CI context — not a workflow error. The `feat(develop):` commit type will trigger
+a minor version bump on merge. Actual publish is CI-automated on merge to `main` or `beta`.

--- a/project-docs/requirements/develop-skill-lineage-read-must-commit-before-write.md
+++ b/project-docs/requirements/develop-skill-lineage-read-must-commit-before-write.md
@@ -1,0 +1,9 @@
+---
+title: "develop skill: lineage read must commit before first write"
+id: req-001
+project-docs-ancestors:
+  - service-descriptions:agent-delivery-harness
+  - features:develop-skill-lineage-plan-step
+rules: []
+questions: []
+---

--- a/project-docs/requirements/develop-skill-lineage-read-must-commit-before-write.md
+++ b/project-docs/requirements/develop-skill-lineage-read-must-commit-before-write.md
@@ -4,6 +4,27 @@ id: req-001
 project-docs-ancestors:
   - service-descriptions:agent-delivery-harness
   - features:develop-skill-lineage-plan-step
-rules: []
+rules:
+  - rule: step 1 requires a stated implementation plan before any code is written
+    examples:
+      - "Given: step 1 reads the lineage graph and finds sibling resources with shared patterns;
+         When: the agent prepares to write the first file;
+         Then: it states which sibling resources it found and will reuse, what it is implementing
+         fresh, and which domain invariants belong in the service vs. orchestration layer"
+    questions: []
+  - rule: the independent review receives the implementation plan alongside code and design artifacts
+    examples:
+      - "Given: a develop skill pass has completed its implementation;
+         When: the independent reviewer is invoked;
+         Then: it receives the api-design/ux-design, domain terms, implementation plan from step 1,
+         and new/changed code — never this pass's own reasoning"
+    questions: []
+  - rule: the independent reviewer's first question checks whether the diff matches the stated plan
+    examples:
+      - "Given: the independent reviewer has the implementation plan and the code diff;
+         When: it evaluates the code;
+         Then: its first question is: does the code match what the plan said it would reuse and
+         build fresh?"
+    questions: []
 questions: []
 ---

--- a/project-docs/service-descriptions/agent-delivery-harness.md
+++ b/project-docs/service-descriptions/agent-delivery-harness.md
@@ -1,0 +1,19 @@
+---
+service: Agent Delivery Harness
+audience: [AI coding agents operating a DDDD workflow]
+known-platforms: []
+questions: []
+project-docs-ancestors: [features:develop-skill-lineage-plan-step]
+---
+
+The Agent Delivery Harness is the set of DDDD skills (Discover, Design, Develop, Deploy) and
+supporting tooling that guides an AI coding agent through delivering a feature end to end.
+Each skill is a Markdown file the agent reads at the start of a stage; together they form the
+workflow skeleton the agent follows to decompose, design, implement, and ship a capability.
+
+The harness is the primary scaffolded output of the `@abgov/nx-agent:agent-delivery` generator.
+It operates in any workspace that hosts a `project-docs/` artifact graph.
+
+Outside the boundary: the business domain being delivered (requirements, domain models, designs),
+the code the agent writes for a consuming service, and the OpenShift/ADSP infrastructure the
+consuming service deploys to.

--- a/project-docs/skill-designs/develop-skill-lineage-plan-step.md
+++ b/project-docs/skill-designs/develop-skill-lineage-plan-step.md
@@ -1,0 +1,51 @@
+---
+title: "develop skill: implementation plan commitment"
+project-docs-ancestors: [domain-models:develop-skill-commitment-pattern]
+---
+
+The develop skill text is the contract this design specifies. The consumer is the agent reading
+step 1 and the independent review section. Both interface points below trace to the three rules
+in the requirement.
+
+## Interface point 1: step 1 — lineage read commitment
+
+**Traces to**: req-001 rule 1 — "step 1 requires a stated implementation plan before any code is
+written"
+
+**File**: `packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md`
+(also `.claude/skills/develop/SKILL.md` in this workspace)
+
+After the current sentence ending "...a sibling resource may have already implemented shared logic
+this pass should reuse.", append the following sentence block:
+
+```
+Before moving on, state your implementation plan in one short block: which sibling resources you
+found and will reuse, what you are implementing fresh, and which domain invariants belong in the
+service vs. orchestration layer. This makes the lineage read a commitment, not a note.
+```
+
+No step is added. No renumbering. The new text is appended to the existing step 1 paragraph.
+
+## Interface point 2: independent review — plan as reviewer input
+
+**Traces to**: req-001 rule 2 — "the independent review receives the implementation plan alongside
+code and design artifacts"; req-001 rule 3 — "the independent reviewer's first question checks
+whether the diff matches the stated plan"
+
+In the `### Independent code review — every pass` section, change the opening sentence from:
+
+> Give the reviewer only the api-design/ux-design, the
+> domain terms it should be consistent with, and the new/changed code — never this pass's own
+> reasoning.
+
+to:
+
+> Give the reviewer the api-design/ux-design, the domain terms it should be consistent with, the
+> implementation plan from step 1, and the new/changed code — never this pass's own reasoning.
+
+And prepend one question to the reviewer's list (before "does the code use a term
+inconsistently..."):
+
+```
+Does the code match what the plan said it would reuse and build fresh?
+```


### PR DESCRIPTION
## Summary

- Appends an implementation plan commitment sentence to step 1 of the develop skill: after reading the lineage graph, the agent must state which sibling resources it will reuse, what it is implementing fresh, and which domain invariants belong in the service vs. orchestration layer — before writing any code
- Updates the independent review section to receive the plan alongside code and design artifacts, and prepends a new first question: "Does the code match what the plan said it would reuse and build fresh?"
- Applied identically to the generator template (`packages/nx-agent/.../develop/SKILL.md`) and the installed copy (`.claude/skills/develop/SKILL.md`)

The change makes the lineage read a commitment rather than a note — an agent that reads siblings, ignores their conventions, and writes the `project-docs-ancestors` comment after the fact no longer satisfies the skill.

Full evidence and rationale in `DEVELOP-SKILL-LINEAGE-PLAN-STEP-PROPOSAL.md`.

## Test plan

- [ ] 218/218 tests pass (no snapshot changes needed — agent-delivery tests do not snapshot SKILL.md content)
- [ ] Lineage gate clean: 0 broken refs, 0 unscoped, 0 orphans, 0 open
- [ ] Verify step 1 commitment sentence present in both skill files
- [ ] Verify independent review section updated with plan input and new first question

🤖 Generated with [Claude Code](https://claude.com/claude-code)