### PR TITLE
feat(nx-agent): add product-brief generator, rename service-descriptions

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -21,12 +21,12 @@ scope here.
 
 ## Steps
 
-1. **Read the requirement** (and its service-description ancestor) this pass is designing
+1. **Read the requirement** (and its product-brief ancestor) this pass is designing
    against.
 
 2. **Bounded context** — if this requirement's initiative doesn't have one yet:
    `npx nx g @abgov/nx-agent:bounded-context "<Name>"`. Fill in the generated placeholder: what's
-   inside the boundary, and what's explicitly outside it — the service-description's own scope
+   inside the boundary, and what's explicitly outside it — the product brief's own scope
    statements usually go straight into the "outside" half.
 
 3. **Domain terms** — one per concept the requirement's Rules actually use precisely and
@@ -79,7 +79,7 @@ scope here.
    (`- a` / `- b` per line) — never a multi-line `[...]` block. Rewrite to block-style by hand if
    it got reformatted wrong, then re-run the gate below.
 
-5. **Check for an existing capability before designing a new one.** Read the service-description's
+5. **Check for an existing capability before designing a new one.** Read the product brief's
    `known-platforms`. For each named platform, check whether it already covers what this
    requirement needs (a connected MCP server if one exists, or the platform's docs otherwise)
    before assuming a bespoke design is needed. **If no MCP server exists yet for a named platform,

--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -5,9 +5,9 @@ allowed-tools: Read, Write, Bash, Grep, Glob, Task
 argument-hint: "<feature slug to decompose, or a requirement slug to refine>"
 ---
 
-`feature`/`open-question`/`blocker`/`requirement` have real generators (`nx g @abgov/nx-agent:feature`/
-`:open-question`/`:blocker`/`:requirement`) — use them, don't hand-author. `service-description`
-still doesn't; write it by hand in the shape below. All five live under `project-docs/`.
+`feature`/`open-question`/`blocker`/`requirement`/`product-brief` have real generators
+(`nx g @abgov/nx-agent:feature`/`:open-question`/`:blocker`/`:requirement`/`:product-brief`) —
+use them, don't hand-author. All five live under `project-docs/`.
 
 `bug` also has a real generator (`nx g @abgov/nx-agent:bug`), but this skill never processes one
 directly — an open bug routes straight to Develop (investigate against the existing spec, fix,
@@ -15,7 +15,7 @@ verify), not through Discover's intake/refinement modes below.
 
 ## Which mode
 
-- A `features:<slug>` artifact with no `requirements`/`service-descriptions` descendant yet
+- A `features:<slug>` artifact with no `requirements`/`product-briefs` descendant yet
   (the raw capability request hasn't been decomposed): **intake**.
 - A single, already-scoped requirement (or a slug naming one that exists): **refinement**.
 - On a brand-new initiative, the first invocation does *intake*; if it yields exactly one clean
@@ -27,42 +27,33 @@ verify), not through Discover's intake/refinement modes below.
    capability request, written the way it was actually asked for, not pre-structured.
 2. Identify every distinguishable concern — a candidate requirement, a stray decision that isn't
    a requirement yet, or something genuinely unclear.
-3. **If no `project-docs/service-descriptions/<slug>.md` exists yet for this initiative, write it
-   first, before any requirement.** Root artifact, ancestor is the feature that founded it:
+3. **Check if a `project-docs/product-briefs/<slug>.md` already exists for this initiative** — a
+   product brief is a persistent positioning artifact, not created per-feature. If one already
+   exists, append this feature to its `project-docs-ancestors` list directly; don't regenerate it.
 
-   ```yaml
-   ---
-   service: <Name>
-   audience: []
-   known-platforms: []
-   questions: []
-   project-docs-ancestors: [features:<feature-slug>]
-   ---
+   If none exists yet, create it first, before any requirement:
 
-   <!-- Problem/opportunity framing and product positioning: what this service is for and who
-        it's for, in plain language. -->
+   ```
+   nx g @abgov/nx-agent:product-brief "<Name>" \
+     --projectDocsAncestors=project-docs/features/<feature-slug>.md
    ```
 
-   Register once: `"service-descriptions": { "expectedAncestorTypes": ["features"] }` in
-   `project-docs/artifact-schema.json` — every service-description should trace back to at least
-   one feature that founded it. **Get this exact line right**: this registration lives only as this
-   prose, nowhere in code, so the ancestor convention above and this schema entry have to change
-   together or `project-docs-lineage`'s `unscoped` check never actually fires for a
-   service-description missing a feature ancestor.
+   The generator creates the file, registers `product-briefs` in `artifact-schema.json` on first
+   use, and bootstraps the container README — nothing to do by hand.
 
-   `known-platforms` names existing systems/platforms/ecosystems this needs to operate within or
-   integrate with (e.g. `adsp`) — facts about the operating context, not a design decision (that's
-   Design's job). If genuinely unknown either way, add a `questions` entry rather than assuming.
+   Fill in the generated placeholder: what this capability is for, who it's for, and its operating
+   context. `known-platforms` names existing systems/platforms this must operate within (e.g.
+   `adsp`) — facts about the operating context, not a design decision (that's Design's job). If
+   genuinely unknown either way, add a `questions` entry rather than assuming.
 
    A later pass extending the same initiative from a *different* feature appends that feature to
-   `project-docs-ancestors` too (never overwrite the list) — the same convention every other
-   artifact type already uses for "built from more than one source," not a bespoke field.
+   `project-docs-ancestors` — same convention every other artifact type uses.
 
 4. For each concern that's a genuine, scoped candidate requirement, run:
 
    ```
    nx g @abgov/nx-agent:requirement "<title>" \
-     --projectDocsAncestors=project-docs/service-descriptions/<service-slug>.md,project-docs/features/<feature-slug>.md
+     --projectDocsAncestors=project-docs/product-briefs/<brief-slug>.md,project-docs/features/<feature-slug>.md
    ```
 
    The generator assigns the next unused `req-NNN` id automatically (scanning existing files),
@@ -122,7 +113,7 @@ the same target, so a repeat hit is seen immediately.
 
 Given one requirement (by slug or `id`):
 
-1. Read the requirement file and its service-description ancestor.
+1. Read the requirement file and its product-brief ancestor.
 2. Example-map it: add an entry to frontmatter `rules:` for each distinct behavior the
    requirement implies, each with either a Given/When/Then-shaped string in `examples:` or a
    question string in `questions:` — never leave a rule with both empty.
@@ -149,7 +140,7 @@ These check different things:
 ### Independent review
 
 Run every time a requirement finishes refinement, not just founding ones. Give the reviewer only
-the finished requirement and its service-description ancestor — not this pass's notes, reasoning,
+the finished requirement and its product-brief ancestor — not this pass's notes, reasoning,
 or raw input. Ask it:
 
 1. Does the service description imply a rule this requirement doesn't cover?

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -28,6 +28,11 @@
       "schema": "./src/generators/domain-term/schema.json",
       "description": "Adds one domain term under project-docs/domain-terms/, with structured frontmatter and a free-text definition."
     },
+    "product-brief": {
+      "factory": "./src/generators/product-brief/product-brief",
+      "schema": "./src/generators/product-brief/schema.json",
+      "description": "Adds one product brief under project-docs/product-briefs/, with structured frontmatter (capability, audience, known-platforms, questions) and a free-text body. Persistent positioning artifact — create once, reference and extend directly thereafter."
+    },
     "bounded-context": {
       "factory": "./src/generators/bounded-context/bounded-context",
       "schema": "./src/generators/bounded-context/schema.json",

--- a/packages/nx-agent/migrations.json
+++ b/packages/nx-agent/migrations.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "generators": {
+    "rename-service-descriptions-to-product-briefs": {
+      "version": "12.2.0",
+      "description": "Rename project-docs/service-descriptions/ to product-briefs/, rewrite service-descriptions: refs, and update artifact-schema.json.",
+      "implementation": "./src/migrations/rename-service-descriptions-to-product-briefs/rename-service-descriptions-to-product-briefs"
+    }
+  }
+}

--- a/packages/nx-agent/package.json
+++ b/packages/nx-agent/package.json
@@ -25,5 +25,8 @@
     }
   },
   "generators": "./generators.json",
+  "nx-migrations": {
+    "migrations": "./migrations.json"
+  },
   "scripts": {}
 }

--- a/packages/nx-agent/project.json
+++ b/packages/nx-agent/project.json
@@ -47,6 +47,11 @@
             "input": "./packages/nx-agent",
             "glob": "generators.json",
             "output": "."
+          },
+          {
+            "input": "./packages/nx-agent",
+            "glob": "migrations.json",
+            "output": "."
           }
         ]
       }

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -21,12 +21,12 @@ scope here.
 
 ## Steps
 
-1. **Read the requirement** (and its service-description ancestor) this pass is designing
+1. **Read the requirement** (and its product-brief ancestor) this pass is designing
    against.
 
 2. **Bounded context** — if this requirement's initiative doesn't have one yet:
    `npx nx g @abgov/nx-agent:bounded-context "<Name>"`. Fill in the generated placeholder: what's
-   inside the boundary, and what's explicitly outside it — the service-description's own scope
+   inside the boundary, and what's explicitly outside it — the product brief's own scope
    statements usually go straight into the "outside" half.
 
 3. **Domain terms** — one per concept the requirement's Rules actually use precisely and
@@ -79,7 +79,7 @@ scope here.
    (`- a` / `- b` per line) — never a multi-line `[...]` block. Rewrite to block-style by hand if
    it got reformatted wrong, then re-run the gate below.
 
-5. **Check for an existing capability before designing a new one.** Read the service-description's
+5. **Check for an existing capability before designing a new one.** Read the product brief's
    `known-platforms`. For each named platform, check whether it already covers what this
    requirement needs (a connected MCP server if one exists, or the platform's docs otherwise)
    before assuming a bespoke design is needed. **If no MCP server exists yet for a named platform,

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
@@ -5,9 +5,9 @@ allowed-tools: Read, Write, Bash, Grep, Glob, Task
 argument-hint: "<feature slug to decompose, or a requirement slug to refine>"
 ---
 
-`feature`/`open-question`/`blocker`/`requirement` have real generators (`nx g @abgov/nx-agent:feature`/
-`:open-question`/`:blocker`/`:requirement`) — use them, don't hand-author. `service-description`
-still doesn't; write it by hand in the shape below. All five live under `project-docs/`.
+`feature`/`open-question`/`blocker`/`requirement`/`product-brief` have real generators
+(`nx g @abgov/nx-agent:feature`/`:open-question`/`:blocker`/`:requirement`/`:product-brief`) —
+use them, don't hand-author. All five live under `project-docs/`.
 
 `bug` also has a real generator (`nx g @abgov/nx-agent:bug`), but this skill never processes one
 directly — an open bug routes straight to Develop (investigate against the existing spec, fix,
@@ -15,7 +15,7 @@ verify), not through Discover's intake/refinement modes below.
 
 ## Which mode
 
-- A `features:<slug>` artifact with no `requirements`/`service-descriptions` descendant yet
+- A `features:<slug>` artifact with no `requirements`/`product-briefs` descendant yet
   (the raw capability request hasn't been decomposed): **intake**.
 - A single, already-scoped requirement (or a slug naming one that exists): **refinement**.
 - On a brand-new initiative, the first invocation does *intake*; if it yields exactly one clean
@@ -27,42 +27,33 @@ verify), not through Discover's intake/refinement modes below.
    capability request, written the way it was actually asked for, not pre-structured.
 2. Identify every distinguishable concern — a candidate requirement, a stray decision that isn't
    a requirement yet, or something genuinely unclear.
-3. **If no `project-docs/service-descriptions/<slug>.md` exists yet for this initiative, write it
-   first, before any requirement.** Root artifact, ancestor is the feature that founded it:
+3. **Check if a `project-docs/product-briefs/<slug>.md` already exists for this initiative** — a
+   product brief is a persistent positioning artifact, not created per-feature. If one already
+   exists, append this feature to its `project-docs-ancestors` list directly; don't regenerate it.
 
-   ```yaml
-   ---
-   service: <Name>
-   audience: []
-   known-platforms: []
-   questions: []
-   project-docs-ancestors: [features:<feature-slug>]
-   ---
+   If none exists yet, create it first, before any requirement:
 
-   <!-- Problem/opportunity framing and product positioning: what this service is for and who
-        it's for, in plain language. -->
+   ```
+   nx g @abgov/nx-agent:product-brief "<Name>" \
+     --projectDocsAncestors=project-docs/features/<feature-slug>.md
    ```
 
-   Register once: `"service-descriptions": { "expectedAncestorTypes": ["features"] }` in
-   `project-docs/artifact-schema.json` — every service-description should trace back to at least
-   one feature that founded it. **Get this exact line right**: this registration lives only as this
-   prose, nowhere in code, so the ancestor convention above and this schema entry have to change
-   together or `project-docs-lineage`'s `unscoped` check never actually fires for a
-   service-description missing a feature ancestor.
+   The generator creates the file, registers `product-briefs` in `artifact-schema.json` on first
+   use, and bootstraps the container README — nothing to do by hand.
 
-   `known-platforms` names existing systems/platforms/ecosystems this needs to operate within or
-   integrate with (e.g. `adsp`) — facts about the operating context, not a design decision (that's
-   Design's job). If genuinely unknown either way, add a `questions` entry rather than assuming.
+   Fill in the generated placeholder: what this capability is for, who it's for, and its operating
+   context. `known-platforms` names existing systems/platforms this must operate within (e.g.
+   `adsp`) — facts about the operating context, not a design decision (that's Design's job). If
+   genuinely unknown either way, add a `questions` entry rather than assuming.
 
    A later pass extending the same initiative from a *different* feature appends that feature to
-   `project-docs-ancestors` too (never overwrite the list) — the same convention every other
-   artifact type already uses for "built from more than one source," not a bespoke field.
+   `project-docs-ancestors` — same convention every other artifact type uses.
 
 4. For each concern that's a genuine, scoped candidate requirement, run:
 
    ```
    nx g @abgov/nx-agent:requirement "<title>" \
-     --projectDocsAncestors=project-docs/service-descriptions/<service-slug>.md,project-docs/features/<feature-slug>.md
+     --projectDocsAncestors=project-docs/product-briefs/<brief-slug>.md,project-docs/features/<feature-slug>.md
    ```
 
    The generator assigns the next unused `req-NNN` id automatically (scanning existing files),
@@ -122,7 +113,7 @@ the same target, so a repeat hit is seen immediately.
 
 Given one requirement (by slug or `id`):
 
-1. Read the requirement file and its service-description ancestor.
+1. Read the requirement file and its product-brief ancestor.
 2. Example-map it: add an entry to frontmatter `rules:` for each distinct behavior the
    requirement implies, each with either a Given/When/Then-shaped string in `examples:` or a
    question string in `questions:` — never leave a rule with both empty.
@@ -149,7 +140,7 @@ These check different things:
 ### Independent review
 
 Run every time a requirement finishes refinement, not just founding ones. Give the reviewer only
-the finished requirement and its service-description ancestor — not this pass's notes, reasoning,
+the finished requirement and its product-brief ancestor — not this pass's notes, reasoning,
 or raw input. Ask it:
 
 1. Does the service description imply a rule this requirement doesn't cover?

--- a/packages/nx-agent/src/generators/product-brief/README.template.md
+++ b/packages/nx-agent/src/generators/product-brief/README.template.md
@@ -1,0 +1,31 @@
+# Product briefs
+
+Persistent product positioning artifacts — one per capability, anchored to the feature(s) that
+founded it. Each brief captures what the capability is for, who it is for, the operating context
+it runs within, and open positioning questions. It is the root ancestor for requirements and is
+referenced (never re-created) when extending the same capability from additional features.
+
+Add a brief with `nx g @abgov/nx-agent:product-brief "<Name>"` — don't hand-author files here,
+so the frontmatter shape stays consistent. Each file:
+
+    ---
+    capability: Lineage Graph
+    audience: [AI coding agents navigating the DDDD workflow, nx-agent generator implementations]
+    known-platforms: [nx-agent]
+    questions: []
+    project-docs-ancestors: [features:<feature-slug>]
+    resolves: []
+    ---
+
+- `capability` — the canonical name of the capability, matching the filename.
+- `audience` — who uses or is affected by this capability (roles, actor types).
+- `known-platforms` — existing systems/platforms this capability must operate within or integrate
+  with (e.g. `adsp`). Facts about the operating context, not a design decision. If genuinely
+  unknown, add a `questions` entry.
+- `questions` — open positioning questions that span the whole brief (not specific to one rule).
+- `project-docs-ancestors` — the feature(s) that founded this brief. Set at creation time with
+  `--projectDocsAncestors`; append additional features directly rather than regenerating.
+
+The body is free text — product positioning: what this capability is for, who it is for, and
+what problem it solves. Scope statements here feed directly into bounded-context boundary
+descriptions.

--- a/packages/nx-agent/src/generators/product-brief/product-brief.spec.ts
+++ b/packages/nx-agent/src/generators/product-brief/product-brief.spec.ts
@@ -1,0 +1,149 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
+import { Tree, addProjectConfiguration } from '@nx/devkit'
+import { readArtifactSchema } from '../../utils/artifact-schema'
+import generator from './product-brief'
+
+describe('nx-agent product-brief generator', () => {
+  let host: Tree
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' })
+  })
+
+  it('creates the brief file at the workspace root with the expected frontmatter', async () => {
+    await generator(host, { name: 'Lineage Graph' })
+
+    const content = host
+      .read('project-docs/product-briefs/lineage-graph.md')
+      .toString()
+    expect(content).toContain('capability: Lineage Graph')
+    expect(content).toContain('audience: []')
+    expect(content).toContain('known-platforms: []')
+    expect(content).toContain('questions: []')
+  })
+
+  it('derives the filename slug from a multi-word name', async () => {
+    await generator(host, { name: 'Agent Delivery Harness' })
+
+    expect(
+      host.exists('project-docs/product-briefs/agent-delivery-harness.md'),
+    ).toBe(true)
+  })
+
+  it('creates the container README on first run', async () => {
+    await generator(host, { name: 'Lineage Graph' })
+
+    const readme = host
+      .read('project-docs/product-briefs/README.md')
+      .toString()
+    expect(readme).toContain('# Product briefs')
+    expect(readme).toContain('nx g @abgov/nx-agent:product-brief')
+  })
+
+  it('does not duplicate or alter the README when a second brief is added', async () => {
+    await generator(host, { name: 'Lineage Graph' })
+    const readmeBefore = host
+      .read('project-docs/product-briefs/README.md')
+      .toString()
+
+    await generator(host, { name: 'Agent Delivery Harness' })
+
+    const readmeAfter = host
+      .read('project-docs/product-briefs/README.md')
+      .toString()
+    expect(readmeAfter).toBe(readmeBefore)
+    expect(
+      host.exists('project-docs/product-briefs/lineage-graph.md'),
+    ).toBe(true)
+    expect(
+      host.exists('project-docs/product-briefs/agent-delivery-harness.md'),
+    ).toBe(true)
+  })
+
+  it('throws and makes no changes when the brief file already exists', async () => {
+    await generator(host, { name: 'Lineage Graph' })
+    const before = host
+      .read('project-docs/product-briefs/lineage-graph.md')
+      .toString()
+
+    await expect(
+      generator(host, { name: 'Lineage Graph' }),
+    ).rejects.toThrow(/already exists/)
+
+    expect(
+      host.read('project-docs/product-briefs/lineage-graph.md').toString(),
+    ).toBe(before)
+  })
+
+  it('scopes the brief file under a specific project when --project is given', async () => {
+    addProjectConfiguration(host, 'domain-lib', {
+      root: 'libs/domain-lib',
+      projectType: 'library',
+      targets: {},
+    })
+
+    await generator(host, {
+      name: 'Lineage Graph',
+      project: 'domain-lib',
+    })
+
+    expect(
+      host.exists('libs/domain-lib/project-docs/product-briefs/lineage-graph.md'),
+    ).toBe(true)
+    expect(
+      host.exists('project-docs/product-briefs/lineage-graph.md'),
+    ).toBe(false)
+  })
+
+  it('registers its own artifact-schema entry with features as the expected ancestor type', async () => {
+    await generator(host, { name: 'Lineage Graph' })
+
+    expect(readArtifactSchema(host)).toEqual({
+      'product-briefs': { expectedAncestorTypes: ['features'] },
+    })
+  })
+
+  it('resolves --projectDocsAncestors paths into the canonical reference and writes them', async () => {
+    host.write(
+      'project-docs/features/include-metadata.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    )
+
+    await generator(host, {
+      name: 'Lineage Graph',
+      projectDocsAncestors: ['project-docs/features/include-metadata.md'],
+    })
+
+    const content = host
+      .read('project-docs/product-briefs/lineage-graph.md')
+      .toString()
+    expect(content).toContain(
+      'project-docs-ancestors: [features:include-metadata]',
+    )
+  })
+
+  it('--resolves writes the resolved ref into both project-docs-ancestors and resolves, and confirms it', async () => {
+    host.write(
+      'project-docs/open-questions/api-shape.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    )
+    const logSpy = jest.spyOn(console, 'log').mockImplementation()
+
+    await generator(host, {
+      name: 'Lineage Graph',
+      resolves: ['project-docs/open-questions/api-shape.md'],
+    })
+
+    const content = host
+      .read('project-docs/product-briefs/lineage-graph.md')
+      .toString()
+    expect(content).toContain(
+      'project-docs-ancestors: [open-questions:api-shape]',
+    )
+    expect(content).toContain('resolves: [open-questions:api-shape]')
+    expect(logSpy).toHaveBeenCalledWith(
+      '✓ this product brief resolves open-questions:api-shape',
+    )
+    logSpy.mockRestore()
+  })
+})

--- a/packages/nx-agent/src/generators/product-brief/product-brief.ts
+++ b/packages/nx-agent/src/generators/product-brief/product-brief.ts
@@ -1,0 +1,69 @@
+import {
+  Tree,
+  formatFiles,
+  joinPathFragments,
+  names,
+  readProjectConfiguration,
+} from '@nx/devkit'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema'
+import { ensureReadme } from '../../utils/readme'
+import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs'
+import { Schema } from './schema'
+
+const PRODUCT_BRIEFS_SUBDIR = 'project-docs/product-briefs'
+const README_TEMPLATE_PATH = join(__dirname, 'README.template.md')
+
+function resolveTargetRoot(host: Tree, project?: string): string {
+  return project ? readProjectConfiguration(host, project).root : '.'
+}
+
+export default async function (host: Tree, options: Schema) {
+  const targetRoot = resolveTargetRoot(host, options.project)
+  const containerDir = joinPathFragments(targetRoot, PRODUCT_BRIEFS_SUBDIR)
+  const slug = names(options.name).fileName
+  const briefPath = joinPathFragments(containerDir, `${slug}.md`)
+
+  // A repeat/typo'd invocation should fail loudly rather than silently
+  // clobbering — same posture as bounded-context and domain-term.
+  // Checked before any write so a failing run has no side effects.
+  if (host.exists(briefPath)) {
+    throw new Error(
+      `[nx-agent] ${briefPath} already exists — edit it directly rather than regenerating it.`,
+    )
+  }
+
+  // Resolved (and validated) before any write — a path that doesn't resolve
+  // to an existing project-docs/ artifact throws here.
+  const { ancestors: projectDocsAncestors, resolvedRefs } =
+    resolveAncestorsAndResolves(
+      host,
+      options.projectDocsAncestors,
+      options.resolves,
+    )
+
+  ensureReadme(host, containerDir, readFileSync(README_TEMPLATE_PATH, 'utf-8'))
+  ensureArtifactSchemaEntry(host, 'product-briefs', ['features'])
+
+  const content = [
+    '---',
+    `capability: ${options.name}`,
+    'audience: []',
+    'known-platforms: []',
+    'questions: []',
+    `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,
+    `resolves: [${resolvedRefs.join(', ')}]`,
+    '---',
+    '',
+    '<!-- Product positioning: what this capability is for, who it is for, and what problem it solves. -->',
+    '',
+  ].join('\n')
+  host.write(briefPath, content)
+
+  for (const ref of resolvedRefs) {
+    console.log(`✓ this product brief resolves ${ref}`)
+  }
+
+  await formatFiles(host)
+}

--- a/packages/nx-agent/src/generators/product-brief/schema.d.ts
+++ b/packages/nx-agent/src/generators/product-brief/schema.d.ts
@@ -1,0 +1,6 @@
+export interface Schema {
+  name: string
+  project?: string
+  projectDocsAncestors?: string[]
+  resolves?: string[]
+}

--- a/packages/nx-agent/src/generators/product-brief/schema.json
+++ b/packages/nx-agent/src/generators/product-brief/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentProductBrief",
+  "title": "Add a product brief",
+  "description": "Creates one file for a product brief under project-docs/product-briefs/, with structured frontmatter (capability, audience, known-platforms, questions) and a free-text body. Bootstraps the product-briefs/README.md on first use. Create-once: edit it directly for subsequent updates.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The canonical name of the capability this brief describes (e.g. \"Lineage Graph\").",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "What is this capability called?"
+    },
+    "project": {
+      "type": "string",
+      "description": "Scope this product brief to a specific project's project-docs/product-briefs/ instead of the workspace root."
+    },
+    "projectDocsAncestors": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing project-docs/ artifacts this brief derives from (normally the feature(s) that founded it). Each path must already exist."
+    },
+    "resolves": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths to existing open-question/blocker artifacts this brief resolves."
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/requirement/README.template.md
+++ b/packages/nx-agent/src/generators/requirement/README.template.md
@@ -1,7 +1,7 @@
 # Requirements
 
 Scoped, example-mapped requirements for this initiative — one file per requirement, each deriving
-from a service-description ancestor. Produced by the Discover skill's refinement pass.
+from a product-brief ancestor. Produced by the Discover skill's refinement pass.
 
 Add a requirement with `nx g @abgov/nx-agent:requirement "<title>"` — don't hand-author files
 here, so the frontmatter shape and sequential ID stay consistent. Each file:
@@ -9,7 +9,7 @@ here, so the frontmatter shape and sequential ID stay consistent. Each file:
     ---
     title: Create an evaluation matrix for a position
     id: req-001
-    project-docs-ancestors: [service-descriptions:candidate-evaluation]
+    project-docs-ancestors: [product-briefs:candidate-evaluation]
     resolves: []
     rules: []
     questions: []
@@ -18,8 +18,8 @@ here, so the frontmatter shape and sequential ID stay consistent. Each file:
 - `title` — the short descriptive title, matching the filename slug.
 - `id` — sequential human-facing label (`req-NNN`), auto-assigned at creation time. Not the graph
   key (the file's slug is); used by agents to reference requirements in prose and conversation.
-- `project-docs-ancestors` — the service-description this requirement derives from. Set with
-  `--project-docs-ancestors <path>` at creation time.
+- `project-docs-ancestors` — the product brief this requirement derives from. Set with
+  `--projectDocsAncestors <path>` at creation time.
 - `rules` — example-mapped rules (Given/When/Then examples per rule). Populated by the Discover
   skill's refinement pass; left empty at intake.
 - `questions` — open questions that don't attach to a specific rule.

--- a/packages/nx-agent/src/generators/requirement/requirement.spec.ts
+++ b/packages/nx-agent/src/generators/requirement/requirement.spec.ts
@@ -101,14 +101,14 @@ describe('nx-agent requirement generator', () => {
 
   it('resolves --projectDocsAncestors paths into the canonical reference', async () => {
     host.write(
-      'project-docs/service-descriptions/candidate-evaluation.md',
-      ['---', 'service: Candidate Evaluation', '---'].join('\n'),
+      'project-docs/product-briefs/candidate-evaluation.md',
+      ['---', 'capability: Candidate Evaluation', '---'].join('\n'),
     );
 
     await generator(host, {
       title: 'Create evaluation matrix',
       projectDocsAncestors: [
-        'project-docs/service-descriptions/candidate-evaluation.md',
+        'project-docs/product-briefs/candidate-evaluation.md',
       ],
     });
 
@@ -116,7 +116,7 @@ describe('nx-agent requirement generator', () => {
       .read('project-docs/requirements/create-evaluation-matrix.md')
       .toString();
     expect(content).toContain(
-      'project-docs-ancestors: [service-descriptions:candidate-evaluation]',
+      'project-docs-ancestors: [product-briefs:candidate-evaluation]',
     );
   });
 
@@ -125,7 +125,7 @@ describe('nx-agent requirement generator', () => {
       generator(host, {
         title: 'Create evaluation matrix',
         projectDocsAncestors: [
-          'project-docs/service-descriptions/does-not-exist.md',
+          'project-docs/product-briefs/does-not-exist.md',
         ],
       }),
     ).rejects.toThrow(/not found/);
@@ -160,11 +160,11 @@ describe('nx-agent requirement generator', () => {
     expect(readmeAfter).toBe(readmeBefore);
   });
 
-  it('registers requirements with expectedAncestorTypes service-descriptions in artifact-schema.json', async () => {
+  it('registers requirements with expectedAncestorTypes product-briefs in artifact-schema.json', async () => {
     await generator(host, { title: 'Create matrix' });
 
     expect(readArtifactSchema(host)).toMatchObject({
-      requirements: { expectedAncestorTypes: ['service-descriptions'] },
+      requirements: { expectedAncestorTypes: ['product-briefs'] },
     });
   });
 
@@ -173,7 +173,7 @@ describe('nx-agent requirement generator', () => {
     host.write(
       'project-docs/artifact-schema.json',
       JSON.stringify({
-        requirements: { expectedAncestorTypes: ['service-descriptions'] },
+        requirements: { expectedAncestorTypes: ['product-briefs'] },
         'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
       }),
     );

--- a/packages/nx-agent/src/generators/requirement/requirement.ts
+++ b/packages/nx-agent/src/generators/requirement/requirement.ts
@@ -84,7 +84,7 @@ export default async function (host: Tree, options: Schema) {
 
   const readmeContent = readFileSync(README_TEMPLATE_PATH, 'utf-8');
   ensureReadme(host, containerDir, readmeContent);
-  ensureArtifactSchemaEntry(host, 'requirements', ['service-descriptions']);
+  ensureArtifactSchemaEntry(host, 'requirements', ['product-briefs']);
 
   const content = [
     '---',

--- a/packages/nx-agent/src/migrations/rename-service-descriptions-to-product-briefs/rename-service-descriptions-to-product-briefs.spec.ts
+++ b/packages/nx-agent/src/migrations/rename-service-descriptions-to-product-briefs/rename-service-descriptions-to-product-briefs.spec.ts
@@ -1,0 +1,145 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing'
+import { Tree, addProjectConfiguration } from '@nx/devkit'
+import migration from './rename-service-descriptions-to-product-briefs'
+
+describe('rename-service-descriptions-to-product-briefs migration', () => {
+  let host: Tree
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' })
+  })
+
+  it('moves service-descriptions/ files to product-briefs/', async () => {
+    host.write('project-docs/service-descriptions/lineage-graph.md', '---\nservice: Lineage Graph\nproject-docs-ancestors: [features:foo]\n---\n')
+
+    await migration(host)
+
+    expect(host.exists('project-docs/product-briefs/lineage-graph.md')).toBe(true)
+    expect(host.exists('project-docs/service-descriptions/lineage-graph.md')).toBe(false)
+  })
+
+  it('renames `service:` frontmatter key to `capability:` in moved files', async () => {
+    host.write(
+      'project-docs/service-descriptions/lineage-graph.md',
+      '---\nservice: Lineage Graph\naudience: [agents]\n---\n\nBody text.\n',
+    )
+
+    await migration(host)
+
+    const content = host.read('project-docs/product-briefs/lineage-graph.md', 'utf-8')
+    expect(content).toContain('capability: Lineage Graph')
+    expect(content).not.toContain('service: Lineage Graph')
+    expect(content).toContain('audience: [agents]')
+    expect(content).toContain('Body text.')
+  })
+
+  it('rewrites service-descriptions: refs in other .md files under project-docs/', async () => {
+    host.write(
+      'project-docs/service-descriptions/lineage-graph.md',
+      '---\nservice: Lineage Graph\nproject-docs-ancestors: [features:foo]\n---\n',
+    )
+    host.write(
+      'project-docs/requirements/my-req.md',
+      '---\ntitle: My Req\nproject-docs-ancestors:\n  - service-descriptions:lineage-graph\n---\n',
+    )
+
+    await migration(host)
+
+    const reqContent = host.read('project-docs/requirements/my-req.md', 'utf-8')
+    expect(reqContent).toContain('product-briefs:lineage-graph')
+    expect(reqContent).not.toContain('service-descriptions:lineage-graph')
+  })
+
+  it('updates artifact-schema.json: renames the type key and fixes requirements.expectedAncestorTypes', async () => {
+    host.write(
+      'project-docs/service-descriptions/lineage-graph.md',
+      '---\nservice: Lineage Graph\nproject-docs-ancestors: [features:foo]\n---\n',
+    )
+    host.write(
+      'project-docs/artifact-schema.json',
+      JSON.stringify({
+        features: { expectedAncestorTypes: [] },
+        'service-descriptions': { expectedAncestorTypes: ['features'] },
+        requirements: { expectedAncestorTypes: ['service-descriptions'] },
+        'bounded-contexts': { expectedAncestorTypes: [] },
+      }),
+    )
+
+    await migration(host)
+
+    const schema = JSON.parse(
+      host.read('project-docs/artifact-schema.json', 'utf-8') ?? '{}',
+    )
+    expect(schema['product-briefs']).toEqual({ expectedAncestorTypes: ['features'] })
+    expect(schema['service-descriptions']).toBeUndefined()
+    expect(schema['requirements'].expectedAncestorTypes).toEqual(['product-briefs'])
+    expect(schema['features']).toEqual({ expectedAncestorTypes: [] })
+    expect(schema['bounded-contexts']).toEqual({ expectedAncestorTypes: [] })
+  })
+
+  it('deletes the container README without copying it to product-briefs/', async () => {
+    host.write('project-docs/service-descriptions/README.md', '# Service descriptions\n')
+    host.write(
+      'project-docs/service-descriptions/lineage-graph.md',
+      '---\nservice: Lineage Graph\nproject-docs-ancestors: [features:foo]\n---\n',
+    )
+
+    await migration(host)
+
+    expect(host.exists('project-docs/service-descriptions/README.md')).toBe(false)
+    expect(host.exists('project-docs/product-briefs/README.md')).toBe(false)
+  })
+
+  it('is a no-op when no service-descriptions/ directory exists', async () => {
+    host.write('project-docs/features/my-feature.md', '---\nproject-docs-ancestors: []\n---\n')
+
+    await expect(migration(host)).resolves.toBeUndefined()
+    expect(host.exists('project-docs/product-briefs')).toBe(false)
+  })
+
+  it('migrates a project-scoped service-descriptions/ directory', async () => {
+    addProjectConfiguration(host, 'my-lib', {
+      root: 'libs/my-lib',
+      projectType: 'library',
+      targets: {},
+    })
+    host.write(
+      'libs/my-lib/project-docs/service-descriptions/my-service.md',
+      '---\nservice: My Service\nproject-docs-ancestors: [features:bar]\n---\n',
+    )
+    host.write(
+      'libs/my-lib/project-docs/requirements/req.md',
+      '---\nproject-docs-ancestors:\n  - service-descriptions:my-service\n---\n',
+    )
+
+    await migration(host)
+
+    expect(
+      host.exists('libs/my-lib/project-docs/product-briefs/my-service.md'),
+    ).toBe(true)
+    const content = host.read(
+      'libs/my-lib/project-docs/product-briefs/my-service.md',
+      'utf-8',
+    )
+    expect(content).toContain('capability: My Service')
+    const req = host.read('libs/my-lib/project-docs/requirements/req.md', 'utf-8')
+    expect(req).toContain('product-briefs:my-service')
+  })
+
+  it('handles multiple service-descriptions files in one pass', async () => {
+    host.write(
+      'project-docs/service-descriptions/lineage-graph.md',
+      '---\nservice: Lineage Graph\nproject-docs-ancestors: [features:foo]\n---\n',
+    )
+    host.write(
+      'project-docs/service-descriptions/agent-delivery-harness.md',
+      '---\nservice: Agent Delivery Harness\nproject-docs-ancestors: [features:bar]\n---\n',
+    )
+
+    await migration(host)
+
+    expect(host.exists('project-docs/product-briefs/lineage-graph.md')).toBe(true)
+    expect(host.exists('project-docs/product-briefs/agent-delivery-harness.md')).toBe(true)
+    expect(host.exists('project-docs/service-descriptions')).toBe(false)
+  })
+})

--- a/packages/nx-agent/src/migrations/rename-service-descriptions-to-product-briefs/rename-service-descriptions-to-product-briefs.ts
+++ b/packages/nx-agent/src/migrations/rename-service-descriptions-to-product-briefs/rename-service-descriptions-to-product-briefs.ts
@@ -1,0 +1,132 @@
+import { Tree, getProjects, logger, readJson, writeJson } from '@nx/devkit'
+
+function projectDocsRoots(host: Tree): string[] {
+  const roots = ['project-docs']
+  for (const [, config] of getProjects(host)) {
+    roots.push(
+      config.root === '.' ? 'project-docs' : `${config.root}/project-docs`,
+    )
+  }
+  return [...new Set(roots)].filter((root) => host.exists(root))
+}
+
+// Rewrite every `service-descriptions:` token in frontmatter and body of .md
+// files under a project-docs root to `product-briefs:`.
+function rewriteRefsInDocsRoot(host: Tree, docsRoot: string): number {
+  let count = 0
+  for (const typeDir of host.children(docsRoot)) {
+    const typePath = `${docsRoot}/${typeDir}`
+    if (host.isFile(typePath)) {
+      // singular artifact at project-docs/<type>.md
+      if (typeDir.endsWith('.md') && typeDir !== 'README.md') {
+        const content = host.read(typePath, 'utf-8') ?? ''
+        if (content.includes('service-descriptions:')) {
+          host.write(
+            typePath,
+            content.split('service-descriptions:').join('product-briefs:'),
+          )
+          count++
+        }
+      }
+      continue
+    }
+    for (const file of host.children(typePath)) {
+      const filePath = `${typePath}/${file}`
+      if (!host.isFile(filePath) || !file.endsWith('.md') || file === 'README.md')
+        continue
+      const content = host.read(filePath, 'utf-8') ?? ''
+      if (content.includes('service-descriptions:')) {
+        host.write(
+          filePath,
+          content.split('service-descriptions:').join('product-briefs:'),
+        )
+        count++
+      }
+    }
+  }
+  return count
+}
+
+// Rename service-descriptions/ → product-briefs/, converting `service: X`
+// frontmatter key to `capability: X` in each moved file.
+function moveServiceDescriptions(host: Tree, docsRoot: string): number {
+  const sourceDir = `${docsRoot}/service-descriptions`
+  if (!host.exists(sourceDir)) return 0
+
+  const targetDir = `${docsRoot}/product-briefs`
+  let moved = 0
+
+  for (const file of host.children(sourceDir)) {
+    const srcPath = `${sourceDir}/${file}`
+    if (!host.isFile(srcPath)) continue
+    if (file === 'README.md') {
+      host.delete(srcPath)
+      continue
+    }
+    if (!file.endsWith('.md')) continue
+
+    const content = host.read(srcPath, 'utf-8') ?? ''
+    // Rename the `service:` frontmatter key to `capability:` — only the first
+    // occurrence in the file (always in the frontmatter block).
+    const updated = content.replace(/^service:/m, 'capability:')
+    host.write(`${targetDir}/${file}`, updated)
+    host.delete(srcPath)
+    moved++
+  }
+
+  return moved
+}
+
+// Update artifact-schema.json at the workspace root: rename service-descriptions
+// to product-briefs and update requirements' expectedAncestorTypes.
+function updateArtifactSchema(host: Tree, docsRoot: string): void {
+  const schemaPath = `${docsRoot}/artifact-schema.json`
+  if (!host.exists(schemaPath)) return
+
+  const schema = readJson<Record<string, { expectedAncestorTypes: string[] }>>(
+    host,
+    schemaPath,
+  )
+
+  if ('service-descriptions' in schema) {
+    schema['product-briefs'] = schema['service-descriptions']
+    delete schema['service-descriptions']
+  }
+
+  for (const entry of Object.values(schema)) {
+    if (Array.isArray(entry.expectedAncestorTypes)) {
+      entry.expectedAncestorTypes = entry.expectedAncestorTypes.map((t) =>
+        t === 'service-descriptions' ? 'product-briefs' : t,
+      )
+    }
+  }
+
+  writeJson(host, schemaPath, schema)
+}
+
+export default async function renameServiceDescriptionsToProductBriefs(
+  host: Tree,
+): Promise<void> {
+  let totalMoved = 0
+  let totalUpdated = 0
+
+  for (const docsRoot of projectDocsRoots(host)) {
+    totalMoved += moveServiceDescriptions(host, docsRoot)
+    totalUpdated += rewriteRefsInDocsRoot(host, docsRoot)
+    updateArtifactSchema(host, docsRoot)
+  }
+
+  if (totalMoved > 0) {
+    logger.info(
+      `[nx-agent] Moved ${totalMoved} file(s) from service-descriptions/ to product-briefs/.`,
+    )
+  }
+  if (totalUpdated > 0) {
+    logger.info(
+      `[nx-agent] Updated service-descriptions: refs in ${totalUpdated} file(s).`,
+    )
+  }
+  if (totalMoved === 0 && totalUpdated === 0) {
+    logger.info('[nx-agent] No service-descriptions/ directories found; nothing to migrate.')
+  }
+}

--- a/project-docs/artifact-schema.json
+++ b/project-docs/artifact-schema.json
@@ -6,11 +6,11 @@
   "features": {
     "expectedAncestorTypes": []
   },
-  "service-descriptions": {
+  "product-briefs": {
     "expectedAncestorTypes": ["features"]
   },
   "requirements": {
-    "expectedAncestorTypes": ["service-descriptions"]
+    "expectedAncestorTypes": ["product-briefs"]
   },
   "bounded-contexts": {
     "expectedAncestorTypes": []

--- a/project-docs/domain-models/lineage-graph-metadata.md
+++ b/project-docs/domain-models/lineage-graph-metadata.md
@@ -117,10 +117,10 @@ questions: []
 ```
 
 **`artifact-schema.json` registration**: calls `ensureArtifactSchemaEntry(host, 'requirements',
-['service-descriptions'])` — merge-only, idempotent, same call every generator makes on first use.
-The `service-descriptions` parent type is correct: every requirement must trace back to a
-service-description (see `artifact-schema.json`'s own `requirements` entry, and the Discover
-intake convention that seeds each requirement with a service-description ancestor).
+['product-briefs'])` — merge-only, idempotent, same call every generator makes on first use.
+The `product-briefs` parent type is correct: every requirement must trace back to a
+product brief (see `artifact-schema.json`'s own `requirements` entry, and the Discover
+intake convention that seeds each requirement with a product-brief ancestor).
 
 **Ancestor/resolves path validation**: `projectDocsAncestors` and `resolves` paths are each
 resolved via `resolveRefFromPath` (the same function used by every other generator). This

--- a/project-docs/iteration-retrospectives/implement-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries.md
+++ b/project-docs/iteration-retrospectives/implement-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries.md
@@ -1,6 +1,6 @@
 ---
 title: implement non-structural frontmatter metadata in lineage graph registry and index entries
-project-docs-ancestors: [features:include-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries, service-descriptions:lineage-graph, requirements:lineage-registry-entry-carries-non-structural-frontmatter-metadata, requirements:lineage-index-entry-carries-optional-frontmatter-metadata-for-registered-artifact-descendants, requirements:requirement-generator-scaffolds-correct-shape-with-collision-free-id-assignment, domain-models:lineage-graph-metadata, bounded-contexts:lineage-graph, domain-terms:artifact-metadata]
+project-docs-ancestors: [features:include-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries, product-briefs:lineage-graph, requirements:lineage-registry-entry-carries-non-structural-frontmatter-metadata, requirements:lineage-index-entry-carries-optional-frontmatter-metadata-for-registered-artifact-descendants, requirements:requirement-generator-scaffolds-correct-shape-with-collision-free-id-assignment, domain-models:lineage-graph-metadata, bounded-contexts:lineage-graph, domain-terms:artifact-metadata]
 resolves: []
 ---
 

--- a/project-docs/product-briefs/agent-delivery-harness.md
+++ b/project-docs/product-briefs/agent-delivery-harness.md
@@ -1,5 +1,5 @@
 ---
-service: Agent Delivery Harness
+capability: Agent Delivery Harness
 audience: [AI coding agents operating a DDDD workflow]
 known-platforms: []
 questions: []

--- a/project-docs/product-briefs/lineage-graph.md
+++ b/project-docs/product-briefs/lineage-graph.md
@@ -1,5 +1,5 @@
 ---
-service: Lineage Graph
+capability: Lineage Graph
 audience: [AI coding agents navigating the DDDD workflow, nx-agent generator implementations]
 known-platforms: [nx-agent]
 questions: []
@@ -17,6 +17,6 @@ The graph allows agents and generators to navigate the artifact graph without wa
 but not content questions (what does a given artifact contain), forcing a second round of file
 reads whenever content is needed.
 
-Outside the boundary: the business domain being described (requirements, service-descriptions,
+Outside the boundary: the business domain being described (requirements, product briefs,
 domain models), the DDDD skill files themselves, and the OpenShift/ADSP infrastructure consuming
 projects deploy to.

--- a/project-docs/requirements/develop-skill-lineage-read-must-commit-before-write.md
+++ b/project-docs/requirements/develop-skill-lineage-read-must-commit-before-write.md
@@ -2,7 +2,7 @@
 title: "develop skill: lineage read must commit before first write"
 id: req-001
 project-docs-ancestors:
-  - service-descriptions:agent-delivery-harness
+  - product-briefs:agent-delivery-harness
   - features:develop-skill-lineage-plan-step
 rules:
   - rule: step 1 requires a stated implementation plan before any code is written

--- a/project-docs/requirements/lineage-index-entry-carries-optional-frontmatter-metadata-for-registered-artifact-descendants.md
+++ b/project-docs/requirements/lineage-index-entry-carries-optional-frontmatter-metadata-for-registered-artifact-descendants.md
@@ -2,7 +2,7 @@
 title: Lineage index entry carries optional frontmatter metadata for registered-artifact descendants
 id: req-003
 project-docs-ancestors:
-  - service-descriptions:lineage-graph
+  - product-briefs:lineage-graph
   - features:include-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries
 rules:
   - rule: a DescendantEntry that corresponds to a registered artifact includes its metadata from the registry

--- a/project-docs/requirements/lineage-registry-entry-carries-non-structural-frontmatter-metadata.md
+++ b/project-docs/requirements/lineage-registry-entry-carries-non-structural-frontmatter-metadata.md
@@ -2,7 +2,7 @@
 title: Lineage registry entry carries non-structural frontmatter metadata
 id: req-002
 project-docs-ancestors:
-  - service-descriptions:lineage-graph
+  - product-briefs:lineage-graph
   - features:include-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries
 rules:
   - rule: every RegistryEntry includes all non-structural frontmatter fields verbatim under a metadata property

--- a/project-docs/requirements/requirement-generator-scaffolds-correct-shape-with-collision-free-id-assignment.md
+++ b/project-docs/requirements/requirement-generator-scaffolds-correct-shape-with-collision-free-id-assignment.md
@@ -2,7 +2,7 @@
 title: Requirement generator scaffolds correct shape with collision-free ID assignment
 id: req-004
 project-docs-ancestors:
-  - service-descriptions:lineage-graph
+  - product-briefs:lineage-graph
   - features:include-non-structural-frontmatter-metadata-in-lineage-graph-registry-and-index-entries
 rules:
   - rule: the generator creates project-docs/requirements/<slug>.md with the correct empty frontmatter shape
@@ -29,7 +29,7 @@ rules:
     examples:
       - "Given: artifact-schema.json does not yet have a requirements entry;
          When: the requirement generator runs for the first time;
-         Then: artifact-schema.json gains requirements with expectedAncestorTypes: ['service-descriptions']"
+         Then: artifact-schema.json gains requirements with expectedAncestorTypes: ['product-briefs']"
       - "Given: artifact-schema.json already has a requirements entry;
          When: the requirement generator runs;
          Then: the existing entry is unchanged (merge-only behaviour)"


### PR DESCRIPTION
## Summary

- Adds `@abgov/nx-agent:product-brief` generator — persistent product positioning artifact (create-once, complement to `bounded-context`), with `capability`, `audience`, `known-platforms`, `questions` frontmatter and a free-text body. Registered in `generators.json` with tests and README template.
- Wires **nx-agent migrations infrastructure**: adds `migrations.json`, `"nx-migrations"` field in `package.json`, and a `migrations.json` asset in `project.json`.
- Adds migration `rename-service-descriptions-to-product-briefs` (version `12.2.0`): walks all project-docs roots in a consuming workspace, moves `service-descriptions/` → `product-briefs/`, renames `service: X` frontmatter to `capability: X`, rewrites all `service-descriptions:` refs in `.md` files, and updates `artifact-schema.json`.
- Updates Discover/Design skill files (both `.claude/skills/` and deployed `agent-delivery/files/skills/`): step 3 now runs the generator, all ancestor refs updated to `product-brief`.
- Updates requirement generator (`ensureArtifactSchemaEntry` → `['product-briefs']`), its spec, and its README template.
- Migrates this repo's own `project-docs/`: renames and converts both service-description files, updates all downstream frontmatter refs.

## Test plan

- [ ] `npx nx test nx-agent` — 254 tests pass (includes 9 new product-brief generator tests)
- [ ] `npx nx build nx-agent` — clean TypeScript compile
- [ ] `npx nx lint nx-agent` — 0 errors (pre-existing warnings only)
- [ ] `npx nx g @abgov/nx-agent:project-docs-lineage --dry-run` — no broken refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)