### PR TITLE
fix(nx-agent): make the lineage graph report its gaps instead of hiding them

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -139,10 +139,11 @@ scope here.
 ## Gate — run before ending this skill
 
 ```
-npx nx g @abgov/nx-agent:project-docs-lineage --dry-run
+npx nx g @abgov/nx-agent:project-docs-lineage --dry-run --strict
 ```
 
-- **Broken reference** always blocks.
+- **Broken reference** always blocks — `--strict` is what makes it fail the command rather than
+  just record the reference in the graph.
 - **`unscoped`** (an artifact missing one of its kind's expected ancestors) blocks the
   Design→Develop transition — advisory while still mid-pass.
 

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -106,7 +106,7 @@ npx nx build <service>
 npx nx lint <service>
 npx secretlint <changed files>
 npm audit --audit-level=high
-npx nx g @abgov/nx-agent:project-docs-lineage
+npx nx g @abgov/nx-agent:project-docs-lineage --strict
 ```
 
 Test/build/lint/secret-scan/lineage are always blocking, no exception. `<service>-e2e`'s own
@@ -144,7 +144,8 @@ blocking status depends on whether this project has a CI backstop yet — see be
 - **`npm audit`** blocks only on a finding introduced by *this* change. A high-severity finding
   already present in scaffolding before this pass touched anything is drift to flag, not a reason
   to block.
-- **`project-docs-lineage`**'s broken-reference check blocks as always. Its orphan/unscoped report
+- **`project-docs-lineage --strict`** blocks on a broken reference, as always — `--strict` is what
+  makes it fail the command rather than just record the reference in `lineage.json`. Its orphan/unscoped report
   should be empty by the time a resource's code exists and correctly references its api-design.
 
 ### Independent code review — every pass

--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -123,13 +123,15 @@ Given one requirement (by slug or `id`):
 ## Gate — run before ending this skill
 
 ```
-npx nx g @abgov/nx-agent:project-docs-lineage --dry-run
+npx nx g @abgov/nx-agent:project-docs-lineage --dry-run --strict
 node scripts/check-example-mapping.mjs
 ```
 
 These check different things:
 
-- `project-docs-lineage`'s broken-reference check always blocks, regardless of mode. Its
+- `project-docs-lineage`'s broken-reference check always blocks, regardless of mode — `--strict`
+  is what turns a recorded broken reference into a failing command, and composes with
+  `--dry-run` to check without writing anything. Its
   `orphans` report is a graph fact (has Design picked this requirement up yet), not an
   example-mapping check — it stays true even after perfect example-mapping, since nothing
   downstream exists yet.

--- a/.github/workflows/agent-delivery-iteration.yml
+++ b/.github/workflows/agent-delivery-iteration.yml
@@ -133,9 +133,11 @@ jobs:
       # scripts/task-identification.mjs's own header for the ready/stalled/summary/prompt
       # contract it must satisfy. ----
       - name: Refresh project-docs lineage graph
-        # `|| true`: a broken reference makes this throw; task identification treats a missing
-        # lineage.json as its own top-priority signal, so let that surface it instead of failing
-        # the job outright.
+        # No `--strict`: a broken reference or YAML parse error is recorded in lineage.json and
+        # picked up as its own top-priority signal below, which only works if the file gets
+        # written. `|| true` covers a genuine failure of the generator itself — task
+        # identification treats a missing lineage.json as its own signal, so let that surface it
+        # instead of failing the job outright.
         run: npx nx g @abgov/nx-agent:project-docs-lineage || true
 
       - name: Resolve artifact scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ npx nx build nx-agent
 npx nx lint nx-agent
 npx secretlint <changed files>
 npm audit --audit-level=high
-npx nx g @abgov/nx-agent:project-docs-lineage
+npx nx g @abgov/nx-agent:project-docs-lineage --strict
 ```
 For `nx-adsp` and `nx-oc`, their e2e projects (`nx-adsp-e2e`, `nx-oc-e2e`) exist and are blocking
 (neither has an `.openshift/` graduation signal, so the develop skill's permanent-blocking default

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -646,7 +646,7 @@ is left or the `MAX_ITERATIONS` cap is hit.
 | Branch prefix | Signal types eligible | Typical use |
 |---|---|---|
 | `feature/**` | All (discover → design → develop → deploy) | Advancing a new capability from a `features:` artifact through to Deploy |
-| `fix/**` | Resolution only (`broken:` and `open:`) | Resolving a specific blocker, open question, or broken reference |
+| `fix/**` | Resolution only (`broken:`, `unparseable:`, `yaml-error:`, `open:`) | Resolving a specific blocker, open question, broken/unparseable reference, or malformed frontmatter |
 
 Both branch types derive artifact scope from the first commit (see below). The `fix/**`
 restriction is enforced independently of scope — a scoped fix branch only sees resolution

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -61,7 +61,7 @@
     "project-docs-lineage": {
       "factory": "./src/generators/project-docs-lineage/project-docs-lineage",
       "schema": "./src/generators/project-docs-lineage/schema.json",
-      "description": "Scans the workspace for project-docs/ artifacts and project-docs-ancestors references, and writes the resulting graph to .nx-agent/lineage.json. Throws on a broken reference. Run with --dry-run to check without writing."
+      "description": "Scans the workspace for project-docs/ artifacts and project-docs-ancestors references, and writes the resulting graph to .nx-agent/lineage.json, recording broken references and YAML parse errors in the output. Run with --dry-run to check without writing, or --strict to fail on a violation."
     },
     "project-docs-report": {
       "factory": "./src/generators/project-docs-report/project-docs-report",

--- a/packages/nx-agent/src/generators/agent-delivery/files/AGENTS.ci-harness.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/AGENTS.ci-harness.md
@@ -10,7 +10,7 @@ is left or the `MAX_ITERATIONS` cap is hit.
 | Branch prefix | Signal types eligible | Typical use |
 |---|---|---|
 | `feature/**` | All (discover → design → develop → deploy) | Advancing a new capability from a `features:` artifact through to Deploy |
-| `fix/**` | Resolution only (`broken:` and `open:`) | Resolving a specific blocker, open question, or broken reference |
+| `fix/**` | Resolution only (`broken:`, `unparseable:`, `yaml-error:`, `open:`) | Resolving a specific blocker, open question, broken/unparseable reference, or malformed frontmatter |
 
 Both branch types derive artifact scope from the first commit (see below). The `fix/**`
 restriction is enforced independently of scope — a scoped fix branch only sees resolution

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -89,8 +89,9 @@ if (!existsSync(LINEAGE_PATH)) {
         stage: 'unknown',
         reason:
           `${LINEAGE_PATH} doesn't exist — either project-docs-lineage hasn't run yet this job, ` +
-          `or it threw on a broken project-docs-ancestors reference (check the previous workflow ` +
-          `step's log for "[nx-agent] broken reference").`,
+          `or it failed outright. A broken reference or a YAML parse error no longer aborts its ` +
+          `write (both come through as their own signals below), so check the previous workflow ` +
+          `step's log for a genuine error.`,
       },
     ],
   });

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -117,6 +117,18 @@ for (const yamlError of violations.yamlErrors ?? []) {
   });
 }
 
+for (const unparseable of violations.unparseableRefs ?? []) {
+  signals.push({
+    key: `unparseable:${unparseable.ref}`,
+    stage: 'unknown',
+    reason:
+      `Unparseable project-docs reference "${unparseable.ref}" in ${unparseable.foundIn} — an id ` +
+      `may contain only letters, digits, hyphens, and underscores. If the offending characters ` +
+      `are in that file's own name, rename the file; otherwise fix the reference. Nothing can ` +
+      `resolve it until then, so do this before anything else.`,
+  });
+}
+
 for (const broken of violations.brokenRefs ?? []) {
   signals.push({
     key: `broken:${broken.ref}`,
@@ -252,7 +264,16 @@ for (const path of mdFilesIn('project-docs/requirements')) {
 // are eligible -- preventing the loop from drifting to unrelated work across iterations.
 const branchName = process.env.GITHUB_REF_NAME ?? '';
 const isFixBranch = branchName.startsWith('fix/');
-const RESOLUTION_PREFIXES = ['broken:', 'open:'];
+// 'unparseable:' and 'yaml-error:' are resolution signals for the same reason 'broken:' is —
+// each names one specific thing to repair, not new work to start. Both only became reachable
+// once project-docs-lineage stopped aborting its write on them; without them here, a fix/**
+// branch would see the signal and then be told it isn't eligible to act on it.
+const RESOLUTION_PREFIXES = [
+  'broken:',
+  'unparseable:',
+  'yaml-error:',
+  'open:',
+];
 
 // '*' is an explicit opt-in to open scope — no artifact filtering at all, not the same as
 // "first commit touched no project-docs files." When set, scopedKeys stays empty (so
@@ -317,7 +338,7 @@ if (eligibleSignals.length === 0 && signals.length > 0) {
     // Both filters active — name the intersection explicitly.
     const inBoth = inScope.filter((s) => inBranchType.includes(s));
     noEligibleNote =
-      `fix/** branch (broken:/open: only) AND artifact scope [${scopedPaths.join(', ')}]: ` +
+      `fix/** branch (${RESOLUTION_PREFIXES.join('/')} only) AND artifact scope [${scopedPaths.join(', ')}]: ` +
       `${inScope.length} signal(s) in scope, ${inBranchType.length} resolution-type total, ` +
       `${inBoth.length} satisfy both — no eligible signals on this branch.`;
   } else if (scopedKeys.size > 0) {
@@ -325,7 +346,7 @@ if (eligibleSignals.length === 0 && signals.length > 0) {
       `artifact scope [${scopedPaths.join(', ')}] matches ${inScope.length} of ${signals.length} signal(s) — nothing in scope yet.`;
   } else if (isFixBranch) {
     noEligibleNote =
-      `fix/** branch restricts to broken:/open: signals only — ${inBranchType.length} such signal(s) currently exist.`;
+      `fix/** branch restricts to ${RESOLUTION_PREFIXES.join('/')} signals only — ${inBranchType.length} such signal(s) currently exist.`;
   }
 }
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/workflows/agent-delivery-iteration.yml
@@ -136,9 +136,11 @@ jobs:
       # scripts/task-identification.mjs's own header for the ready/stalled/summary/prompt
       # contract it must satisfy. ----
       - name: Refresh project-docs lineage graph
-        # `|| true`: a broken reference makes this throw; task identification treats a missing
-        # lineage.json as its own top-priority signal, so let that surface it instead of failing
-        # the job outright.
+        # No `--strict`: a broken reference or YAML parse error is recorded in lineage.json and
+        # picked up as its own top-priority signal below, which only works if the file gets
+        # written. `|| true` covers a genuine failure of the generator itself — task
+        # identification treats a missing lineage.json as its own signal, so let that surface it
+        # instead of failing the job outright.
         run: npx nx g @abgov/nx-agent:project-docs-lineage || true
 
       - name: Resolve artifact scope

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -139,10 +139,11 @@ scope here.
 ## Gate — run before ending this skill
 
 ```
-npx nx g @abgov/nx-agent:project-docs-lineage --dry-run
+npx nx g @abgov/nx-agent:project-docs-lineage --dry-run --strict
 ```
 
-- **Broken reference** always blocks.
+- **Broken reference** always blocks — `--strict` is what makes it fail the command rather than
+  just record the reference in the graph.
 - **`unscoped`** (an artifact missing one of its kind's expected ancestors) blocks the
   Design→Develop transition — advisory while still mid-pass.
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -106,7 +106,7 @@ npx nx build <service>
 npx nx lint <service>
 npx secretlint <changed files>
 npm audit --audit-level=high
-npx nx g @abgov/nx-agent:project-docs-lineage
+npx nx g @abgov/nx-agent:project-docs-lineage --strict
 ```
 
 Test/build/lint/secret-scan/lineage are always blocking, no exception. `<service>-e2e`'s own
@@ -144,7 +144,8 @@ blocking status depends on whether this project has a CI backstop yet — see be
 - **`npm audit`** blocks only on a finding introduced by *this* change. A high-severity finding
   already present in scaffolding before this pass touched anything is drift to flag, not a reason
   to block.
-- **`project-docs-lineage`**'s broken-reference check blocks as always. Its orphan/unscoped report
+- **`project-docs-lineage --strict`** blocks on a broken reference, as always — `--strict` is what
+  makes it fail the command rather than just record the reference in `lineage.json`. Its orphan/unscoped report
   should be empty by the time a resource's code exists and correctly references its api-design.
 
 ### Independent code review — every pass

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
@@ -123,13 +123,15 @@ Given one requirement (by slug or `id`):
 ## Gate — run before ending this skill
 
 ```
-npx nx g @abgov/nx-agent:project-docs-lineage --dry-run
+npx nx g @abgov/nx-agent:project-docs-lineage --dry-run --strict
 node scripts/check-example-mapping.mjs
 ```
 
 These check different things:
 
-- `project-docs-lineage`'s broken-reference check always blocks, regardless of mode. Its
+- `project-docs-lineage`'s broken-reference check always blocks, regardless of mode — `--strict`
+  is what turns a recorded broken reference into a failing command, and composes with
+  `--dry-run` to check without writing anything. Its
   `orphans` report is a graph fact (has Design picked this requirement up yet), not an
   example-mapping check — it stays true even after perfect example-mapping, since nothing
   downstream exists yet.

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -29,13 +29,63 @@ describe('nx-agent project-docs-lineage generator', () => {
     expect(lineage.violations.unscoped).toEqual([]);
   });
 
-  it('throws and lists every broken reference when one is found', async () => {
+  it('throws and lists every broken reference when one is found, with --strict', async () => {
     host.write(
       'apps/test/src/routes/collision-reports.ts',
       '// project-docs-ancestors: domain-terms:typo-id\nexport {};',
     );
 
-    await expect(generator(host)).rejects.toThrow(/1 broken/);
+    await expect(generator(host, { strict: true })).rejects.toThrow(/1 broken/);
+  });
+
+  // The whole point of recording rather than aborting: a consumer reading the
+  // file has to be able to tell "one known gap" from "no data at all".
+  it('still writes the graph, with the broken reference recorded, by default', async () => {
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      ['---', 'term: Collision Report', '---'].join('\n'),
+    );
+    host.write(
+      'apps/test/src/routes/collision-reports.ts',
+      [
+        '// project-docs-ancestors: domain-terms:collision-report, domain-terms:typo-id',
+        'export {};',
+      ].join('\n'),
+    );
+
+    await expect(generator(host)).resolves.toBeUndefined();
+
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.brokenRefs).toEqual([
+      {
+        ref: 'domain-terms:typo-id',
+        referencedFrom: 'apps/test/src/routes/collision-reports.ts',
+      },
+    ]);
+    // Everything unrelated to the broken reference survives — that's the fact
+    // aborting the write used to destroy.
+    expect(lineage.registry['domain-terms:collision-report']).toBeDefined();
+    expect(lineage.violations.orphans).toEqual([]);
+  });
+
+  it('throws on a YAML parse error with --strict, and records it by default', async () => {
+    host.write(
+      'project-docs/domain-terms/malformed.md',
+      ['---', 'term: Malformed', '  bad: indentation', '---'].join('\n'),
+    );
+    jest.spyOn(console, 'log').mockImplementation();
+
+    await expect(generator(host, { strict: true })).rejects.toThrow(
+      /YAML parse error/,
+    );
+
+    await expect(generator(host)).resolves.toBeUndefined();
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.yamlErrors).toHaveLength(1);
+    expect(lineage.violations.yamlErrors[0].path).toBe(
+      'project-docs/domain-terms/malformed.md',
+    );
+    jest.restoreAllMocks();
   });
 
   it('reports an orphan without throwing', async () => {

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -88,6 +88,45 @@ describe('nx-agent project-docs-lineage generator', () => {
     jest.restoreAllMocks();
   });
 
+  // The reported case end to end: an artifact whose title carried a version
+  // number, referenced from code. Both the reference and the artifact's own key
+  // are unreadable to the grammar, and both used to vanish without a word.
+  it('records an unparseable reference in the graph, and blocks on it with --strict', async () => {
+    host.write(
+      'project-docs/open-questions/otel-1.23.0.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    host.write(
+      'apps/test/src/telemetry.ts',
+      '// project-docs-ancestors: open-questions:otel-1.23.0\nexport {};',
+    );
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await expect(generator(host)).resolves.toBeUndefined();
+
+    const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(lineage.violations.unparseableRefs).toEqual([
+      {
+        ref: 'open-questions:otel-1.23.0',
+        foundIn: 'project-docs/open-questions/otel-1.23.0.md',
+      },
+      {
+        ref: 'open-questions:otel-1.23.0',
+        foundIn: 'apps/test/src/telemetry.ts',
+      },
+    ]);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'unparseable reference "open-questions:otel-1.23.0"',
+      ),
+    );
+    logSpy.mockRestore();
+
+    await expect(generator(host, { strict: true })).rejects.toThrow(
+      /2 unparseable/,
+    );
+  });
+
   it('reports an orphan without throwing', async () => {
     host.write(
       'project-docs/domain-terms/unused.md',

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -7,10 +7,11 @@ import {
   computeViolations,
   YamlError,
 } from '../../utils/project-docs-refs';
+import { Schema } from './schema';
 
 const LINEAGE_PATH = '.nx-agent/lineage.json';
 
-export default async function (host: Tree) {
+export default async function (host: Tree, options: Schema = {}) {
   // 100% mechanically derived from other files — committing it would create
   // a second, driftable source of truth the moment anyone adds a reference
   // without re-running this generator, exactly the failure mode backward
@@ -61,21 +62,44 @@ export default async function (host: Tree) {
     ),
   );
 
-  // Thrown after the write is staged so a normal run's Tree flush still
-  // happens for a clean result — a run with a broken reference rolls that
-  // write back (Nx's usual all-or-nothing generator semantics), which is
-  // fine: the console output above already says exactly what's broken, and
-  // there's no value in persisting a snapshot already known to be wrong.
-  // Orphans alone never reach this — an artifact nothing implements yet is a
-  // normal, temporary state, not a mistake.
+  // A broken reference and a YAML parse error are both recorded in the output
+  // above rather than aborting the write, because the consumer that acts on
+  // them is a script reading this file (agent-delivery's task-identification),
+  // not a human reading this console — and it already models both as its own
+  // top-priority signals, signals it can only ever see if the file exists.
+  // Aborting the write to force a non-zero exit therefore disabled the exact
+  // mechanism that would have reported the problem, and took every unrelated
+  // fact in the graph down with it: one dangling reference and the loop reads
+  // no open bug, no undesigned requirement, nothing. Worse, .nx-agent/ is
+  // gitignored, so locally the previous run's file survives the rollback and
+  // the next reader silently consumes a stale graph. Neither is a graph that
+  // can't be trusted — it's a complete graph with a known, enumerated gap.
+  const failures: string[] = []
   if (violations.brokenRefs.length > 0) {
-    throw new Error(
-      `[nx-agent] ${violations.brokenRefs.length} broken project-docs-ancestors reference(s) found — see above.`,
-    );
-  }
-  if (violations.yamlErrors.length > 0) {
-    throw new Error(
-      `[nx-agent] ${violations.yamlErrors.length} YAML parse error(s) in project-docs frontmatter — fix the malformed file(s) above before continuing.`,
+    failures.push(
+      `${violations.brokenRefs.length} broken project-docs-ancestors reference(s)`,
     )
   }
+  if (violations.yamlErrors.length > 0) {
+    failures.push(
+      `${violations.yamlErrors.length} YAML parse error(s) in project-docs frontmatter`,
+    )
+  }
+  if (failures.length === 0) {
+    return
+  }
+
+  // --strict is for gate use, where the exit code is the point and the
+  // artifact isn't: Nx's all-or-nothing generator semantics mean a throw
+  // rolls the staged write back, so failing and producing the graph genuinely
+  // can't both happen in one run. Orphans and unscoped artifacts never reach
+  // here either way — an artifact nothing implements yet is a normal,
+  // temporary state, not a mistake.
+  if (options.strict) {
+    throw new Error(`[nx-agent] ${failures.join(' and ')} found — see above.`)
+  }
+  // eslint-disable-next-line no-console
+  console.log(
+    `[nx-agent] wrote ${LINEAGE_PATH} with ${failures.join(' and ')} recorded — re-run with --strict to fail on them.`,
+  )
 }

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -5,6 +5,7 @@ import {
   buildIndex,
   buildRegistry,
   computeViolations,
+  UnparseableRef,
   YamlError,
 } from '../../utils/project-docs-refs';
 import { Schema } from './schema';
@@ -19,10 +20,17 @@ export default async function (host: Tree, options: Schema = {}) {
   ensureGitignoreEntries(host, ['.nx-agent/']);
 
   const yamlErrors: YamlError[] = []
-  const registry = buildRegistry(host, yamlErrors);
-  const index = buildIndex(host, registry);
+  const unparseableRefs: UnparseableRef[] = []
+  const registry = buildRegistry(host, yamlErrors, unparseableRefs);
+  const index = buildIndex(host, registry, unparseableRefs);
   const artifactSchema = readArtifactSchema(host);
-  const violations = computeViolations(registry, index, artifactSchema, yamlErrors);
+  const violations = computeViolations(
+    registry,
+    index,
+    artifactSchema,
+    yamlErrors,
+    unparseableRefs,
+  );
 
   for (const orphan of violations.orphans) {
     // eslint-disable-next-line no-console
@@ -38,6 +46,13 @@ export default async function (host: Tree, options: Schema = {}) {
     // eslint-disable-next-line no-console
     console.log(
       `[nx-agent] broken reference "${broken.ref}" in ${broken.referencedFrom}`,
+    );
+  }
+  for (const unparseable of violations.unparseableRefs) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[nx-agent] unparseable reference "${unparseable.ref}" in ${unparseable.foundIn} — ` +
+        `an id may contain only letters, digits, hyphens, and underscores`,
     );
   }
   for (const open of violations.resolutionStatus.open) {
@@ -80,6 +95,11 @@ export default async function (host: Tree, options: Schema = {}) {
       `${violations.brokenRefs.length} broken project-docs-ancestors reference(s)`,
     )
   }
+  if (violations.unparseableRefs.length > 0) {
+    failures.push(
+      `${violations.unparseableRefs.length} unparseable project-docs reference(s)`,
+    )
+  }
   if (violations.yamlErrors.length > 0) {
     failures.push(
       `${violations.yamlErrors.length} YAML parse error(s) in project-docs frontmatter`,
@@ -96,10 +116,12 @@ export default async function (host: Tree, options: Schema = {}) {
   // here either way — an artifact nothing implements yet is a normal,
   // temporary state, not a mistake.
   if (options.strict) {
-    throw new Error(`[nx-agent] ${failures.join(' and ')} found — see above.`)
+    throw new Error(
+      `[nx-agent] ${failures.join(', ')} found — see above.`,
+    )
   }
   // eslint-disable-next-line no-console
   console.log(
-    `[nx-agent] wrote ${LINEAGE_PATH} with ${failures.join(' and ')} recorded — re-run with --strict to fail on them.`,
+    `[nx-agent] wrote ${LINEAGE_PATH} with ${failures.join(', ')} recorded — re-run with --strict to fail on them.`,
   )
 }

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.d.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.d.ts
@@ -1,2 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Schema {}
+export interface Schema {
+  strict?: boolean
+}

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.json
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.json
@@ -2,8 +2,14 @@
   "$schema": "http://json-schema.org/schema",
   "id": "NxAgentProjectDocsLineage",
   "title": "Build the project-docs lineage graph",
-  "description": "Scans the workspace for project-docs/ artifacts and project-docs-ancestors references across code and docs, and writes the resulting graph to .nx-agent/lineage.json (gitignored). Throws if any reference is broken. Run with --dry-run to check without writing.",
+  "description": "Scans the workspace for project-docs/ artifacts and project-docs-ancestors references across code and docs, and writes the resulting graph to .nx-agent/lineage.json (gitignored). Broken references and YAML parse errors are recorded in the output rather than aborting the write. Run with --dry-run to check without writing, or --strict to fail the command on a violation.",
   "type": "object",
-  "properties": {},
+  "properties": {
+    "strict": {
+      "type": "boolean",
+      "default": false,
+      "description": "Fail the command when a reference is broken or frontmatter is unparseable, instead of only recording it in the output. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json — use it as a gate, not to build the graph."
+    }
+  },
   "additionalProperties": false
 }

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -13,6 +13,7 @@ import {
   parseAncestorRef,
   refKey,
   resolveRefFromPath,
+  UnparseableRef,
 } from './project-docs-refs';
 
 describe('parseAncestorRef', () => {
@@ -855,6 +856,134 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
     );
 
     expect(violations.resolutionStatus).toEqual({ open: [], resolved: [] });
+  });
+});
+
+describe('unparseableRefs', () => {
+  let host: Tree;
+  let unparseableRefs: UnparseableRef[];
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    unparseableRefs = [];
+  });
+
+  // The grammar admits letters, digits, hyphens and underscores. A version
+  // number in a title is the ordinary way a period reaches an id, and dropping
+  // the reference silently made the target read as unreferenced — an orphan —
+  // rather than as something nobody can resolve.
+  it('records a reference the grammar cannot read, rather than dropping it', () => {
+    host.write(
+      'project-docs/open-questions/upgrade-otel.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+    host.write(
+      'apps/test/src/telemetry.ts',
+      '// project-docs-ancestors: open-questions:otel-1.23.0\nexport {};',
+    );
+
+    const registry = buildRegistry(host, [], unparseableRefs);
+    buildIndex(host, registry, unparseableRefs);
+
+    expect(unparseableRefs).toEqual([
+      { ref: 'open-questions:otel-1.23.0', foundIn: 'apps/test/src/telemetry.ts' },
+    ]);
+  });
+
+  it('records an unparseable reference written in frontmatter, not just a code comment', () => {
+    host.write(
+      'project-docs/domain-models/m.md',
+      [
+        '---',
+        'name: M',
+        'project-docs-ancestors: [requirements:v1.2-scope]',
+        '---',
+      ].join('\n'),
+    );
+
+    const registry = buildRegistry(host, [], unparseableRefs);
+    buildIndex(host, registry, unparseableRefs);
+
+    expect(unparseableRefs).toEqual([
+      { ref: 'requirements:v1.2-scope', foundIn: 'project-docs/domain-models/m.md' },
+    ]);
+  });
+
+  // The other direction: the offending characters are in the artifact's own
+  // filename, so its key can't be parsed back. It stays registered — hiding it
+  // is the failure being fixed — but resolutionStatus silently skipped it, so a
+  // tracked question stopped being reported either open or resolved.
+  it("records an artifact whose own path-derived key cannot be parsed, and still registers it", () => {
+    host.write(
+      'project-docs/open-questions/otel-1.23.0.md',
+      ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
+    );
+
+    const registry = buildRegistry(host, [], unparseableRefs);
+
+    expect(registry.has('open-questions:otel-1.23.0')).toBe(true);
+    expect(unparseableRefs).toEqual([
+      {
+        ref: 'open-questions:otel-1.23.0',
+        foundIn: 'project-docs/open-questions/otel-1.23.0.md',
+      },
+    ]);
+  });
+
+  it('surfaces them through computeViolations', () => {
+    host.write(
+      'apps/test/src/telemetry.ts',
+      '// project-docs-ancestors: open-questions:otel-1.23.0\nexport {};',
+    );
+
+    const registry = buildRegistry(host, [], unparseableRefs);
+    const index = buildIndex(host, registry, unparseableRefs);
+    const violations = computeViolations(registry, index, {}, [], unparseableRefs);
+
+    expect(violations.unparseableRefs).toEqual([
+      { ref: 'open-questions:otel-1.23.0', foundIn: 'apps/test/src/telemetry.ts' },
+    ]);
+    // Not a broken reference — it never parsed, so there was never a key to
+    // look up in the registry.
+    expect(violations.brokenRefs).toEqual([]);
+  });
+
+  // extractCommentAncestorRefs matches the bare token anywhere in a source
+  // file, so generator code that writes this frontmatter matches too. Reporting
+  // those would have added 35 findings in this repo alone and buried every real
+  // one.
+  it('ignores a code-shaped match that was never meant to be a reference', () => {
+    host.write(
+      'packages/p/src/generators/thing/thing.ts',
+      [
+        "const content = [",
+        "  `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,",
+        "].join('\\n');",
+      ].join('\n'),
+    );
+
+    const registry = buildRegistry(host, [], unparseableRefs);
+    buildIndex(host, registry, unparseableRefs);
+
+    expect(unparseableRefs).toEqual([]);
+  });
+
+  it('stays empty for a graph whose every reference and filename parses', () => {
+    host.write(
+      'project-docs/domain-terms/collision-report.md',
+      ['---', 'term: Collision Report', '---'].join('\n'),
+    );
+    host.write(
+      'apps/test/src/routes/collision-reports.ts',
+      '// project-docs-ancestors: domain-terms:collision-report\nexport {};',
+    );
+
+    const registry = buildRegistry(host, [], unparseableRefs);
+    const index = buildIndex(host, registry, unparseableRefs);
+    const violations = computeViolations(registry, index, {}, [], unparseableRefs);
+
+    expect(violations.unparseableRefs).toEqual([]);
+    expect(violations.brokenRefs).toEqual([]);
   });
 });
 

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -329,10 +329,47 @@ function projectDocsRoots(host: Tree): string[] {
   return [...new Set(roots)].filter((root) => host.exists(root));
 }
 
+// A reference string the grammar can't read. Distinct from a broken reference,
+// which parses cleanly and simply names something that doesn't exist: this one
+// never became a reference at all, so nothing downstream can resolve, invert,
+// or classify it. Collected from two places, hence `foundIn` rather than
+// brokenRefs' `referencedFrom` — a reference written in some file (a code
+// comment or frontmatter), or an artifact's own path-derived key, where the
+// offending characters are in the filename itself and the fix is a rename.
+export interface UnparseableRef {
+  ref: string
+  foundIn: string
+}
+
+// Whether a scanned token was plausibly *meant* to be a reference, and so is
+// worth reporting when it doesn't parse. extractCommentAncestorRefs matches the
+// bare `project-docs-ancestors:` token anywhere in a source file, which also
+// catches generator code that writes that frontmatter and test fixtures that
+// assert on it — `[${ancestors.join(', ')}]` is not a typo'd reference, it's a
+// template literal, and reporting it as one would bury the real finding in
+// noise (35 such matches in this repo alone). Code punctuation is the tell, so
+// this admits only the grammar's own charset plus the characters that
+// realistically slip into a hand-written id: a period, a stray slash, a space.
+const PLAUSIBLE_REF = /^[\w .:/#-]+$/
+
+function recordUnparseable(
+  unparseableRefs: UnparseableRef[],
+  ref: string,
+  foundIn: string,
+): void {
+  if (PLAUSIBLE_REF.test(ref)) {
+    unparseableRefs.push({ ref, foundIn })
+  }
+}
+
 // Every project-docs/ artifact in the workspace, keyed by its canonical
 // reference string, recording its own ancestor refs (chained artifacts —
 // e.g. a domain term deriving from a bounded context).
-export function buildRegistry(host: Tree, yamlErrors: YamlError[] = []): Registry {
+export function buildRegistry(
+  host: Tree,
+  yamlErrors: YamlError[] = [],
+  unparseableRefs: UnparseableRef[] = [],
+): Registry {
   const registry: Registry = new Map();
 
   for (const docsRoot of projectDocsRoots(host)) {
@@ -355,7 +392,14 @@ export function buildRegistry(host: Tree, yamlErrors: YamlError[] = []): Registr
           continue;
         }
         const type = child.replace(/\.md$/, '');
-        registerArtifact(host, registry, childPath, { project, type }, yamlErrors);
+        registerArtifact(
+          host,
+          registry,
+          childPath,
+          { project, type },
+          yamlErrors,
+          unparseableRefs,
+        );
       } else {
         for (const file of host.children(childPath)) {
           const filePath = `${childPath}/${file}`;
@@ -367,11 +411,14 @@ export function buildRegistry(host: Tree, yamlErrors: YamlError[] = []): Registr
             continue;
           }
           const id = file.replace(/\.md$/, '');
-          registerArtifact(host, registry, filePath, {
-            project,
-            type: child,
-            id,
-          }, yamlErrors);
+          registerArtifact(
+            host,
+            registry,
+            filePath,
+            { project, type: child, id },
+            yamlErrors,
+            unparseableRefs,
+          );
         }
       }
     }
@@ -386,8 +433,19 @@ function registerArtifact(
   path: string,
   ref: Pick<AncestorRef, 'project' | 'type' | 'id'>,
   yamlErrors: YamlError[],
+  unparseableRefs: UnparseableRef[],
 ): void {
   const key = refKey(ref)
+  // An artifact whose own key can't be parsed back is still registered — it
+  // exists, and hiding it would be the very failure this records. But every
+  // parse-dependent check below degrades on it: orphans counts it as an orphan
+  // regardless, and resolutionStatus skips it entirely, so a tracked artifact
+  // silently stops being reported open or resolved. Since 7b777dd the
+  // generators reject these at creation time, so this only catches a
+  // hand-authored or pre-existing file.
+  if (!parseAncestorRef(key)) {
+    unparseableRefs.push({ ref: key, foundIn: path })
+  }
   const content = host.read(path, 'utf-8') ?? ''
   const block = FRONTMATTER_BLOCK.exec(content)
   if (block) {
@@ -417,6 +475,7 @@ function registerArtifact(
 export function buildIndex(
   host: Tree,
   registry: Registry = buildRegistry(host),
+  unparseableRefs: UnparseableRef[] = [],
 ): Index {
   const index: Index = new Map();
   const pathToKey = buildPathToKeyMap(registry);
@@ -439,6 +498,11 @@ export function buildIndex(
     for (const raw of rawRefs) {
       const parsed = parseAncestorRef(raw);
       if (!parsed) {
+        // Recorded rather than skipped: a grammar will always meet an id it
+        // didn't expect, and dropping it silently turns that into a wrong
+        // report (the target looks unreferenced, so it reads as an orphan)
+        // instead of a loud one.
+        recordUnparseable(unparseableRefs, raw, file);
         continue;
       }
       const key = refKey(parsed);
@@ -462,6 +526,7 @@ export interface YamlError {
 
 export interface Violations {
   brokenRefs: { ref: string; referencedFrom: string }[];
+  unparseableRefs: UnparseableRef[];
   orphans: string[];
   unscoped: string[];
   resolutionStatus: { open: string[]; resolved: string[] };
@@ -481,6 +546,7 @@ export function computeViolations(
   index: Index,
   artifactSchema: ArtifactSchema = {},
   yamlErrors: YamlError[] = [],
+  unparseableRefs: UnparseableRef[] = [],
 ): Violations {
   const brokenRefs: Violations['brokenRefs'] = [];
   for (const [key, entries] of index) {
@@ -550,7 +616,14 @@ export function computeViolations(
     ).push(key);
   }
 
-  return { brokenRefs, orphans, unscoped, resolutionStatus, yamlErrors };
+  return {
+    brokenRefs,
+    unparseableRefs,
+    orphans,
+    unscoped,
+    resolutionStatus,
+    yamlErrors,
+  };
 }
 
 // The two retrieval directions, deliberately not symmetric in cost. Forward

--- a/scripts/task-identification.mjs
+++ b/scripts/task-identification.mjs
@@ -27,6 +27,13 @@ const STALL_THRESHOLD = 3;
 const HISTORY_KEEP = STALL_THRESHOLD + 2;
 const DESIGN_TYPES = ['api-designs', 'ux-designs'];
 
+// Declared here — before the lineage-missing early-exit — because composePrompt references
+// scopedPaths and these values only need process.env, not the registry.
+const rawScope = process.env.ARTIFACT_SCOPE ?? '';
+const openScope = rawScope === '*';
+const noScope = !openScope && rawScope === '';
+const scopedPaths = openScope || noScope ? [] : rawScope.split(',').filter(Boolean);
+
 const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/;
 
 function readFrontmatter(path) {
@@ -82,8 +89,9 @@ if (!existsSync(LINEAGE_PATH)) {
         stage: 'unknown',
         reason:
           `${LINEAGE_PATH} doesn't exist — either project-docs-lineage hasn't run yet this job, ` +
-          `or it threw on a broken project-docs-ancestors reference (check the previous workflow ` +
-          `step's log for "[nx-agent] broken reference").`,
+          `or it failed outright. A broken reference or a YAML parse error no longer aborts its ` +
+          `write (both come through as their own signals below), so check the previous workflow ` +
+          `step's log for a genuine error.`,
       },
     ],
   });
@@ -100,6 +108,26 @@ const designArtifactsOf = (key) => (index[key] ?? []).filter((e) => DESIGN_TYPES
 // --- Signals, in priority order --------------------------------------------------------------
 
 const signals = [];
+
+for (const yamlError of violations.yamlErrors ?? []) {
+  signals.push({
+    key: `yaml-error:${yamlError.path}`,
+    stage: 'unknown',
+    reason: `YAML parse error in ${yamlError.path}: ${yamlError.error} — fix the frontmatter before anything else.`,
+  });
+}
+
+for (const unparseable of violations.unparseableRefs ?? []) {
+  signals.push({
+    key: `unparseable:${unparseable.ref}`,
+    stage: 'unknown',
+    reason:
+      `Unparseable project-docs reference "${unparseable.ref}" in ${unparseable.foundIn} — an id ` +
+      `may contain only letters, digits, hyphens, and underscores. If the offending characters ` +
+      `are in that file's own name, rename the file; otherwise fix the reference. Nothing can ` +
+      `resolve it until then, so do this before anything else.`,
+  });
+}
 
 for (const broken of violations.brokenRefs ?? []) {
   signals.push({
@@ -236,15 +264,22 @@ for (const path of mdFilesIn('project-docs/requirements')) {
 // are eligible -- preventing the loop from drifting to unrelated work across iterations.
 const branchName = process.env.GITHUB_REF_NAME ?? '';
 const isFixBranch = branchName.startsWith('fix/');
-const RESOLUTION_PREFIXES = ['broken:', 'open:'];
+// 'unparseable:' and 'yaml-error:' are resolution signals for the same reason 'broken:' is —
+// each names one specific thing to repair, not new work to start. Both only became reachable
+// once project-docs-lineage stopped aborting its write on them; without them here, a fix/**
+// branch would see the signal and then be told it isn't eligible to act on it.
+const RESOLUTION_PREFIXES = [
+  'broken:',
+  'unparseable:',
+  'yaml-error:',
+  'open:',
+];
 
 // '*' is an explicit opt-in to open scope — no artifact filtering at all, not the same as
 // "first commit touched no project-docs files." When set, scopedKeys stays empty (so
 // isInArtifactScope returns true for everything), but the composePrompt note is explicit.
-const rawScope = process.env.ARTIFACT_SCOPE ?? '';
-const openScope = rawScope === '*';
-const noScope = !openScope && rawScope === ''; // first commit touched no project-docs files — distinct from open scope
-const scopedPaths = openScope || noScope ? [] : rawScope.split(',').filter(Boolean);
+// (rawScope/openScope/noScope/scopedPaths are declared earlier — before the lineage-missing
+// early-exit — because composePrompt needs them and runs on that path too.)
 const scopedKeys = new Set(
   scopedPaths
     .map((p) => Object.keys(registry).find((k) => registry[k].path === p))
@@ -303,7 +338,7 @@ if (eligibleSignals.length === 0 && signals.length > 0) {
     // Both filters active — name the intersection explicitly.
     const inBoth = inScope.filter((s) => inBranchType.includes(s));
     noEligibleNote =
-      `fix/** branch (broken:/open: only) AND artifact scope [${scopedPaths.join(', ')}]: ` +
+      `fix/** branch (${RESOLUTION_PREFIXES.join('/')} only) AND artifact scope [${scopedPaths.join(', ')}]: ` +
       `${inScope.length} signal(s) in scope, ${inBranchType.length} resolution-type total, ` +
       `${inBoth.length} satisfy both — no eligible signals on this branch.`;
   } else if (scopedKeys.size > 0) {
@@ -311,7 +346,7 @@ if (eligibleSignals.length === 0 && signals.length > 0) {
       `artifact scope [${scopedPaths.join(', ')}] matches ${inScope.length} of ${signals.length} signal(s) — nothing in scope yet.`;
   } else if (isFixBranch) {
     noEligibleNote =
-      `fix/** branch restricts to broken:/open: signals only — ${inBranchType.length} such signal(s) currently exist.`;
+      `fix/** branch restricts to ${RESOLUTION_PREFIXES.join('/')} signals only — ${inBranchType.length} such signal(s) currently exist.`;
   }
 }
 


### PR DESCRIPTION
Two defects from an external report by a team running the DDDD harness on a real delivery workload. Both reproduced, both the same underlying failure: **the lineage graph hid a gap instead of reporting it**, so the consumer that acts on gaps couldn't see them.

## 1. A broken reference aborted the write it was meant to be reported in

`project-docs-lineage` threw on a broken `project-docs-ancestors` reference or a YAML parse error. Nx rolls a generator's staged write back when it throws, so `lineage.json` never appeared — and `lineage.json` is the only channel the violation had.

`task-identification.mjs` already models `broken:` and `yaml-error:` as its top-priority signals, but it reads them out of that file, so **both handlers were unreachable**. The reporter measured it: one dangling reference took their loop from 20 signals to 1. It could not see an open bug, an unprocessed feature, or an implemented-but-undeployed requirement — and the reason it printed pointed at a missing file rather than at the reference that caused it.

There's a second failure nobody had noticed: `.nx-agent/` is gitignored, so **locally** the previous run's file survives the rollback and the next reader silently consumes a stale graph. CI gets "missing"; a workstation gets "quietly wrong".

A broken reference is a known, enumerated gap in an otherwise complete graph — not a graph that can't be trusted. It's now recorded in `violations` and the write always happens.

`--strict` restores fail-fast for gate use, where the exit code is the point and the artifact isn't. It composes with `--dry-run` for a pure check. The develop/discover/design skill gates and this repo's own gate battery pass it, so their blocking behaviour is unchanged.

## 2. An unparseable reference was dropped as if it weren't there

`parseAncestorRef` returns `null` for a reference outside the slug charset, and `buildIndex` read that as "no reference here". So the target looked *unreferenced* — an orphan — rather than like something nobody can resolve, with nothing anywhere saying a parse had failed.

A version number in a title is the ordinary way a period reaches an id, and dependency questions are a common thing to file:

```
parseAncestorRef('open-questions:otel-1.23.0')      -> null   (silently dropped)
parseAncestorRef('open-questions:otel-upgrade')     -> parsed
```

The same `null` degraded the other direction: an artifact whose own path-derived key won't parse is still registered, but `computeViolations` skips it in `resolutionStatus`, so a **tracked question stopped being reported either open or resolved**.

Both now land in `violations.unparseableRefs`, get printed, and reach `lineage.json` — the same treatment 478df71 gave a YAML parse error.

### The grammar itself is unchanged

The reporter asked for the period to be admitted. Declined: since 7b777dd the generators reject these slugs at creation time (so the tool no longer disagrees with itself, which was the sharp part), and an id is an identifier, not a display string — the title can say `1.23.0` freely. Widening the charset would foreclose any future dotted syntax to serve something the title already covers. What mattered was the second half of their ask, and that's what this does: an unparseable reference is now loud.

### Reporting is gated on the token looking like a reference at all

`extractCommentAncestorRefs` matches the bare `project-docs-ancestors:` token *anywhere* in a source file, so generator code that writes that frontmatter matches too. Unfiltered, a real run against this repo reported **35** template literals like `` `[${ancestors.join(', ')}]` `` and buried anything genuine. Code punctuation is the tell, so only the grammar's charset plus a period, stray slash, or space is admitted. Found by running the generator for real, not by unit test.

## Also

`unparseable:` and `yaml-error:` join `RESOLUTION_PREFIXES`. Both name one specific thing to repair, exactly like `broken:`, and both only became *reachable* as of this PR — without them a `fix/**` branch would see the signal and then be told it isn't eligible to act on it. The two "broken:/open: only" diagnostics now derive their wording from that list so they can't drift.

## Verification

- `npx nx test nx-agent` — 273 passed (20 suites)
- `npx nx build nx-agent`, `npx nx lint nx-agent` — clean (0 errors; the 26 warnings are pre-existing, +1 of the `no-console`-directive class already appearing 6x in that file)
- `npx secretlint` on the diff — clean
- `npx nx g @abgov/nx-agent:project-docs-lineage --dry-run --strict` against this repo — passes, 0 unparseable refs
- `npm audit --audit-level=high` — pre-existing high findings, unchanged; this adds no dependencies

Targets `main`: fully verifiable in-repo against the stable line.

## This repo's own harness copies are synced too

`scripts/task-identification.mjs` is a verbatim copy of the template and had fallen two commits behind it — bb4633d and 478df71 — so the third commit catches it up along with this branch's changes. Verified by running the synced script against this repo's real lineage graph (21 registry entries, zero violations): it reports the derived prefix list in its own diagnostic, `fix/** branch restricts to broken:/unparseable:/yaml-error:/open: signals only`.

The live `.github/workflows/` copy needed nothing beyond the comment updated in the first commit — it matches the template apart from one deliberate divergence that is preserved: the `push` trigger stays disabled while Copilot CLI isn't enabled in this org. The `.claude/skills/` copies were already in sync and are updated.

The remaining three defects from the same report (nx-agent title slugging — already resolved by rejection; nx-oc hardcoded Dockerfile path; nx-oc unconditional rollout restart) are separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
