### PR TITLE
feat(nx-adsp): add --cors option to express-service generator

### DIFF
--- a/packages/nx-adsp/src/generators/express-service/express-service.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.ts
@@ -50,6 +50,7 @@ async function normalizeOptions(
     projectRoot,
     adsp,
     database: options.database ?? 'none',
+    cors: options.cors ?? true,
     pairedProjectTag: pairedFrontend?.tag,
   };
 }
@@ -120,7 +121,7 @@ export default async function (host: Tree, options: Schema) {
       '@abgov/adsp-service-sdk': '^2.23.0',
       '@asteasolutions/zod-to-openapi': '^7.3.4',
       compression: '^1.8.1',
-      cors: '^2.8.5',
+      ...(normalizedOptions.cors ? { cors: '^2.8.5' } : {}),
       dotenv: '^16.4.7',
       envalid: '^8.0.0',
       helmet: '^8.0.0',
@@ -138,7 +139,7 @@ export default async function (host: Tree, options: Schema) {
     },
     {
       '@types/compression': '^1.7.5',
-      '@types/cors': '^2.8.17',
+      ...(normalizedOptions.cors ? { '@types/cors': '^2.8.17' } : {}),
       '@types/passport': '^1.0.16',
       '@types/passport-anonymous': '^1.0.3',
       supertest: '^7.0.0',

--- a/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/express-service/files/src/main.ts__tmpl__
@@ -1,8 +1,8 @@
 import { AdspId, createErrorHandler, initializeService } from '@abgov/adsp-service-sdk';
 import { OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
 import compression from 'compression';
-import cors from 'cors';
-import express from 'express';
+<% if (cors) { %>import cors from 'cors';
+<% } %>import express from 'express';
 import helmet from 'helmet';
 import passport from 'passport';
 import { Strategy as AnonymousStrategy } from 'passport-anonymous';
@@ -42,7 +42,13 @@ async function initializeApp() {
   app.use(compression());
   app.use(helmet());
   app.use(express.json());
-  app.use(cors());
+<% if (cors) { %>  app.use(cors());
+<% } else { %>  // This service is paired with a frontend via a same-origin reverse proxy —
+  // the browser never issues a cross-origin request, so no CORS middleware is
+  // needed. If you later expose this service directly to other origins (e.g. a
+  // platform API consumed by other tenants), add: app.use(cors({ origin: [...] }))
+  // and install the 'cors' and '@types/cors' packages.
+<% } %>
 
   if (environment.TRUSTED_PROXY) {
     app.set('trust proxy', environment.TRUSTED_PROXY);

--- a/packages/nx-adsp/src/generators/express-service/schema.d.ts
+++ b/packages/nx-adsp/src/generators/express-service/schema.d.ts
@@ -16,6 +16,8 @@ export interface Schema {
   database?: DatabaseType;
   /** Name of the paired frontend app project, set by composite generators (pevn, pern, pean, etc.). */
   pairedProject?: string;
+  /** When true (default), CORS middleware is added. Composite generators set this to false. */
+  cors?: boolean;
 }
 
 export interface NormalizedSchema extends Schema {
@@ -24,4 +26,5 @@ export interface NormalizedSchema extends Schema {
   adsp: AdspConfiguration;
   database: DatabaseType;
   pairedProjectTag?: string;
+  cors: boolean;
 }

--- a/packages/nx-adsp/src/generators/express-service/schema.json
+++ b/packages/nx-adsp/src/generators/express-service/schema.json
@@ -71,6 +71,11 @@
     "pairedProject": {
       "type": "string",
       "description": "Name of a frontend app project (vue-app, react-app, or angular-app) to pair with this service. When that frontend already exists in the workspace, the generator automatically wires its nginx proxy config, dev-server proxy file (vite.proxy.json or proxy.conf.json), serve target proxyConfig, and adsp:proxy-service: tag. Set automatically by composite generators (pevn, pern, pean, mern, mean) — also valid standalone when the frontend was scaffolded first."
+    },
+    "cors": {
+      "type": "boolean",
+      "description": "When true (default), CORS middleware is added — Access-Control-Allow-Origin: *. Set to false by full-stack composite generators whose service is paired with a frontend via a same-origin reverse proxy.",
+      "default": true
     }
   },
   "required": ["name", "env"],

--- a/packages/nx-adsp/src/generators/mean/mean.ts
+++ b/packages/nx-adsp/src/generators/mean/mean.ts
@@ -46,6 +46,7 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'mongo',
+    cors: false,
     pairedProject: appName,
   });
   await initAngularApp(host, {

--- a/packages/nx-adsp/src/generators/mern/mern.ts
+++ b/packages/nx-adsp/src/generators/mern/mern.ts
@@ -46,6 +46,7 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'mongo',
+    cors: false,
     pairedProject: appName,
   });
   await initReactApp(host, {

--- a/packages/nx-adsp/src/generators/mevn/mevn.ts
+++ b/packages/nx-adsp/src/generators/mevn/mevn.ts
@@ -42,6 +42,7 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'mongo',
+    cors: false,
     pairedProject: appName,
   });
   await initVueApp(host, {

--- a/packages/nx-adsp/src/generators/pean/pean.ts
+++ b/packages/nx-adsp/src/generators/pean/pean.ts
@@ -46,6 +46,7 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'postgres',
+    cors: false,
     pairedProject: appName,
   });
   await initAngularApp(host, {

--- a/packages/nx-adsp/src/generators/pern/pern.ts
+++ b/packages/nx-adsp/src/generators/pern/pern.ts
@@ -46,6 +46,7 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'postgres',
+    cors: false,
     pairedProject: appName,
   });
   await initReactApp(host, {

--- a/packages/nx-adsp/src/generators/pevn/pevn.ts
+++ b/packages/nx-adsp/src/generators/pevn/pevn.ts
@@ -42,6 +42,7 @@ export default async function (host: Tree, options: Schema) {
     name: serviceName,
     skipAgent: true,
     database: 'postgres',
+    cors: false,
     pairedProject: appName,
   });
   await initVueApp(host, {


### PR DESCRIPTION
## Summary

- Adds a `--cors` boolean option (default `true`) to the `express-service` generator controlling whether CORS middleware is scaffolded
- All six full-stack composite generators (`pevn`, `pern`, `pean`, `mevn`, `mern`, `mean`) now pass `cors: false` — their services are paired with a frontend via a same-origin reverse proxy so the browser never issues a cross-origin request
- When `cors: false`, the `cors` and `@types/cors` packages are omitted from `package.json` and a comment is generated in `main.ts` explaining when and how to re-enable
- Backwards compatible: standalone `express-service` invocations default to `cors: true` and behave exactly as before

## Test plan

- [x] Pre-commit hook passed: 181 tests, lint clean, build clean
- [ ] Verify standalone `express-service` still generates `app.use(cors())` (default `--cors true`)
- [ ] Verify a composite generator (e.g. `pevn`) generates `main.ts` without the cors import or call, with the explanatory comment
- [ ] Verify `cors` and `@types/cors` absent from `package.json` when `cors: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)