### PR TITLE
feat(nx-agent): add handoff skill to agent-delivery workflow

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: handoff
+description: Wraps up a completed agent-delivery iteration — squashes any WIP commits into clean conventional ones and writes a meaningful PR body, preparing the branch for human review.
+allowed-tools: Read, Write, Bash
+---
+
+## Purpose
+
+This skill runs immediately after the main DDDD skill completes. It has two jobs:
+
+1. Squash any WIP/checkpoint commits into clean conventional commits
+2. Write a PR body that a human reviewer can actually use
+
+The branch boundary — `git merge-base HEAD origin/main` — is the single reference point for
+both jobs. Using it for both means the commit history and the PR body tell the same story at
+the same granularity, and there's no per-iteration state to track.
+
+## Steps
+
+### 1. Read the branch boundary
+
+```bash
+BOUNDARY=$(git merge-base HEAD origin/main)
+git log --oneline "$BOUNDARY..HEAD"
+```
+
+### 2. Assess commit quality
+
+Read each commit message between the boundary and HEAD. A commit is **clean** when it follows
+Conventional Commits format (`type(scope): description`) with a meaningful description.
+A commit is **WIP** when its message is: "WIP", "wip", "checkpoint", "tmp", "save", "fix",
+a bare filename, or similarly uninformative. If every commit is already clean, skip step 3.
+
+### 3. Squash WIP commits (only when needed)
+
+```bash
+BOUNDARY=$(git merge-base HEAD origin/main)
+git fetch origin
+git reset --soft "$BOUNDARY"
+git restore --staged .github/agent-delivery-iteration/
+git diff --cached --stat
+```
+
+Unstaging `.github/agent-delivery-iteration/` keeps harness bookkeeping (history.json,
+pr-body.md) out of the substantive commits — otherwise a previous iteration's pr-body.md
+gets swept into the next squash. The staged diff now contains everything that changed this
+branch. Make 1–3 clean commits:
+
+- `feat(<scope>): <what was added>` for new capability
+- `fix(<scope>): <what was corrected>` for a bug fix or incorrect behaviour
+- `chore(<scope>): <what was updated>` for configuration, docs, or tooling
+
+`<scope>` is the Nx project name (`nx-adsp`, `nx-agent`, `nx-oc`, etc.) or a meaningful
+logical scope like `agent-delivery`.
+
+Then force-push to replace the WIP commits on the remote:
+
+```bash
+git push --force-with-lease origin "HEAD:$(git branch --show-current)"
+```
+
+### 4. Write the PR body
+
+```bash
+BOUNDARY=$(git merge-base HEAD origin/main)
+git log --oneline "$BOUNDARY..HEAD"
+git diff --stat "$BOUNDARY..HEAD"
+```
+
+Also scan changed files for `// project-docs-ancestors:` comments and any `resolves:` fields
+in committed project-docs artifacts — these link the code back to the requirements it
+satisfies and belong in the summary.
+
+Write to `.github/agent-delivery-iteration/pr-body.md`:
+
+```markdown
+## Summary
+<!-- 2–4 bullets: what was implemented or fixed, referencing project-docs artifact slugs -->
+
+## Changes
+<!-- Bulleted breakdown of what changed and why, grouped by concern -->
+
+## Test plan
+<!-- Which gates passed: packages tested/built/linted, any e2e target run -->
+
+## Artifacts advanced
+<!-- project-docs artifacts moved forward this iteration: slug, type, and new status -->
+```
+
+### 5. Done
+
+`ensure-completion-pr.sh` runs in the same job and reads `pr-body.md` directly from disk —
+no commit needed. The handoff is complete.

--- a/.github/agent-delivery-iteration/.gitignore
+++ b/.github/agent-delivery-iteration/.gitignore
@@ -1,0 +1,1 @@
+pr-body.md

--- a/.github/workflows/agent-delivery-iteration.yml
+++ b/.github/workflows/agent-delivery-iteration.yml
@@ -18,8 +18,8 @@ name: Agent Delivery Iteration (Copilot CLI)
 # self-dispatch -- any other push (starting the branch, or a human pushing mid-sequence) resets to
 # iteration 1 by construction. That's intentional: a human push means supervised, ongoing work,
 # not a runaway loop, so it earns a fresh MAX_ITERATIONS budget.
-# Disabled: Copilot CLI is not yet enabled in this org. Re-add the push trigger below to activate.
 on:
+  # Disabled: Copilot CLI is not yet enabled in this org. Re-add the push trigger below to activate.
   workflow_dispatch:
     inputs:
       iteration:
@@ -56,6 +56,8 @@ permissions:
   pull-requests: write
   # Needed for the self-dispatch (gh workflow run) that starts the next iteration.
   actions: write
+  # FLOW-SPECIFIC: this flow's deploy step publishes to GHCR under GITHUB_TOKEN.
+  packages: write
   # Deliberately not granted: workflows: write -- a GitHub anti-self-escalation control. A change
   # to this workflow file itself needs that permission and stays a human action.
 
@@ -91,6 +93,26 @@ jobs:
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
+
+      # ---- FLOW-SPECIFIC: Deploy needs a live OpenShift session. A flow with no deploy stage
+      # would drop these two steps. ----
+      - name: Install oc CLI
+        # oc-login (below) doesn't install the CLI itself.
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          oc: "latest"
+
+      - name: Log in to OpenShift
+        # Without this, nx-oc's own login helper (called inside the sandbox generator/executor)
+        # falls through to an interactive `oc login --web` browser flow, which hangs on a runner
+        # with no browser. Logging in here first means that check already succeeds downstream.
+        uses: redhat-actions/oc-login@v1
+        with:
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+          namespace: ${{ vars.OPENSHIFT_NAMESPACE }}
+          insecure_skip_tls_verify: true
 
       # ---- HARNESS: register whatever MCP servers this workspace happens to have configured --
       # generic behavior, the *content* of .mcp.json (if any) is what varies per workspace/flow ----
@@ -192,7 +214,31 @@ jobs:
           WORKFLOW_FILE: agent-delivery-iteration.yml
           ITERATION: ${{ steps.iterations.outputs.iteration }}
           PROMPT: ${{ steps.readiness.outputs.prompt }}
+          # FLOW-SPECIFIC: this flow's deploy stage runs nx-oc:sandbox/adsp-cli.
+          ADSP_CLIENT_ID: ${{ secrets.ADSP_CLIENT_ID }}
+          ADSP_CLIENT_SECRET: ${{ secrets.ADSP_CLIENT_SECRET }}
+          # ADSP_ENV/ADSP_TENANT_NAME steer nx-oc:sandbox's own --env/--tenant defaults;
+          # ADSP_TENANT_REALM steers adsp-cli's separate, non-interactive token fetch -- point all
+          # three at the same tenant, or the two resolution paths can disagree silently.
+          ADSP_ENV: ${{ vars.ADSP_ENV }}
+          ADSP_TENANT_NAME: ${{ vars.ADSP_TENANT_NAME }}
+          ADSP_TENANT_REALM: ${{ vars.ADSP_TENANT_REALM }}
         run: bash scripts/run-agent-delivery-iteration.sh "$PROMPT"
+
+      # ---- HARNESS: handoff — squash any WIP commits into clean conventional ones and write a
+      # structured PR body for human review. Runs as a second bounded copilot session so it can
+      # inspect the diff, reason about commit messages, and produce a useful description without
+      # any hardcoded templates. The workflow and handoff skill are emitted as one atomic unit by
+      # nx-agent:agent-delivery --githubActions, so the skill is always present when this workflow
+      # is. ----
+      - name: Handoff — clean up commits and write PR body
+        if: steps.iteration.outputs.made_commits == 'true'
+        run: |
+          copilot -p "$(cat .claude/skills/handoff/SKILL.md)" \
+            --no-ask-user \
+            --allow-tool=read \
+            --allow-tool=write \
+            --allow-tool=shell
 
       # ---- FLOW-SPECIFIC: re-check readiness immediately after this iteration's own commits
       # land, in this same job -- everything is already installed, so this costs almost nothing

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts
@@ -79,6 +79,16 @@ function addGithubActionsFiles(host: Tree): void {
     join(FILES_DIR, 'github-actions', 'learnings', 'learnings.md'),
     joinPathFragments('.github', 'agent-delivery-iteration', 'learnings.md'),
   );
+  copyIfMissing(
+    host,
+    join(FILES_DIR, 'github-actions', 'learnings', 'gitignore'),
+    joinPathFragments('.github', 'agent-delivery-iteration', '.gitignore'),
+  );
+  copyIfMissing(
+    host,
+    join(FILES_DIR, 'github-actions', 'skills', 'handoff', 'SKILL.md'),
+    joinPathFragments('.claude', 'skills', 'handoff', 'SKILL.md'),
+  );
 }
 
 function readGuidance(githubActions: boolean): string {

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/learnings/gitignore
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/learnings/gitignore
@@ -1,0 +1,1 @@
+pr-body.md

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/ensure-completion-pr.sh
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/ensure-completion-pr.sh
@@ -27,7 +27,16 @@ fi
 
 existing=$(gh pr list --head "$BRANCH_NAME" --base main --json number --jq '.[0].number // empty')
 if [[ -z "$existing" ]]; then
-  body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' "$WORKFLOW_NAME" "$SUMMARY")
+  # Prefer the structured PR body written by the handoff skill; fall back to the task-
+  # identification summary when the handoff step didn't run or didn't produce a file.
+  PR_BODY_FILE=".github/agent-delivery-iteration/pr-body.md"
+  if [[ -s "$PR_BODY_FILE" ]]; then
+    body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' \
+      "$WORKFLOW_NAME" "$(cat "$PR_BODY_FILE")")
+  else
+    body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' \
+      "$WORKFLOW_NAME" "$SUMMARY")
+  fi
   gh pr create --base main --head "$BRANCH_NAME" \
     --title "$WORKFLOW_NAME: $BRANCH_NAME" \
     --body "$body"

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/run-agent-delivery-iteration.sh
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/run-agent-delivery-iteration.sh
@@ -36,6 +36,7 @@ git config user.name "agent-delivery-iteration[bot]"
 git config user.email "agent-delivery-iteration[bot]@users.noreply.github.com"
 
 BEFORE_HEAD="$(git rev-parse HEAD)"
+echo "before_head=$BEFORE_HEAD" >> "$GITHUB_OUTPUT"
 
 # Push-watcher: runs alongside the copilot -p call below, pushing whenever HEAD moves, so a real,
 # multi-commit session's progress survives even if something later fails, hangs, or the job gets

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/skills/handoff/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/skills/handoff/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: handoff
+description: Wraps up a completed agent-delivery iteration — squashes any WIP commits into clean conventional ones and writes a meaningful PR body, preparing the branch for human review.
+allowed-tools: Read, Write, Bash
+---
+
+## Purpose
+
+This skill runs immediately after the main DDDD skill completes. It has two jobs:
+
+1. Squash any WIP/checkpoint commits into clean conventional commits
+2. Write a PR body that a human reviewer can actually use
+
+The branch boundary — `git merge-base HEAD origin/main` — is the single reference point for
+both jobs. Using it for both means the commit history and the PR body tell the same story at
+the same granularity, and there's no per-iteration state to track.
+
+## Steps
+
+### 1. Read the branch boundary
+
+```bash
+BOUNDARY=$(git merge-base HEAD origin/main)
+git log --oneline "$BOUNDARY..HEAD"
+```
+
+### 2. Assess commit quality
+
+Read each commit message between the boundary and HEAD. A commit is **clean** when it follows
+Conventional Commits format (`type(scope): description`) with a meaningful description.
+A commit is **WIP** when its message is: "WIP", "wip", "checkpoint", "tmp", "save", "fix",
+a bare filename, or similarly uninformative. If every commit is already clean, skip step 3.
+
+### 3. Squash WIP commits (only when needed)
+
+```bash
+BOUNDARY=$(git merge-base HEAD origin/main)
+git fetch origin
+git reset --soft "$BOUNDARY"
+git restore --staged .github/agent-delivery-iteration/
+git diff --cached --stat
+```
+
+Unstaging `.github/agent-delivery-iteration/` keeps harness bookkeeping (history.json,
+pr-body.md) out of the substantive commits — otherwise a previous iteration's pr-body.md
+gets swept into the next squash. The staged diff now contains everything that changed this
+branch. Make 1–3 clean commits:
+
+- `feat(<scope>): <what was added>` for new capability
+- `fix(<scope>): <what was corrected>` for a bug fix or incorrect behaviour
+- `chore(<scope>): <what was updated>` for configuration, docs, or tooling
+
+`<scope>` is the Nx project name (`nx-adsp`, `nx-agent`, `nx-oc`, etc.) or a meaningful
+logical scope like `agent-delivery`.
+
+Then force-push to replace the WIP commits on the remote:
+
+```bash
+git push --force-with-lease origin "HEAD:$(git branch --show-current)"
+```
+
+### 4. Write the PR body
+
+```bash
+BOUNDARY=$(git merge-base HEAD origin/main)
+git log --oneline "$BOUNDARY..HEAD"
+git diff --stat "$BOUNDARY..HEAD"
+```
+
+Also scan changed files for `// project-docs-ancestors:` comments and any `resolves:` fields
+in committed project-docs artifacts — these link the code back to the requirements it
+satisfies and belong in the summary.
+
+Write to `.github/agent-delivery-iteration/pr-body.md`:
+
+```markdown
+## Summary
+<!-- 2–4 bullets: what was implemented or fixed, referencing project-docs artifact slugs -->
+
+## Changes
+<!-- Bulleted breakdown of what changed and why, grouped by concern -->
+
+## Test plan
+<!-- Which gates passed: packages tested/built/linted, any e2e target run -->
+
+## Artifacts advanced
+<!-- project-docs artifacts moved forward this iteration: slug, type, and new status -->
+```
+
+### 5. Done
+
+`ensure-completion-pr.sh` runs in the same job and reads `pr-body.md` directly from disk —
+no commit needed. The handoff is complete.

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
@@ -228,6 +228,21 @@ jobs:
           ADSP_TENANT_REALM: ${{ vars.ADSP_TENANT_REALM }}
         run: bash scripts/run-agent-delivery-iteration.sh "$PROMPT"
 
+      # ---- HARNESS: handoff — squash any WIP commits into clean conventional ones and write a
+      # structured PR body for human review. Runs as a second bounded copilot session so it can
+      # inspect the diff, reason about commit messages, and produce a useful description without
+      # any hardcoded templates. The workflow and handoff skill are emitted as one atomic unit by
+      # nx-agent:agent-delivery --githubActions, so the skill is always present when this workflow
+      # is. ----
+      - name: Handoff — clean up commits and write PR body
+        if: steps.iteration.outputs.made_commits == 'true'
+        run: |
+          copilot -p "$(cat .claude/skills/handoff/SKILL.md)" \
+            --no-ask-user \
+            --allow-tool=read \
+            --allow-tool=write \
+            --allow-tool=shell
+
       # ---- FLOW-SPECIFIC: re-check readiness immediately after this iteration's own commits
       # land, in this same job -- everything is already installed, so this costs almost nothing
       # compared to a whole fresh job whose only purpose might turn out to be discovering there's

--- a/scripts/ensure-completion-pr.sh
+++ b/scripts/ensure-completion-pr.sh
@@ -27,7 +27,16 @@ fi
 
 existing=$(gh pr list --head "$BRANCH_NAME" --base main --json number --jq '.[0].number // empty')
 if [[ -z "$existing" ]]; then
-  body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' "$WORKFLOW_NAME" "$SUMMARY")
+  # Prefer the structured PR body written by the handoff skill; fall back to the task-
+  # identification summary when the handoff step didn't run or didn't produce a file.
+  PR_BODY_FILE=".github/agent-delivery-iteration/pr-body.md"
+  if [[ -s "$PR_BODY_FILE" ]]; then
+    body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' \
+      "$WORKFLOW_NAME" "$(cat "$PR_BODY_FILE")")
+  else
+    body=$(printf 'Automated by the "%s" workflow.\n\n%s\n\nNo auto-merge -- this loop never merges its own work; review and merge by hand when ready.\n' \
+      "$WORKFLOW_NAME" "$SUMMARY")
+  fi
   gh pr create --base main --head "$BRANCH_NAME" \
     --title "$WORKFLOW_NAME: $BRANCH_NAME" \
     --body "$body"

--- a/scripts/run-agent-delivery-iteration.sh
+++ b/scripts/run-agent-delivery-iteration.sh
@@ -36,6 +36,7 @@ git config user.name "agent-delivery-iteration[bot]"
 git config user.email "agent-delivery-iteration[bot]@users.noreply.github.com"
 
 BEFORE_HEAD="$(git rev-parse HEAD)"
+echo "before_head=$BEFORE_HEAD" >> "$GITHUB_OUTPUT"
 
 # Push-watcher: runs alongside the copilot -p call below, pushing whenever HEAD moves, so a real,
 # multi-commit session's progress survives even if something later fails, hangs, or the job gets


### PR DESCRIPTION
## Summary

- Adds a `handoff` skill emitted by `nx-agent:agent-delivery --githubActions` that squashes WIP commits and writes a structured PR body after each iteration
- Uses `git merge-base HEAD origin/main` as the single boundary for both commit squashing and PR body generation
- `ensure-completion-pr.sh` now prefers the handoff-written `pr-body.md` (read from disk in the same job) over the raw task-identification summary
- `pr-body.md` is gitignored in `.github/agent-delivery-iteration/`; the generator emits the `.gitignore` via `copyIfMissing`

## Changes

- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/skills/handoff/SKILL.md`** (new): squash branch commits to the merge-base, unstage `.github/agent-delivery-iteration/` to keep harness bookkeeping out of conventional commits, write PR body to `pr-body.md`
- **`packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts`**: `addGithubActionsFiles()` emits the handoff skill and the `.gitignore` via `copyIfMissing`
- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/learnings/gitignore`** (new): source for `.github/agent-delivery-iteration/.gitignore`, named without the dot to avoid workspace gitignore interference
- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml`**: adds handoff step after the main iteration step; condition is `made_commits == 'true'` only — no `hashFiles` guard since workflow and skill are one atomic unit
- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/ensure-completion-pr.sh`**: reads `pr-body.md` from disk when present, falls back to `$SUMMARY`
- Live copies in `scripts/`, `.github/workflows/`, `.github/agent-delivery-iteration/`, and `.claude/skills/handoff/` mirrored from generator source

## Test plan

- `npx nx test nx-agent` — 264 tests passed
- `npx nx build nx-agent` — clean
- `npx nx lint nx-agent` — warnings only (pre-existing), no errors

## Artifacts advanced

No project-docs artifacts — this is a tooling improvement to the agent delivery workflow itself.