### PR TITLE
feat(nx-oc): register deployed service in ADSP directory after sandbox rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,7 +363,8 @@ The executor (`packages/nx-oc/src/executors/sandbox/`) runs: preflight (`oc` log
 per-deploy pull secret → `oc tag … --reference-policy=local` → **`oc import-image` with retry**
 (absorbs the tag-reconcile 409) → `oc process | oc apply` → `oc rollout`. Pods pull in-cluster
 via the local reference policy. Options include `--database`, `--imageTag`, `--importRetries`,
-`--deployBackend`, and `--skipBuild`/`--skipPush` (resume a partial deploy).
+`--deployBackend`, `--skipBuild`/`--skipPush` (resume a partial deploy), and
+`--registerDirectory` (opt-in ADSP directory registration after rollout).
 
 Key wiring to preserve when editing:
 
@@ -397,8 +398,16 @@ Key wiring to preserve when editing:
   token (`GITHUB_TOKEN`), so a workflow running this executor under its own token (no PAT) needs the
   `GITHUB_ACTOR` fallback the Actions runner always sets. Local/interactive use is unaffected —
   `GITHUB_ACTOR` is unset there, so it still resolves the active `gh` account.
+- **`--registerDirectory` (opt-in, non-fatal)**: after a successful rollout, resolves the app's
+  Route host via `oc get route`, derives the tenant namespace from the project's
+  `adsp:scaffold-tenant:<name>` tag (`toLowerCase().replace(/ /g, '-')`), then calls
+  `registerDirectoryService` from `@abgov/adsp-cli`. Register-once semantics: a 409 is silently
+  skipped. Token comes from `getAccessToken()` — a `not-authenticated` result warns and skips (run
+  `adsp login` first). A 403 from the directory service means the logged-in user lacks the
+  `directory-admin` role — warn and skip, not a hard failure. Only runs for `node`/`dotnet` app
+  types; frontends are skipped unconditionally. Requires `@abgov/adsp-cli ^1.10.0`.
 - The generator unit tests assert the target/manifest shape; the executor tests mock `child_process`
-  `execSync` and assert the command sequence/preflight/retry.
+  `execSync` and `@abgov/adsp-cli` and assert the command sequence/preflight/retry/registration.
 
 ---
 

--- a/docs/nx-oc/nx-oc.md
+++ b/docs/nx-oc/nx-oc.md
@@ -167,6 +167,7 @@ npx nx g @abgov/nx-oc:sandbox my-app-service --sandboxProject my-sandbox-ns --da
 
 - `podman` installed.
 - `gh auth login` as an account with **`write:packages`** on the registry org (the same login supplies both the push and the per-deploy pull secret — no PAT is stored).
+- For `--registerDirectory`: `npx @abgov/adsp-cli login --tenant "<tenant name>"` as a user with the `directory-admin` role (tenant admins have it automatically).
 
 The generator adds `sandbox` and `sandbox-teardown` targets to the project and creates:
 
@@ -188,6 +189,7 @@ Running `nx run my-app:sandbox` executes the full loop:
 3. Refreshes the `ghcr-pull` Secret from the current `gh` session token.
 4. `oc tag` + `oc import-image --reference-policy=local` — the internal registry serves the image, so pods pull in-cluster (no per-pod pull secret, no node egress).
 5. Applies the manifest, restarts the Deployment, waits for rollout.
+6. **ADSP directory registration** (opt-in — `--registerDirectory`): resolves the app's Route URL, derives the tenant namespace from the project's `adsp:scaffold-tenant:` tag, and calls `registerDirectoryService` (from `@abgov/adsp-cli`) to POST the entry. Register-once — a 409 is silently skipped. All auth/permission failures are non-fatal warns; the deploy succeeds regardless. Only runs for `node`/`dotnet` app types.
 
 Local layer caching makes iteration fast — after the first push, only the changed app layer is re-uploaded.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@abgov/adsp-cli": "^1.7.0",
+        "@abgov/adsp-cli": "^1.10.0",
         "@angular/core": "22.0.8",
         "@nx/devkit": "23.1.1",
         "json-schema-to-typescript": "^13.0.1",
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/@abgov/adsp-cli": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.8.0.tgz",
-      "integrity": "sha512-nJphvfqHJCgKBKzWeNS+ChhB4ED6HDK0oFIRvPuEaDYTFssrXLiNCXj1SlSM6ZlVINeB0w7A6ic0eYQcr3Bcjw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@abgov/adsp-cli/-/adsp-cli-1.10.0.tgz",
+      "integrity": "sha512-yhzB+WmCKMmlV1XVseVEC3b8mEZA7NIsGQvd++553VKVRUKqcKlne+46tszeke7xOQcEcrZERn05e+TOab12Cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "enquirer": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "private": true,
   "dependencies": {
-    "@abgov/adsp-cli": "^1.7.0",
+    "@abgov/adsp-cli": "^1.10.0",
     "@angular/core": "22.0.8",
     "@nx/devkit": "23.1.1",
     "json-schema-to-typescript": "^13.0.1",
@@ -45,8 +45,8 @@
     "@angular-devkit/core": "22.0.9",
     "@angular-devkit/schematics": "22.0.9",
     "@nx/angular": "23.1.1",
-    "@nx/dotnet": "23.1.1",
     "@nx/cypress": "23.1.1",
+    "@nx/dotnet": "23.1.1",
     "@nx/eslint": "23.1.1",
     "@nx/eslint-plugin": "23.1.1",
     "@nx/express": "23.1.1",

--- a/packages/nx-oc/package.json
+++ b/packages/nx-oc/package.json
@@ -14,7 +14,7 @@
     "tslib": "^2.0.0"
   },
   "dependencies": {
-    "@abgov/adsp-cli": "^1.7.0",
+    "@abgov/adsp-cli": "^1.10.0",
     "axios": "^1.19.0",
     "enquirer": "^2.3.6",
     "yaml": "~2.9.0"

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -7,9 +7,19 @@ jest.mock('child_process', () => ({
   execSync: jest.fn(),
 }));
 jest.mock('../../utils/oc-utils', () => ({ ensureOcLogin: jest.fn() }));
+jest.mock('@abgov/adsp-cli', () => ({
+  getAccessToken: jest.fn(),
+  getDirectoryServiceUrl: jest.fn(),
+  registerDirectoryService: jest.fn(),
+}));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { execSync } = require('child_process') as { execSync: jest.Mock };
+
+const adspCli = require('@abgov/adsp-cli') as {
+  getAccessToken: jest.Mock;
+  getDirectoryServiceUrl: jest.Mock;
+  registerDirectoryService: jest.Mock;
+};
 
 const IMAGE_REF = 'ghcr.io/test-org/test-sandbox-test:sandbox';
 
@@ -42,6 +52,12 @@ function commands(): string[] {
 beforeEach(() => {
   execSync.mockReset();
   execSync.mockImplementation(() => Buffer.from(''));
+  adspCli.getAccessToken.mockReset();
+  adspCli.getAccessToken.mockResolvedValue({ status: 'ok', token: 'test-token' });
+  adspCli.getDirectoryServiceUrl.mockReset();
+  adspCli.getDirectoryServiceUrl.mockReturnValue('https://directory.adsp.alberta.ca');
+  adspCli.registerDirectoryService.mockReset();
+  adspCli.registerDirectoryService.mockResolvedValue('registered');
 });
 
 describe('sandbox executor', () => {
@@ -461,5 +477,140 @@ describe('sandbox executor', () => {
     ).toBe(true);
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  describe('registerDirectory', () => {
+    const TENANT_TAG = 'adsp:scaffold-tenant:My Tenant';
+
+    it('registers the service when route resolves and tenant tag is present', async () => {
+      execSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        return Buffer.from('');
+      });
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: true },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(adspCli.registerDirectoryService).toHaveBeenCalledWith(
+        'https://directory.adsp.alberta.ca',
+        'my-tenant',
+        'test',
+        'https://test.apps.example.com',
+        'test-token',
+      );
+    });
+
+    it('logs skip when the directory entry already exists (409)', async () => {
+      execSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        return Buffer.from('');
+      });
+      adspCli.registerDirectoryService.mockResolvedValue('exists');
+      const info = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: true },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(info).toHaveBeenCalledWith(
+        expect.stringContaining('already exists'),
+      );
+      info.mockRestore();
+    });
+
+    it('warns and skips registration when the route cannot be resolved', async () => {
+      // default execSync mock returns '' → no route host
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: true },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(adspCli.registerDirectoryService).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Could not resolve route'),
+      );
+      warn.mockRestore();
+    });
+
+    it('warns and skips registration when no ADSP tenant tag is present', async () => {
+      execSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        return Buffer.from('');
+      });
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: true },
+        context(), // no tenant tag
+      );
+      expect(result.success).toBe(true);
+      expect(adspCli.registerDirectoryService).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('No ADSP tenant tag'),
+      );
+      warn.mockRestore();
+    });
+
+    it('warns and skips registration when not authenticated to ADSP', async () => {
+      execSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        return Buffer.from('');
+      });
+      adspCli.getAccessToken.mockResolvedValue({ status: 'not-authenticated' });
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: true },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(adspCli.registerDirectoryService).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Not authenticated to ADSP'),
+      );
+      warn.mockRestore();
+    });
+
+    it('warns (non-fatal) when registerDirectoryService throws (e.g. 403)', async () => {
+      execSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        return Buffer.from('');
+      });
+      adspCli.registerDirectoryService.mockRejectedValue(
+        new Error("Not authorized to register services in namespace 'my-tenant'."),
+      );
+      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: true },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Directory registration skipped'),
+      );
+      warn.mockRestore();
+    });
+
+    it('skips registration entirely for frontend app types', async () => {
+      execSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        return Buffer.from('');
+      });
+      const result = await runExecutor(
+        { ...baseOptions, appType: 'frontend', registerDirectory: true },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(adspCli.registerDirectoryService).not.toHaveBeenCalled();
+    });
+
+    it('does not call registerDirectoryService when registerDirectory is false', async () => {
+      const result = await runExecutor(
+        { ...baseOptions, registerDirectory: false },
+        context([TENANT_TAG]),
+      );
+      expect(result.success).toBe(true);
+      expect(adspCli.registerDirectoryService).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -1,8 +1,14 @@
 import { ExecutorContext, logger } from '@nx/devkit';
+import {
+  getAccessToken,
+  getDirectoryServiceUrl,
+  registerDirectoryService,
+} from '@abgov/adsp-cli';
 import { execSync } from 'child_process';
 import { detectApplicationType } from '../../utils/app-type';
 import { activeAccountScopes } from '../../utils/gh-utils';
 import { ensureOcLogin } from '../../utils/oc-utils';
+import { detectAdspTenant } from '../../adsp/adsp-utils';
 import { SandboxExecutorSchema } from './schema';
 
 const PROXY_TAG_PREFIX = 'adsp:proxy-service:';
@@ -153,6 +159,7 @@ export default async function runExecutor(
     skipPush = false,
     deployBackend = false,
     importRetries = 5,
+    registerDirectory = false,
   } = options;
 
   if (!sandboxProject) {
@@ -501,6 +508,73 @@ export default async function runExecutor(
       `oc rollout status deployment/${projectName} -n ${sandboxProject} --timeout=180s`,
       cwd,
     );
+
+    // ---- ADSP directory registration (opt-in, non-fatal) ----
+    if (registerDirectory && appType !== 'frontend') {
+      const routeHost = capture(
+        `oc get route ${projectName} -n ${sandboxProject} -o jsonpath='{.spec.host}'`,
+        cwd,
+      );
+      if (!routeHost) {
+        logger.warn(
+          `[nx-oc:sandbox] Could not resolve route for ${projectName} — skipping directory registration.`,
+        );
+      } else {
+        const serviceUrl = `https://${routeHost}`;
+        const tenantName = detectAdspTenant(project.tags ?? []);
+        if (!tenantName) {
+          logger.warn(
+            `[nx-oc:sandbox] No ADSP tenant tag found on ${projectName} — skipping directory registration. ` +
+              `Scaffold with nx-adsp or add the tag manually.`,
+          );
+        } else {
+          const namespace = tenantName.toLowerCase().replace(/ /g, '-');
+          const tokenResult = await getAccessToken();
+          if (tokenResult.status !== 'ok') {
+            logger.warn(
+              `[nx-oc:sandbox] Not authenticated to ADSP — skipping directory registration. ` +
+                `Run \`adsp login --tenant "${tenantName}"\` first.`,
+            );
+          } else {
+            try {
+              const directoryServiceUrl = getDirectoryServiceUrl();
+              const outcome = await registerDirectoryService(
+                directoryServiceUrl,
+                namespace,
+                projectName,
+                serviceUrl,
+                tokenResult.token,
+              );
+              if (outcome === 'registered') {
+                logger.info(
+                  `\n✓ Registered urn:ads:${namespace}:${projectName} → ${serviceUrl}`,
+                );
+              } else {
+                logger.info(
+                  `  Directory entry urn:ads:${namespace}:${projectName} already exists, skipping.`,
+                );
+              }
+            } catch (err) {
+              logger.warn(
+                `[nx-oc:sandbox] Directory registration skipped: ${(err as Error).message}`,
+              );
+            }
+            // Advisory: warn if the app doesn't serve the HAL root docs link
+            // that the api-docs aggregator needs to discover the OpenAPI spec.
+            const rootJson = capture(
+              `curl -sf --connect-timeout 5 --max-time 10 ${serviceUrl}/ 2>/dev/null`,
+              cwd,
+            );
+            if (rootJson && !rootJson.includes('"docs"')) {
+              logger.warn(
+                `[nx-oc:sandbox] ${projectName} does not expose _links.docs.href at GET /. ` +
+                  `The ADSP api-docs aggregator won't be able to find its OpenAPI spec.`,
+              );
+            }
+          }
+        }
+      }
+    }
 
     logger.info(`\n✓ Sandbox deploy complete for ${projectName}.`);
     return { success: true };

--- a/packages/nx-oc/src/executors/sandbox/schema.d.ts
+++ b/packages/nx-oc/src/executors/sandbox/schema.d.ts
@@ -13,4 +13,5 @@ export interface SandboxExecutorSchema {
   skipPush?: boolean;
   deployBackend?: boolean;
   importRetries?: number;
+  registerDirectory?: boolean;
 }

--- a/packages/nx-oc/src/executors/sandbox/schema.json
+++ b/packages/nx-oc/src/executors/sandbox/schema.json
@@ -49,6 +49,11 @@
       "type": "number",
       "default": 5,
       "description": "How many times to retry oc import-image (absorbs the 409 from oc tag's async reconcile)."
+    },
+    "registerDirectory": {
+      "type": "boolean",
+      "default": false,
+      "description": "After a successful rollout, register the service in the ADSP directory under the tenant's namespace (register-once — skips if the entry already exists). Only applies to node and dotnet app types. Requires an active adsp login with the directory-admin role."
     }
   },
   "required": ["sandboxProject", "registry"]

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -44,15 +44,22 @@ workspace-wide) and provisioned into GitHub Actions secrets by
 5. `oc tag … --reference-policy=local` then `oc import-image` (retried to absorb
    the tag-reconcile 409).
 6. `oc process | oc apply` the manifest, then `oc rollout restart` + `status`.
+7. **ADSP directory registration** (opt-in — `--registerDirectory`): resolves the
+   app's Route URL, derives the tenant namespace from the `adsp:scaffold-tenant:`
+   project tag, and calls `registerDirectoryService` from `@abgov/adsp-cli` to POST
+   the entry. Register-once — a 409 (already exists) is silently skipped. All
+   failures are non-fatal warns; the deploy succeeds regardless. Only runs for
+   `node`/`dotnet` app types.
 
 ## Options (resume a partial deploy without rebuilding)
 
 ```bash
-nx run <%= projectName %>:sandbox --skipBuild            # reuse the built image; re-push + import + roll out
-nx run <%= projectName %>:sandbox --skipBuild --skipPush # reuse the pushed image; re-import + roll out only
-nx run <%= projectName %>:sandbox --imageTag=<tag>       # push/import under a different tag
-nx run <%= projectName %>:sandbox --importRetries=8      # more import retries on a slow cluster
-<% if (appType === 'frontend') { %>nx run <%= projectName %>:sandbox --deployBackend         # deploy each paired backend (its own sandbox) first
+nx run <%= projectName %>:sandbox --skipBuild              # reuse the built image; re-push + import + roll out
+nx run <%= projectName %>:sandbox --skipBuild --skipPush   # reuse the pushed image; re-import + roll out only
+nx run <%= projectName %>:sandbox --imageTag=<tag>         # push/import under a different tag
+nx run <%= projectName %>:sandbox --importRetries=8        # more import retries on a slow cluster
+nx run <%= projectName %>:sandbox --registerDirectory      # register in ADSP directory after rollout (opt-in)
+<% if (appType === 'frontend') { %>nx run <%= projectName %>:sandbox --deployBackend           # deploy each paired backend (its own sandbox) first
 <% } %>```
 <% if (appType === 'frontend') { %>
 This frontend proxies `/api` to its paired backend Service. The target always
@@ -129,6 +136,18 @@ oc get pods -n <%= sandboxProject %> -l name=<%= projectName %>
   to the client's valid redirect URIs.
 <% } %>- **Import 409 "object has been modified"** — the `oc tag` reconcile race; the
   executor already retries. If you hit it manually, just re-run the import.
+- **`--registerDirectory` warns "Not authenticated to ADSP"** — run
+  `npx @abgov/adsp-cli login --tenant "<tenant name>"` before deploying, or
+  ensure `ADSP_CLIENT_ID`/`ADSP_CLIENT_SECRET`/`ADSP_TENANT_REALM` are set for CI.
+  The deploy still completes — registration is non-fatal.
+- **`--registerDirectory` warns "Not authorized to register services"** — the
+  logged-in ADSP user is missing the `directory-admin` role. A tenant admin has it
+  automatically; other users need it granted. The deploy still completes.
+- **`--registerDirectory` warns "does not expose `_links.docs.href`"** — the app's
+  `GET /` root does not return a HAL JSON body with `_links.docs.href`. The ADSP
+  api-docs aggregator follows that link to discover the OpenAPI spec; without it the
+  service is in the directory but won't appear in api-docs. `nx-adsp`'s
+  `express-service` scaffolds this automatically; add it manually if needed.
 <% if (database === 'postgres') { %>
 ## CloudNativePG notes
 


### PR DESCRIPTION
## Summary

- Adds opt-in `registerDirectory: boolean` flag (default `false`) to the sandbox executor schema
- After a successful rollout, resolves the app's OpenShift route, derives the tenant namespace from the project's `adsp:scaffold-tenant:` tag, and calls `registerDirectoryService` from `@abgov/adsp-cli` to POST the service entry to the ADSP directory service
- Register-once semantics: a 409 (entry already exists) is silently skipped, not an error
- All auth and permission failures (`not-authenticated`, missing `directory-admin` role, network errors) are non-fatal `logger.warn()` — a failed registration never blocks a working deploy
- Only runs for `node`/`dotnet` app types; silently skipped for `frontend`
- Advisory `curl` check after registration: warns if `GET /` doesn't return `_links.docs.href`, which the ADSP api-docs aggregator needs to discover the OpenAPI spec
- Bumps `@abgov/adsp-cli` to `^1.10.0`, which ships the new `registerDirectoryService` library export (released from adsp-monorepo PR #5766)

## Test plan

- [ ] 160/160 unit tests pass (`npx nx test nx-oc`)
- [ ] Build succeeds (`npx nx build nx-oc`)
- [ ] Lint passes — 0 errors, only 2 pre-existing warnings (`npx nx lint nx-oc`)
- [ ] New `registerDirectory` tests cover: successful registration, already-exists skip, no route warn, no tenant tag warn, not-authenticated warn, 403 non-fatal warn, frontend skip, flag-off no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)