### PR TITLE
fix(nx-agent): fix scopedPaths TDZ crash on lineage-missing signal

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -27,6 +27,13 @@ const STALL_THRESHOLD = 3;
 const HISTORY_KEEP = STALL_THRESHOLD + 2;
 const DESIGN_TYPES = ['api-designs', 'ux-designs'];
 
+// Declared here — before the lineage-missing early-exit — because composePrompt references
+// scopedPaths and these values only need process.env, not the registry.
+const rawScope = process.env.ARTIFACT_SCOPE ?? '';
+const openScope = rawScope === '*';
+const noScope = !openScope && rawScope === '';
+const scopedPaths = openScope || noScope ? [] : rawScope.split(',').filter(Boolean);
+
 const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/;
 
 function readFrontmatter(path) {
@@ -241,10 +248,8 @@ const RESOLUTION_PREFIXES = ['broken:', 'open:'];
 // '*' is an explicit opt-in to open scope — no artifact filtering at all, not the same as
 // "first commit touched no project-docs files." When set, scopedKeys stays empty (so
 // isInArtifactScope returns true for everything), but the composePrompt note is explicit.
-const rawScope = process.env.ARTIFACT_SCOPE ?? '';
-const openScope = rawScope === '*';
-const noScope = !openScope && rawScope === ''; // first commit touched no project-docs files — distinct from open scope
-const scopedPaths = openScope || noScope ? [] : rawScope.split(',').filter(Boolean);
+// (rawScope/openScope/noScope/scopedPaths are declared earlier — before the lineage-missing
+// early-exit — because composePrompt needs them and runs on that path too.)
 const scopedKeys = new Set(
   scopedPaths
     .map((p) => Object.keys(registry).find((k) => registry[k].path === p))


### PR DESCRIPTION
## Summary

- `scopedPaths` (and `rawScope`/`openScope`/`noScope`) were declared after the `lineage-missing` early-exit block, but `composePrompt` references `scopedPaths` to build the scope note in the generated prompt.
- When `lineage.json` is absent the script calls `emit()` → `composePrompt()` before ever reaching those `const` declarations, causing a temporal dead zone `ReferenceError` that crashes the entire task-identification CI step.
- Fix: hoist the four declarations to immediately after the top-level constants — they only need `process.env.ARTIFACT_SCOPE`, not the registry. `scopedKeys` stays in its original position since it depends on the registry loaded after `lineage.json` is read.

## Test plan

- [ ] Reproduce locally: run `node task-identification.mjs` with no `.nx-agent/lineage.json` present — should now emit a clean `lineage-missing` signal and exit 0 rather than crashing with `ReferenceError`
- [ ] `npx nx test nx-agent` passes
- [ ] `npx nx build nx-agent` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)