### PR TITLE
fix(nx-agent): preserve learnings.md in handoff; pass GITHUB_TOKEN; disable live push trigger

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -37,13 +37,13 @@ a bare filename, or similarly uninformative. If every commit is already clean, s
 BOUNDARY=$(git merge-base HEAD origin/main)
 git fetch origin
 git reset --soft "$BOUNDARY"
-git restore --staged .github/agent-delivery-iteration/
+git restore --staged .github/agent-delivery-iteration/history.json 2>/dev/null || true
 git diff --cached --stat
 ```
 
-Unstaging `.github/agent-delivery-iteration/` keeps harness bookkeeping (history.json,
-pr-body.md) out of the substantive commits — otherwise a previous iteration's pr-body.md
-gets swept into the next squash. The staged diff now contains everything that changed this
+Unstaging only `history.json` — it is committed by its own dedicated workflow step, not here.
+`pr-body.md` is gitignored so it cannot be staged. `learnings.md` must stay staged so its
+changes are included in the clean commits. The staged diff now contains everything that changed this
 branch. Make 1–3 clean commits:
 
 - `feat(<scope>): <what was added>` for new capability

--- a/.github/workflows/agent-delivery-iteration.yml
+++ b/.github/workflows/agent-delivery-iteration.yml
@@ -233,6 +233,8 @@ jobs:
       # is. ----
       - name: Handoff — clean up commits and write PR body
         if: steps.iteration.outputs.made_commits == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           copilot -p "$(cat .claude/skills/handoff/SKILL.md)" \
             --no-ask-user \

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/skills/handoff/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/skills/handoff/SKILL.md
@@ -37,13 +37,13 @@ a bare filename, or similarly uninformative. If every commit is already clean, s
 BOUNDARY=$(git merge-base HEAD origin/main)
 git fetch origin
 git reset --soft "$BOUNDARY"
-git restore --staged .github/agent-delivery-iteration/
+git restore --staged .github/agent-delivery-iteration/history.json 2>/dev/null || true
 git diff --cached --stat
 ```
 
-Unstaging `.github/agent-delivery-iteration/` keeps harness bookkeeping (history.json,
-pr-body.md) out of the substantive commits — otherwise a previous iteration's pr-body.md
-gets swept into the next squash. The staged diff now contains everything that changed this
+Unstaging only `history.json` — it is committed by its own dedicated workflow step, not here.
+`pr-body.md` is gitignored so it cannot be staged. `learnings.md` must stay staged so its
+changes are included in the clean commits. The staged diff now contains everything that changed this
 branch. Make 1–3 clean commits:
 
 - `feat(<scope>): <what was added>` for new capability

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
@@ -236,6 +236,8 @@ jobs:
       # is. ----
       - name: Handoff — clean up commits and write PR body
         if: steps.iteration.outputs.made_commits == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           copilot -p "$(cat .claude/skills/handoff/SKILL.md)" \
             --no-ask-user \


### PR DESCRIPTION
## Summary

- Adds a `handoff` skill emitted by `nx-agent:agent-delivery --githubActions` that squashes WIP commits and writes a structured PR body after each iteration
- Uses `git merge-base HEAD origin/main` as the single boundary for both commit squashing and PR body generation
- `ensure-completion-pr.sh` now prefers the handoff-written `pr-body.md` (read from disk in the same job) over the raw task-identification summary
- `pr-body.md` is gitignored in `.github/agent-delivery-iteration/`; the generator emits the `.gitignore` via `copyIfMissing`

## Changes

- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/skills/handoff/SKILL.md`** (new): squash branch commits to the merge-base, unstage `.github/agent-delivery-iteration/` to keep harness bookkeeping out of conventional commits, write PR body to `pr-body.md`
- **`packages/nx-agent/src/generators/agent-delivery/agent-delivery.ts`**: `addGithubActionsFiles()` emits the handoff skill and the `.gitignore` via `copyIfMissing`
- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/learnings/gitignore`** (new): source for `.github/agent-delivery-iteration/.gitignore`, named without the dot to avoid workspace gitignore interference
- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml`**: adds handoff step after the main iteration step; condition is `made_commits == 'true'` only — no `hashFiles` guard since workflow and skill are one atomic unit
- **`packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/ensure-completion-pr.sh`**: reads `pr-body.md` from disk when present, falls back to `$SUMMARY`
- Live copies in `scripts/`, `.github/workflows/`, `.github/agent-delivery-iteration/`, and `.claude/skills/handoff/` mirrored from generator source

## Test plan

- `npx nx test nx-agent` — 264 tests passed
- `npx nx build nx-agent` — clean
- `npx nx lint nx-agent` — warnings only (pre-existing), no errors

## Artifacts advanced

No project-docs artifacts — this is a tooling improvement to the agent delivery workflow itself.