### PR TITLE
fix(project-docs): quote title containing colon in develop-skill-lineage-plan-step feature

### DIFF
--- a/project-docs/features/develop-skill-lineage-plan-step.md
+++ b/project-docs/features/develop-skill-lineage-plan-step.md
@@ -1,5 +1,5 @@
 ---
-title: develop skill: require implementation plan commitment before first write
+title: "develop skill: require implementation plan commitment before first write"
 project-docs-ancestors: []
 resolves: []
 ---


### PR DESCRIPTION
## Summary

- The `title` field in `project-docs/features/develop-skill-lineage-plan-step.md` contained an unquoted colon (`develop skill: require...`), which YAML parses as a nested mapping key
- This caused the lineage tool to drop the artifact silently and report it as "unscoped" — exactly the class of bug fixed in PR #416
- Fix: wrap the title value in double quotes

## Test plan

- [ ] `npx nx g @abgov/nx-agent:project-docs-report` produces no YAML parse warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)