### PR TITLE
feat(nx-agent): surface YAML parse errors as first-class violations

### DIFF
--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -101,6 +101,14 @@ const designArtifactsOf = (key) => (index[key] ?? []).filter((e) => DESIGN_TYPES
 
 const signals = [];
 
+for (const yamlError of violations.yamlErrors ?? []) {
+  signals.push({
+    key: `yaml-error:${yamlError.path}`,
+    stage: 'unknown',
+    reason: `YAML parse error in ${yamlError.path}: ${yamlError.error} — fix the frontmatter before anything else.`,
+  });
+}
+
 for (const broken of violations.brokenRefs ?? []) {
   signals.push({
     key: `broken:${broken.ref}`,

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -5,6 +5,7 @@ import {
   buildIndex,
   buildRegistry,
   computeViolations,
+  YamlError,
 } from '../../utils/project-docs-refs';
 
 const LINEAGE_PATH = '.nx-agent/lineage.json';
@@ -16,10 +17,11 @@ export default async function (host: Tree) {
   // references were chosen over a forward-ownership model to avoid.
   ensureGitignoreEntries(host, ['.nx-agent/']);
 
-  const registry = buildRegistry(host);
+  const yamlErrors: YamlError[] = []
+  const registry = buildRegistry(host, yamlErrors);
   const index = buildIndex(host, registry);
   const artifactSchema = readArtifactSchema(host);
-  const violations = computeViolations(registry, index, artifactSchema);
+  const violations = computeViolations(registry, index, artifactSchema, yamlErrors);
 
   for (const orphan of violations.orphans) {
     // eslint-disable-next-line no-console
@@ -70,5 +72,10 @@ export default async function (host: Tree) {
     throw new Error(
       `[nx-agent] ${violations.brokenRefs.length} broken project-docs-ancestors reference(s) found — see above.`,
     );
+  }
+  if (violations.yamlErrors.length > 0) {
+    throw new Error(
+      `[nx-agent] ${violations.yamlErrors.length} YAML parse error(s) in project-docs frontmatter — fix the malformed file(s) above before continuing.`,
+    )
   }
 }

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -312,7 +312,7 @@ function projectDocsRoots(host: Tree): string[] {
 // Every project-docs/ artifact in the workspace, keyed by its canonical
 // reference string, recording its own ancestor refs (chained artifacts —
 // e.g. a domain term deriving from a bounded context).
-export function buildRegistry(host: Tree): Registry {
+export function buildRegistry(host: Tree, yamlErrors: YamlError[] = []): Registry {
   const registry: Registry = new Map();
 
   for (const docsRoot of projectDocsRoots(host)) {
@@ -335,7 +335,7 @@ export function buildRegistry(host: Tree): Registry {
           continue;
         }
         const type = child.replace(/\.md$/, '');
-        registerArtifact(host, registry, childPath, { project, type });
+        registerArtifact(host, registry, childPath, { project, type }, yamlErrors);
       } else {
         for (const file of host.children(childPath)) {
           const filePath = `${childPath}/${file}`;
@@ -351,7 +351,7 @@ export function buildRegistry(host: Tree): Registry {
             project,
             type: child,
             id,
-          });
+          }, yamlErrors);
         }
       }
     }
@@ -365,15 +365,29 @@ function registerArtifact(
   registry: Registry,
   path: string,
   ref: Pick<AncestorRef, 'project' | 'type' | 'id'>,
+  yamlErrors: YamlError[],
 ): void {
-  const key = refKey(ref);
-  const content = host.read(path, 'utf-8') ?? '';
+  const key = refKey(ref)
+  const content = host.read(path, 'utf-8') ?? ''
+  const block = FRONTMATTER_BLOCK.exec(content)
+  if (block) {
+    try {
+      yaml.parse(block[1])
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e)
+      yamlErrors.push({ path, error })
+      // eslint-disable-next-line no-console
+      console.log(`[nx-agent] YAML parse error in ${path}: ${error}`)
+      registry.set(key, { path, ancestorRefs: [], resolves: [], metadata: {} })
+      return
+    }
+  }
   registry.set(key, {
     path,
     ancestorRefs: extractFrontmatterAncestorRefs(content, path),
     resolves: extractFrontmatterField(content, 'resolves', path),
     metadata: extractFrontmatterMetadata(content, path),
-  });
+  })
 }
 
 // Every project-docs-ancestors reference found anywhere in the workspace's
@@ -421,11 +435,17 @@ export function buildIndex(
   return index;
 }
 
+export interface YamlError {
+  path: string
+  error: string
+}
+
 export interface Violations {
   brokenRefs: { ref: string; referencedFrom: string }[];
   orphans: string[];
   unscoped: string[];
   resolutionStatus: { open: string[]; resolved: string[] };
+  yamlErrors: YamlError[];
 }
 
 // `artifactSchema` is plain data the workspace owns (see utils/artifact-schema.ts)
@@ -440,6 +460,7 @@ export function computeViolations(
   registry: Registry,
   index: Index,
   artifactSchema: ArtifactSchema = {},
+  yamlErrors: YamlError[] = [],
 ): Violations {
   const brokenRefs: Violations['brokenRefs'] = [];
   for (const [key, entries] of index) {
@@ -509,7 +530,7 @@ export function computeViolations(
     ).push(key);
   }
 
-  return { brokenRefs, orphans, unscoped, resolutionStatus };
+  return { brokenRefs, orphans, unscoped, resolutionStatus, yamlErrors };
 }
 
 // The two retrieval directions, deliberately not symmetric in cost. Forward


### PR DESCRIPTION
## Summary

Previously a malformed project-docs frontmatter block produced a `console.warn` and was silently treated as an artifact with no ancestors — showing up as unscoped or orphaned in the lineage report with no clear indication of why. This made YAML errors hard to diagnose and easy to miss.

- **`project-docs-refs.ts`**: added `YamlError` interface and `yamlErrors: YamlError[]` to `Violations`. `buildRegistry` now accepts a `yamlErrors` accumulator and threads it into `registerArtifact`, which probes the raw YAML block before delegating to field extractors — a parse failure pushes to the accumulator, logs the file and error, and registers the artifact with empty refs (traversal continues). `computeViolations` accepts and includes `yamlErrors` in its return.
- **`project-docs-lineage.ts`**: collects `yamlErrors` through `buildRegistry` and `computeViolations`, writes them into `lineage.json`, and throws after broken-ref detection if any YAML errors are present — same fail-fast gate posture as broken refs.
- **`task-identification.mjs`**: emits `yaml-error:` signals from `violations.yamlErrors` **before** `broken:` signals — highest priority, since a file with unparseable frontmatter is worse than a broken ref.

## Test plan

- [ ] `npx nx test nx-agent` passes
- [ ] `npx nx build nx-agent` passes
- [ ] `npx nx lint nx-agent` passes (warnings only, pre-existing)
- [ ] Manually: write a project-docs file with invalid YAML frontmatter, run `npx nx g @abgov/nx-agent:project-docs-lineage` — should fail with `[nx-agent] YAML parse error in <path>` and the summary throw
- [ ] Verify `lineage.json` `violations.yamlErrors` is populated with `{ path, error }` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)