### PR TITLE
chore: gitignore project-docs/report.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ id_ed25519
 credentials.json
 
 .nx-agent/
+project-docs/report.html


### PR DESCRIPTION
## Summary

- Adds `project-docs/report.html` to `.gitignore`

The `project-docs-report` generator adds this entry via `ensureGitignoreEntries` when first run in a consuming workspace. This repo skipped that step on first use — adding the entry directly.

## Test plan

- [ ] `project-docs/report.html` no longer appears as untracked after running the generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)