### PR TITLE
bug(nx-oc): sandbox frontend stub Service selector mismatch blocks backend endpoints

### DIFF
--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -421,14 +421,16 @@ describe('sandbox executor', () => {
       { ...baseOptions, appType: 'frontend' },
       context(['adsp:proxy-service:test-service:3333']),
     );
-    const guard = commands().find((c) =>
-      c.includes('oc get service test-service'),
+    const applyCmd = commands().find((c) =>
+      c.includes('oc apply -f - -n test-sandbox'),
     );
-    expect(guard).toBeTruthy();
-    expect(guard).toContain('||');
-    expect(guard).toContain(
-      'oc create service clusterip test-service --tcp=3333:3333',
-    );
+    expect(applyCmd).toBeTruthy();
+    expect(applyCmd).toContain('name: test-service');
+    expect(applyCmd).toContain('app: test-service');
+    expect(applyCmd).toContain('deployment-mode: sandbox');
+    expect(applyCmd).toContain('selector:\n    name: test-service');
+    expect(applyCmd).toContain('port: 3333');
+    expect(applyCmd).not.toContain('oc create service clusterip');
   });
 
   it('adds no paired-service guard without proxy-service tags', async () => {

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -394,14 +394,29 @@ export default async function runExecutor(
         };
       });
     for (const { name, port } of proxyServices) {
-      // Always label with deployment-mode=sandbox so the teardown target's selector
-      // (-l app=<name>,deployment-mode=sandbox) can clean up the stub when the backend
-      // was never deployed (and oc apply never ran to reconcile the Service itself).
+      // Use oc apply (idempotent) with selector: name: <name> — the same selector the
+      // backend's own manifest uses. oc create service clusterip writes selector: app: <name>
+      // and oc apply's three-way merge never removes it (it was never in last-applied-
+      // configuration), leaving both keys and no matching endpoints. app: <name> is kept in
+      // metadata.labels so the teardown target's -l app=<name>,deployment-mode=sandbox
+      // can clean up the stub if the backend is never deployed.
       run(
         `Ensure paired Service ${name}`,
-        `oc get service ${name} -n ${sandboxProject} >/dev/null 2>&1 || ` +
-          `oc create service clusterip ${name} --tcp=${port}:${port} -n ${sandboxProject}; ` +
-          `oc label service ${name} deployment-mode=sandbox -n ${sandboxProject} --overwrite`,
+        `cat <<'EOF' | oc apply -f - -n ${sandboxProject}
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${name}
+  labels:
+    app: ${name}
+    deployment-mode: sandbox
+spec:
+  selector:
+    name: ${name}
+  ports:
+  - port: ${port}
+    targetPort: ${port}
+EOF`,
         cwd,
       );
     }


### PR DESCRIPTION
## Summary

Registers a bug artifact for a confirmed defect in the `nx-oc:sandbox` executor.

When a frontend is deployed before its backend, the executor stubs the backend Service with `oc create service clusterip`, which hardcodes `selector: app: <name>`. The backend's own manifest uses `selector: name: <name>`. On the subsequent backend deploy, `oc apply`'s three-way merge leaves the `app:` key in place (it was never in `last-applied-configuration`), producing a Service with both selectors. Backend pods are only labelled `name:`, so no pod matches, endpoints stay empty, and the route returns 503. The pod shows `1/1 Running` and the readiness probe passes, making the breakage invisible until the route is tested directly.

Confirmed on `factory-prototype` (`vm-request-service` deployed after `vm-request-app`).

The fix (documented in the bug body) is to replace `oc create service clusterip` with an inline `oc apply` of a minimal manifest that explicitly sets `selector: name: <name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)