### PR TITLE
fix(nx-oc): CNPG probe permissions and ADSP missing-scope error message

### DIFF
--- a/packages/nx-oc/src/adsp/adsp-utils.spec.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.spec.ts
@@ -132,6 +132,18 @@ describe('ensureAdspToken', () => {
     expect(mockedSpawnSync).not.toHaveBeenCalled();
   });
 
+  it('throws a distinct "missing scope" error when signed in but lacking the requested scope', async () => {
+    mockedGetAccessToken
+      .mockResolvedValueOnce({ status: 'not-authenticated' }) // scoped fetch fails
+      .mockResolvedValueOnce({ status: 'ok', token: 'base-tok' }); // base fetch succeeds
+    mockedIsNonInteractive.mockReturnValue(true);
+
+    await expect(
+      ensureAdspToken({ env: 'test', tenant: 'my-tenant', scopes: ['adsp-cli-admin'] }),
+    ).rejects.toThrow(/missing required scope/);
+    expect(mockedSpawnSync).not.toHaveBeenCalled();
+  });
+
   it('drives an interactive login and retries when the fast path misses', async () => {
     mockedIsNonInteractive.mockReturnValue(false);
     mockedGetAccessToken

--- a/packages/nx-oc/src/adsp/adsp-utils.ts
+++ b/packages/nx-oc/src/adsp/adsp-utils.ts
@@ -160,6 +160,19 @@ export async function ensureAdspToken(options: {
       ]
         .filter(Boolean)
         .join(' ');
+      // Distinguish "not signed in at all" from "signed in but missing scope":
+      // the error message for the latter is the same corrective action but
+      // a different diagnosis — users who ran `adsp login` without --scope
+      // adsp-cli-admin see "Not signed in" and ignore it, thinking it's wrong.
+      if (scopes.length) {
+        const base = await getAccessToken();
+        if (base.status === 'ok') {
+          throw new Error(
+            `Signed in to ADSP but missing required scope(s): ${scopes.join(', ')}.\n` +
+              `Re-sign in with:\n  ${loginCmd}`,
+          );
+        }
+      }
       throw new Error(
         `Not signed in to ADSP (non-interactive run). Sign in first with:\n  ${loginCmd}\n` +
           'Or, for a CI service account, set ADSP_CLIENT_ID and ADSP_CLIENT_SECRET ' +

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -273,8 +273,8 @@ describe('sandbox executor', () => {
   describe('database: postgres', () => {
     it('uses the CNPG operator path when the CRD is present', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get crd ')) {
-          return Buffer.from('clusters.postgresql.cnpg.io  2025-01-01T00:00:00Z');
+        if (cmd.includes('oc api-resources')) {
+          return Buffer.from('ok');
         }
         return Buffer.from('');
       });
@@ -353,7 +353,7 @@ describe('sandbox executor', () => {
 
     it('fails fast when a CNPG Cluster exists but the operator CRD is absent', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get crd ')) return Buffer.from(''); // operator down
+        if (cmd.includes('oc api-resources')) return Buffer.from(''); // operator down
         if (cmd.includes('clusters.postgresql.cnpg.io sandbox-postgres')) {
           return Buffer.from('sandbox-postgres  Cluster  Healthy'); // cluster exists
         }
@@ -374,8 +374,8 @@ describe('sandbox executor', () => {
 
     it('fails fast when azure-disk quota is full', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get crd ')) {
-          return Buffer.from('clusters.postgresql.cnpg.io  2025-01-01T00:00:00Z');
+        if (cmd.includes('oc api-resources')) {
+          return Buffer.from('ok');
         }
         if (
           cmd.includes('oc describe resourcequota') &&

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -209,8 +209,11 @@ export default async function runExecutor(
 
     // ---- shared database provisioning ----
     if (database === 'postgres') {
+      // oc get crd is cluster-scoped and returns Forbidden for namespace-admin
+      // users. oc api-resources hits the API discovery endpoint which is
+      // accessible regardless of namespace scope.
       const cnpgAvailable = !!capture(
-        `oc get crd clusters.postgresql.cnpg.io 2>/dev/null`,
+        `oc api-resources --api-group=postgresql.cnpg.io 2>/dev/null | grep -q '^clusters' && echo ok`,
         cwd,
       );
       // Check for a pre-existing CNPG Cluster regardless of CRD availability —


### PR DESCRIPTION
## Summary

Two bugs surfaced during the nx-oc 13.9.0 CNPG upgrade trial.

- **`oc get crd` → `oc api-resources` for CNPG availability probe**: `oc get crd clusters.postgresql.cnpg.io` is a cluster-scoped resource read — namespace-admin users (the normal case on GoA ARO) get `Forbidden`, making `cnpgAvailable` always falsy and causing the one-way-door guard to throw even when the CNPG operator is running fine. `oc api-resources --api-group=postgresql.cnpg.io` queries the API discovery endpoint, which is accessible regardless of namespace scope.

- **Distinct "missing scope" error in `ensureAdspToken`**: when a user had run `adsp login` without `--scope adsp-cli-admin`, the cached token lacked the scope, `fetchToken()` returned undefined, and `isNonInteractive()` (no TTY in a piped shell) threw "Not signed in to ADSP" — a wrong diagnosis. Before throwing, we now check whether a base-scope token is available. If it is, the user is signed in but missing the scope and gets a targeted "Signed in to ADSP but missing required scope(s)" message with the same corrective re-sign-in command, rather than the misleading "Not signed in" message.

## Test plan

- [ ] `npx nx test nx-oc` — sandbox spec mock branches updated from `oc get crd` to `oc api-resources`; new `adsp-utils` test covers the signed-in-but-missing-scope path
- [ ] `npx nx build nx-oc` — compiles cleanly
- [ ] `npx nx lint nx-oc` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)