### PR TITLE
fix(nx-agent): register the product-briefs rename migration on the 1.x line

### DIFF
--- a/packages/nx-agent/migrations.json
+++ b/packages/nx-agent/migrations.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "generators": {
     "rename-service-descriptions-to-product-briefs": {
-      "version": "12.2.0",
+      "version": "1.27.4",
       "description": "Rename project-docs/service-descriptions/ to product-briefs/, rewrite service-descriptions: refs, and update artifact-schema.json.",
       "implementation": "./src/migrations/rename-service-descriptions-to-product-briefs/rename-service-descriptions-to-product-briefs"
     }

--- a/packages/nx-agent/src/migrations.spec.ts
+++ b/packages/nx-agent/src/migrations.spec.ts
@@ -1,0 +1,39 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Guards the migration registry against an unreachable `version`.
+ *
+ * `nx migrate` only collects migrations where
+ * `installed < version <= target`, so a version above the package's own
+ * release line can never be selected — the migration is registered, packaged,
+ * and dead. `rename-service-descriptions-to-product-briefs` shipped that way
+ * for five minor releases: authored for 1.22.0, registered as `12.2.0`
+ * (transposed), and therefore never run by any consumer.
+ *
+ * @abgov/nx-agent publishes on the 1.x line — unlike nx-oc/nx-adsp it is not
+ * pinned to `Nx major - 10`, which is what makes a 12.x/13.x version look
+ * plausible here. On a major bump, update MAJOR_LINE.
+ */
+describe('migrations registry', () => {
+  const MAJOR_LINE = 1
+
+  const registry = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '..', 'migrations.json'), 'utf-8'),
+  )
+  const entries: [string, { version?: string }][] = Object.entries(
+    registry.generators ?? {},
+  )
+
+  it('registers at least one migration', () => {
+    expect(entries.length).toBeGreaterThan(0)
+  })
+
+  it.each(entries)(
+    'registers %s with a version on the published major line',
+    (_name, migration) => {
+      expect(migration.version).toMatch(/^\d+\.\d+\.\d+(-[\w.]+)?$/)
+      expect(Number(migration.version.split('.')[0])).toBe(MAJOR_LINE)
+    },
+  )
+})


### PR DESCRIPTION
## Why

`rename-service-descriptions-to-product-briefs` has been registered in `packages/nx-agent/migrations.json` at version **`12.2.0`** since it was added — a transposition of `1.22.0`, the release it actually shipped in.

`@abgov/nx-agent` publishes on the **1.x** line (52 releases, `0.0.0` → `1.27.3`; there has never been a 12.x). `nx migrate` only collects migrations where `installed < version <= target`, so `12.2.0` has always sat above every reachable target. The migration has been packaged and shipped but **unrunnable by any consumer since 1.22.0** — every workspace that still has a `project-docs/service-descriptions/` directory silently never got the rename.

This is the package where the mistake is easiest to make: unlike `nx-oc` and `nx-adsp`, `nx-agent` is *not* pinned to `Nx major - 10`, which is exactly what makes a `12.x`/`13.x` version look plausible in its registry.

`nx-adsp`'s `add-migrate-advisory-lock` at `13.24.0` was checked and is **correct** — it shipped in `13.24.0`, so `13.23.x → 13.24.0` upgrades run it. No change there.

## What

- Retarget the migration to **`1.27.4`**, the release this `fix:` commit publishes in, making it reachable from every currently-published version. Re-running it late is safe: it already no-ops when no `service-descriptions/` directory exists (existing test coverage).
- Add `packages/nx-agent/src/migrations.spec.ts`, asserting every registered migration `version` is valid semver on the published major line — so an unreachable version fails the test gate instead of shipping silently. Verified it fails on `12.2.0` and passes on `1.27.4`.

## Gate

`npx nx test nx-agent` (21 suites / 275 tests), `npx nx build nx-agent`, `npx nx lint nx-agent` (0 errors), `npx secretlint`, `npx nx g @abgov/nx-agent:project-docs-lineage --dry-run` — all pass. Packaged output confirmed: `dist/packages/nx-agent/migrations.json` carries `1.27.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)