### PR TITLE
fix(nx-agent): validate project-docs slugs against shared character set

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -97,7 +97,9 @@ scope here.
    before its interface points, not after.** An interaction surface is how a human actually
    experiences the requirement: what it shows, what it does, which rule each behavior traces to.
    For a UI-backed requirement, this is a **UX design** — hand-author under
-   `project-docs/ux-designs/<slug>.md`, frontmatter `project-docs-ancestors:
+   `project-docs/ux-designs/<slug>.md` (`<slug>` must contain only letters, digits, hyphens, and
+   underscores — other characters are silently dropped by the lineage system), frontmatter
+   `project-docs-ancestors:
    [domain-models:<slug>]`, and a structured shape with these sections:
    - **`navigation`** — where this feature lives in the app's information architecture: `sitemap-position`
      (its place relative to existing sections), `entry-from` (how users reach it from the app shell —
@@ -117,7 +119,8 @@ scope here.
 7. **Design the requirement's interface points** — the named contracts other code calls into,
    each satisfying something a real consumer (the interaction surface above, or another service)
    actually stated it needs, each tracing to a specific rule. For an HTTP-backed requirement, this
-   is an **API design** — hand-author under `project-docs/api-designs/<slug>.md`, frontmatter
+   is an **API design** — hand-author under `project-docs/api-designs/<slug>.md` (same slug
+   constraint: letters, digits, hyphens, underscores only), frontmatter
    `project-docs-ancestors: [domain-models:<slug>, ux-designs:<slug>]` when a ux-design exists for
    this requirement (`domain-models` alone otherwise). Each endpoint should satisfy something the
    ux-design's screens actually stated they need — don't let this become "design the interface

--- a/packages/nx-agent/src/generators/blocker/blocker.ts
+++ b/packages/nx-agent/src/generators/blocker/blocker.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveRefFromPath } from '../../utils/project-docs-refs';
+import {
+  resolveRefFromPath,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const BLOCKERS_SUBDIR = 'project-docs/blockers';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, BLOCKERS_SUBDIR);
   const slug = names(options.description).fileName;
+  validateProjectDocsSlug(slug, options.description)
   const blockerPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/bounded-context/bounded-context.ts
+++ b/packages/nx-agent/src/generators/bounded-context/bounded-context.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const BOUNDED_CONTEXTS_SUBDIR = 'project-docs/bounded-contexts';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, BOUNDED_CONTEXTS_SUBDIR);
   const slug = names(options.name).fileName;
+  validateProjectDocsSlug(slug, options.name)
   const contextPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/bug/bug.ts
+++ b/packages/nx-agent/src/generators/bug/bug.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveRefFromPath } from '../../utils/project-docs-refs';
+import {
+  resolveRefFromPath,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const BUGS_SUBDIR = 'project-docs/bugs';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, BUGS_SUBDIR);
   const slug = names(options.description).fileName;
+  validateProjectDocsSlug(slug, options.description)
   const bugPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/domain-model/domain-model.ts
+++ b/packages/nx-agent/src/generators/domain-model/domain-model.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const DOMAIN_MODELS_SUBDIR = 'project-docs/domain-models';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, DOMAIN_MODELS_SUBDIR);
   const slug = names(options.name).fileName;
+  validateProjectDocsSlug(slug, options.name)
   const modelPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/domain-term/domain-term.ts
+++ b/packages/nx-agent/src/generators/domain-term/domain-term.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const DOMAIN_TERMS_SUBDIR = 'project-docs/domain-terms';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, DOMAIN_TERMS_SUBDIR);
   const slug = names(options.term).fileName;
+  validateProjectDocsSlug(slug, options.term)
   const termPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/feature/feature.ts
+++ b/packages/nx-agent/src/generators/feature/feature.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const FEATURES_SUBDIR = 'project-docs/features';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, FEATURES_SUBDIR);
   const slug = names(options.title).fileName;
+  validateProjectDocsSlug(slug, options.title)
   const featurePath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
+++ b/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const ITERATION_RETROSPECTIVES_SUBDIR = 'project-docs/iteration-retrospectives';
@@ -44,6 +47,7 @@ export default async function (host: Tree, options: Schema) {
     ITERATION_RETROSPECTIVES_SUBDIR,
   );
   const slug = names(options.title).fileName;
+  validateProjectDocsSlug(slug, options.title)
   const retrospectivePath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/open-question/open-question.ts
+++ b/packages/nx-agent/src/generators/open-question/open-question.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveRefFromPath } from '../../utils/project-docs-refs';
+import {
+  resolveRefFromPath,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const OPEN_QUESTIONS_SUBDIR = 'project-docs/open-questions';
@@ -40,6 +43,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, OPEN_QUESTIONS_SUBDIR);
   const slug = names(options.question).fileName;
+  validateProjectDocsSlug(slug, options.question)
   const questionPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/product-brief/product-brief.ts
+++ b/packages/nx-agent/src/generators/product-brief/product-brief.ts
@@ -9,7 +9,10 @@ import { readFileSync } from 'fs'
 import { join } from 'path'
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema'
 import { ensureReadme } from '../../utils/readme'
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs'
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs'
 import { Schema } from './schema'
 
 const PRODUCT_BRIEFS_SUBDIR = 'project-docs/product-briefs'
@@ -23,6 +26,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project)
   const containerDir = joinPathFragments(targetRoot, PRODUCT_BRIEFS_SUBDIR)
   const slug = names(options.name).fileName
+  validateProjectDocsSlug(slug, options.name)
   const briefPath = joinPathFragments(containerDir, `${slug}.md`)
 
   // A repeat/typo'd invocation should fail loudly rather than silently

--- a/packages/nx-agent/src/generators/requirement/requirement.ts
+++ b/packages/nx-agent/src/generators/requirement/requirement.ts
@@ -11,7 +11,10 @@ import { join } from 'path';
 import * as yaml from 'yaml';
 import { ensureArtifactSchemaEntry } from '../../utils/artifact-schema';
 import { ensureReadme } from '../../utils/readme';
-import { resolveAncestorsAndResolves } from '../../utils/project-docs-refs';
+import {
+  resolveAncestorsAndResolves,
+  validateProjectDocsSlug,
+} from '../../utils/project-docs-refs';
 import { Schema } from './schema';
 
 const REQUIREMENTS_SUBDIR = 'project-docs/requirements';
@@ -61,6 +64,7 @@ export default async function (host: Tree, options: Schema) {
   const targetRoot = resolveTargetRoot(host, options.project);
   const containerDir = joinPathFragments(targetRoot, REQUIREMENTS_SUBDIR);
   const slug = names(options.title).fileName;
+  validateProjectDocsSlug(slug, options.title)
   const requirementPath = joinPathFragments(containerDir, `${slug}.md`);
 
   // Fail loudly before any write — a duplicate is always a mistake, not an

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -2,6 +2,25 @@ import { Tree, getProjects } from '@nx/devkit';
 import * as yaml from 'yaml';
 import { ArtifactSchema } from './artifact-schema';
 
+// The allowed character set for project-docs slugs — used by both the
+// lineage parser and generator validation so they cannot drift apart.
+export const SLUG_CHARS = 'a-zA-Z0-9_-'
+
+const SLUG_INVALID_RE = new RegExp(`[^${SLUG_CHARS}]`, 'g')
+
+export function validateProjectDocsSlug(
+  slug: string,
+  originalInput: string,
+): void {
+  const invalid = slug.match(SLUG_INVALID_RE)
+  if (!invalid) return
+  const chars = [...new Set(invalid)].map((c) => `"${c}"`).join(', ')
+  throw new Error(
+    `[nx-agent] "${originalInput}" produces slug "${slug}" containing invalid character(s): ${chars}. ` +
+      `Project-docs slugs must contain only letters, digits, hyphens, and underscores.`,
+  )
+}
+
 // project-docs-ancestors convention: <type>[:<id>][#fragment], optionally
 // qualified with a project name (<project>/<type>...). `type` is the literal
 // project-docs/ subfolder name — no singular/plural transformation, so an
@@ -17,8 +36,9 @@ export interface AncestorRef {
   fragment?: string;
 }
 
-const ANCESTOR_REF_TOKEN =
-  /^(?:([^/]+)\/)?([a-zA-Z0-9_-]+)(?::([a-zA-Z0-9_-]+))?(?:#([a-zA-Z0-9_-]+))?$/;
+const ANCESTOR_REF_TOKEN = new RegExp(
+  `^(?:([^/]+)/)?([${SLUG_CHARS}]+)(?::([${SLUG_CHARS}]+))?(?:#([${SLUG_CHARS}]+))?$`,
+)
 
 export function parseAncestorRef(token: string): AncestorRef | null {
   const trimmed = token.trim();


### PR DESCRIPTION
## Summary

- **Bug**: \`names().fileName\` (from \`@nx/devkit\`) passes characters outside \`[a-zA-Z0-9_-]\` through unchanged — apostrophes, question marks, parentheses, etc. The lineage parser's \`ANCESTOR_REF_TOKEN\` regex silently returns \`null\` for any token containing those characters, so the artifact appears as an orphan and its referencing artifact appears unscoped. No error is thrown.
- **Fix**: export \`SLUG_CHARS = 'a-zA-Z0-9_-'\` from \`project-docs-refs.ts\` and rebuild \`ANCESTOR_REF_TOKEN\` from it as a \`new RegExp(...)\`. Export \`validateProjectDocsSlug(slug, originalInput)\` built from the same constant. All 10 project-docs generators call \`validateProjectDocsSlug\` immediately after computing the slug, throwing a clear error before any file is written.
- **Structural guarantee**: the parser regex and generator validation are now derived from the same \`SLUG_CHARS\` constant — they cannot drift apart without a single edit that is visible to reviewers.

## Test plan

- [ ] \`npx nx test nx-agent\` — 264 tests pass
- [ ] \`npx nx build nx-agent\` — clean build
- [ ] \`npx nx lint nx-agent\` — warnings only (pre-existing), no errors
- [ ] Manual: \`npx nx g @abgov/nx-agent:open-question "What's the right approach?"` should throw with a clear message listing \`"'"\` and \`"?"\` as invalid characters
- [ ] Manual: \`npx nx g @abgov/nx-agent:feature "Collision Reporting"\` (only letters and spaces) should succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)