### PR TITLE
feat(nx-agent): require navigation/IA in UX designs and app-shell e2e paths

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -98,14 +98,21 @@ scope here.
    experiences the requirement: what it shows, what it does, which rule each behavior traces to.
    For a UI-backed requirement, this is a **UX design** — hand-author under
    `project-docs/ux-designs/<slug>.md`, frontmatter `project-docs-ancestors:
-   [domain-models:<slug>]`, and a structured `screens`/`rules`/`examples`/`questions` shape
-   (screens, not endpoints — each translating one of the requirement's business rules into what a
-   screen shows and does, plus which design-system component(s) it uses, per step 5). Each screen
-   also states what it needs from its provider as its own list — the contract interface points get
-   checked against next: the consumer states what it needs, the provider satisfies it. Register
-   once: `"ux-designs": { "expectedAncestorTypes": ["domain-models"] }`. A requirement with no
-   human-facing consumer (a backend-to-backend integration, a scheduled job) has no interaction
-   surface to design — skip straight to interface points below.
+   [domain-models:<slug>]`, and a structured shape with these sections:
+   - **`navigation`** — where this feature lives in the app's information architecture: `sitemap-position`
+     (its place relative to existing sections), `entry-from` (how users reach it from the app shell —
+     `"temporary dev route"` is a valid explicit answer for a feature under initial development), and
+     `route` (the URL path). This section is required; an absent or blank `entry-from` is a design gap,
+     not a deferral — make the decision consciously and state it.
+   - **`screens`** — each translating one of the requirement's business rules into what a screen shows
+     and does, plus which design-system component(s) it uses (per step 5). Each screen also states what
+     it needs from its provider as its own list.
+   - **`rules`**, **`examples`**, **`questions`**
+
+   The contract interface points get checked against next: the consumer states what it needs, the
+   provider satisfies it. Register once: `"ux-designs": { "expectedAncestorTypes": ["domain-models"] }`.
+   A requirement with no human-facing consumer (a backend-to-backend integration, a scheduled job) has
+   no interaction surface to design — skip straight to interface points below.
 
 7. **Design the requirement's interface points** — the named contracts other code calls into,
    each satisfying something a real consumer (the interaction surface above, or another service)
@@ -146,6 +153,7 @@ produced this pass — not this pass's own reasoning. Ask it:
 3. Is the API design consistent with existing API designs in the workspace (naming, status codes, auth patterns)?
 4. Are auth and authorization requirements explicitly addressed, or silently assumed?
 5. Does the API design actually satisfy what the UX design says its screens need?
+6. Does the UX design's `navigation` section specify a concrete `entry-from` path, and is it consistent with the app's existing information architecture?
 
 Always advisory — act on a real finding by fixing the inconsistency or missing coverage, don't
 just log it.

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -120,7 +120,12 @@ blocking status depends on whether this project has a CI backstop yet — see be
   workspace/input and asserting on its actual output or side effects, not a unit test that mocks
   the very thing being verified. If the scaffolded e2e project's own spec is still the generic
   starter, that's not a passing gate — write real cases from the design's Given/When/Then examples
-  first. The same spec file should also work verbatim against a live deployment via `BASE_URL`
+  first. **For a frontend view, e2e tests must reach the feature via the entry point the ux-design's
+  `navigation` section specifies** — starting from the app shell, not by visiting the route URL
+  directly. A test that opens `/new-feature` directly passes even when the view is completely
+  orphaned from navigation and proves nothing about reachability; if `entry-from` is `"temporary dev
+  route"`, the test may deep-link for now but must include a TODO naming the permanent entry point to
+  wire in before graduation. The same spec file should also work verbatim against a live deployment via `BASE_URL`
   (see Deploy's Gate — the same `e2e` target, not a separate one, once
   `global-setup.ts`/`global-teardown.ts` guard on `BASE_URL`).
 
@@ -158,5 +163,3 @@ the code's approach is the better one, don't just log it.
 Commit the implementation once every blocking check above passes —
 `feat(develop): implement <resource> against <api-design/ux-design>` — covering the new code, its
 tests, and the `project-docs-ancestors` comment tying it back to the design, together as one unit.
-If `package.json` changed, `package-lock.json` must be consistent with it and staged in the same
-commit — run `npm install` first if it isn't.

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -98,14 +98,21 @@ scope here.
    experiences the requirement: what it shows, what it does, which rule each behavior traces to.
    For a UI-backed requirement, this is a **UX design** — hand-author under
    `project-docs/ux-designs/<slug>.md`, frontmatter `project-docs-ancestors:
-   [domain-models:<slug>]`, and a structured `screens`/`rules`/`examples`/`questions` shape
-   (screens, not endpoints — each translating one of the requirement's business rules into what a
-   screen shows and does, plus which design-system component(s) it uses, per step 5). Each screen
-   also states what it needs from its provider as its own list — the contract interface points get
-   checked against next: the consumer states what it needs, the provider satisfies it. Register
-   once: `"ux-designs": { "expectedAncestorTypes": ["domain-models"] }`. A requirement with no
-   human-facing consumer (a backend-to-backend integration, a scheduled job) has no interaction
-   surface to design — skip straight to interface points below.
+   [domain-models:<slug>]`, and a structured shape with these sections:
+   - **`navigation`** — where this feature lives in the app's information architecture: `sitemap-position`
+     (its place relative to existing sections), `entry-from` (how users reach it from the app shell —
+     `"temporary dev route"` is a valid explicit answer for a feature under initial development), and
+     `route` (the URL path). This section is required; an absent or blank `entry-from` is a design gap,
+     not a deferral — make the decision consciously and state it.
+   - **`screens`** — each translating one of the requirement's business rules into what a screen shows
+     and does, plus which design-system component(s) it uses (per step 5). Each screen also states what
+     it needs from its provider as its own list.
+   - **`rules`**, **`examples`**, **`questions`**
+
+   The contract interface points get checked against next: the consumer states what it needs, the
+   provider satisfies it. Register once: `"ux-designs": { "expectedAncestorTypes": ["domain-models"] }`.
+   A requirement with no human-facing consumer (a backend-to-backend integration, a scheduled job) has
+   no interaction surface to design — skip straight to interface points below.
 
 7. **Design the requirement's interface points** — the named contracts other code calls into,
    each satisfying something a real consumer (the interaction surface above, or another service)
@@ -146,6 +153,7 @@ produced this pass — not this pass's own reasoning. Ask it:
 3. Is the API design consistent with existing API designs in the workspace (naming, status codes, auth patterns)?
 4. Are auth and authorization requirements explicitly addressed, or silently assumed?
 5. Does the API design actually satisfy what the UX design says its screens need?
+6. Does the UX design's `navigation` section specify a concrete `entry-from` path, and is it consistent with the app's existing information architecture?
 
 Always advisory — act on a real finding by fixing the inconsistency or missing coverage, don't
 just log it.

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -120,7 +120,12 @@ blocking status depends on whether this project has a CI backstop yet — see be
   workspace/input and asserting on its actual output or side effects, not a unit test that mocks
   the very thing being verified. If the scaffolded e2e project's own spec is still the generic
   starter, that's not a passing gate — write real cases from the design's Given/When/Then examples
-  first. The same spec file should also work verbatim against a live deployment via `BASE_URL`
+  first. **For a frontend view, e2e tests must reach the feature via the entry point the ux-design's
+  `navigation` section specifies** — starting from the app shell, not by visiting the route URL
+  directly. A test that opens `/new-feature` directly passes even when the view is completely
+  orphaned from navigation and proves nothing about reachability; if `entry-from` is `"temporary dev
+  route"`, the test may deep-link for now but must include a TODO naming the permanent entry point to
+  wire in before graduation. The same spec file should also work verbatim against a live deployment via `BASE_URL`
   (see Deploy's Gate — the same `e2e` target, not a separate one, once
   `global-setup.ts`/`global-teardown.ts` guard on `BASE_URL`).
 


### PR DESCRIPTION
## Summary

- **Design skill**: adds a required `navigation` section to the UX design shape (`sitemap-position`, `entry-from`, `route`), making information architecture a first-class design output. A blank `entry-from` is a design gap — `"temporary dev route"` is a valid explicit answer while the permanent IA placement is unsettled.
- **Design skill**: adds review checklist item 6 — verifies the UX design's `navigation` section is concrete and consistent with the app's existing information architecture.
- **Develop skill**: adds guidance in the e2e gate section requiring frontend e2e tests to navigate to a view via the app shell's declared entry point rather than visiting the route URL directly. Tests that deep-link pass even when a view is completely orphaned from navigation; if `entry-from` is `"temporary dev route"`, a TODO naming the permanent entry point is required before graduation.

## Motivation

Features were being completed with UI views that had no navigational path from the app shell, making them untestable without knowing the exact route URL. The root cause was twofold: the design skill had no IA/nav consideration, and the develop skill's e2e guidance didn't require exercising the navigation path.

## Test plan

- [ ] Review design skill step 6 — `navigation` section described clearly with valid placeholder value documented
- [ ] Review design skill review checklist — question 6 present and actionable
- [ ] Review develop skill e2e section — app-shell navigation requirement clear, temporary dev route escape hatch present with TODO requirement
- [ ] `npx nx test nx-agent` passes
- [ ] `npx nx build nx-agent` passes
- [ ] `npx nx lint nx-agent` passes (warnings only, pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)