### PR TITLE
feat(nx-oc): let the sandbox executor build from a Dockerfile elsewhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,7 @@ The executor (`packages/nx-oc/src/executors/sandbox/`) runs: preflight (`oc` log
 per-deploy pull secret → `oc tag … --reference-policy=local` → **`oc import-image` with retry**
 (absorbs the tag-reconcile 409) → `oc process | oc apply` → `oc rollout`. Pods pull in-cluster
 via the local reference policy. Options include `--database`, `--imageTag`, `--importRetries`,
-`--deployBackend`, `--skipBuild`/`--skipPush` (resume a partial deploy), and
+`--dockerfile`, `--deployBackend`, `--skipBuild`/`--skipPush` (resume a partial deploy), and
 `--registerDirectory` (opt-in ADSP directory registration after rollout).
 
 Key wiring to preserve when editing:
@@ -422,6 +422,15 @@ Key wiring to preserve when editing:
   app manifest format is identical regardless of path. Always use `clusters.postgresql.cnpg.io`
   (fully qualified) — `oc get cluster` resolves to `clusters.aro.openshift.io` on GoA ARO.
   Mongo continues to use a plain Deployment; there is no CNPG path for mongo.
+- **Container build file**: resolved in the preflight, not at the build step, so a missing or
+  misnamed file fails before secrets and a database are provisioned. Default is
+  `.openshift/<project>/Dockerfile`, falling back to `.openshift/<project>/Containerfile` (podman
+  treats the names as equivalent; the generator emits `Dockerfile`, so the fallback is a fallback,
+  not a preference). `--dockerfile=<path>` overrides both, and a non-existent override fails naming
+  the value given. The override exists because the OpenShift container-contract preflight and the
+  Government Developer Station both look for a **repository-root** Dockerfile — without it, a
+  project satisfying that contract could not use this executor at all. Build context stays `.`
+  either way.
 - **DB auto-detection**: `express-service` records an `adsp:database:<type>` project tag; the
   sandbox generator reads it (falling back to a drizzle `db:migrate` target ⇒ `postgres`), so
   no `--database` flag is needed. Mirrors the `adsp:proxy-service:<name>:<port>` tag that

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -6,6 +6,10 @@ jest.mock('child_process', () => ({
   ...jest.requireActual('child_process'),
   execSync: jest.fn(),
 }));
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+}));
 jest.mock('../../utils/oc-utils', () => ({ ensureOcLogin: jest.fn() }));
 jest.mock('@abgov/adsp-cli', () => ({
   getAccessToken: jest.fn(),
@@ -14,6 +18,14 @@ jest.mock('@abgov/adsp-cli', () => ({
 }));
 
 const { execSync } = require('child_process') as { execSync: jest.Mock };
+const { existsSync } = require('fs') as { existsSync: jest.Mock };
+
+/** Only the given workspace-relative paths exist. */
+function onlyTheseFilesExist(...paths: string[]) {
+  existsSync.mockImplementation((candidate: string) =>
+    paths.some((path) => String(candidate).endsWith(path)),
+  );
+}
 
 const adspCli = require('@abgov/adsp-cli') as {
   getAccessToken: jest.Mock;
@@ -51,6 +63,9 @@ function commands(): string[] {
 
 beforeEach(() => {
   execSync.mockReset();
+  existsSync.mockReset();
+  // The generated default: the sandbox generator emits this path.
+  onlyTheseFilesExist('.openshift/test/Dockerfile');
   execSync.mockImplementation(() => Buffer.from(''));
   adspCli.getAccessToken.mockReset();
   adspCli.getAccessToken.mockResolvedValue({ status: 'ok', token: 'test-token' });
@@ -61,6 +76,65 @@ beforeEach(() => {
 });
 
 describe('sandbox executor', () => {
+  describe('container build file resolution', () => {
+    const buildCmd = () => commands().find((cmd) => cmd.startsWith('podman build'));
+
+    it('defaults to the path the sandbox generator emits', async () => {
+      await runExecutor(baseOptions, context());
+      expect(buildCmd()).toContain('-f .openshift/test/Dockerfile');
+    });
+
+    it('falls back to Containerfile when only that name is present', async () => {
+      onlyTheseFilesExist('.openshift/test/Containerfile');
+      await runExecutor(baseOptions, context());
+      expect(buildCmd()).toContain('-f .openshift/test/Containerfile');
+    });
+
+    it('prefers Dockerfile when both names are present', async () => {
+      onlyTheseFilesExist(
+        '.openshift/test/Dockerfile',
+        '.openshift/test/Containerfile',
+      );
+      await runExecutor(baseOptions, context());
+      expect(buildCmd()).toContain('-f .openshift/test/Dockerfile');
+    });
+
+    it('honours --dockerfile, e.g. the root Dockerfile the OpenShift container contract requires', async () => {
+      onlyTheseFilesExist('Dockerfile');
+      await runExecutor({ ...baseOptions, dockerfile: 'Dockerfile' }, context());
+      expect(buildCmd()).toContain('-f Dockerfile');
+    });
+
+    it('fails fast when --dockerfile points at nothing, naming the value given', async () => {
+      onlyTheseFilesExist('.openshift/test/Dockerfile');
+      await expect(
+        runExecutor({ ...baseOptions, dockerfile: 'build/Containerfile' }, context()),
+      ).resolves.toEqual({ success: false });
+      expect(buildCmd()).toBeUndefined();
+    });
+
+    it('fails before provisioning anything when no build file exists at all', async () => {
+      onlyTheseFilesExist();
+      await expect(runExecutor(baseOptions, context())).resolves.toEqual({
+        success: false,
+      });
+      // The point of resolving in the preflight: nothing expensive ran.
+      const cmds = commands();
+      expect(cmds.some((cmd) => cmd.startsWith('podman build'))).toBe(false);
+      expect(cmds.some((cmd) => cmd.startsWith('npx nx build'))).toBe(false);
+      expect(cmds.some((cmd) => cmd.includes('oc create secret'))).toBe(false);
+    });
+
+    it('needs no build file when --skipBuild is set', async () => {
+      onlyTheseFilesExist();
+      const result = await runExecutor(
+        { ...baseOptions, skipBuild: true },
+        context(),
+      );
+      expect(result).toEqual({ success: true });
+    });
+  });
+
   it('builds, pushes, tags, imports, and rolls out in order', async () => {
     const result = await runExecutor(baseOptions, context());
     expect(result.success).toBe(true);

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -5,6 +5,8 @@ import {
   registerDirectoryService,
 } from '@abgov/adsp-cli';
 import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { detectApplicationType } from '../../utils/app-type';
 import { activeAccountScopes } from '../../utils/gh-utils';
 import { ensureOcLogin } from '../../utils/oc-utils';
@@ -12,6 +14,48 @@ import { detectAdspTenant } from '../../adsp/adsp-utils';
 import { SandboxExecutorSchema } from './schema';
 
 const PROXY_TAG_PREFIX = 'adsp:proxy-service:';
+
+// Resolves the container build file before the build runs, so a missing or
+// misnamed file fails here rather than several minutes in as a podman error.
+//
+// `--dockerfile` exists because the path is a convention, not a law: the
+// OpenShift container-contract preflight and the Government Developer Station
+// both look for a repository-root Dockerfile, so a project satisfying that
+// contract could not otherwise use this executor at all.
+//
+// Containerfile is checked as a fallback, not preferred: podman treats the two
+// names as equivalent, and the sandbox generator emits `Dockerfile`.
+function resolveContainerfile(
+  cwd: string,
+  projectName: string,
+  override?: string,
+): string {
+  if (override) {
+    if (!existsSync(join(cwd, override))) {
+      throw new Error(
+        `--dockerfile was set to '${override}' but no such file exists relative to the workspace root.`,
+      );
+    }
+    return override;
+  }
+
+  const candidates = [
+    `.openshift/${projectName}/Dockerfile`,
+    `.openshift/${projectName}/Containerfile`,
+  ];
+  const found = candidates.find((candidate) =>
+    existsSync(join(cwd, candidate)),
+  );
+  if (!found) {
+    throw new Error(
+      `No container build file found. Looked for:\n` +
+        candidates.map((candidate) => `  ${candidate}`).join('\n') +
+        `\nRun \`nx g @abgov/nx-oc:sandbox ${projectName}\` to generate one, ` +
+        `or pass --dockerfile=<path> if it lives elsewhere (e.g. a root Dockerfile).`,
+    );
+  }
+  return found;
+}
 
 // Fail fast, with an actionable message, before the (slow) production build —
 // rather than a raw "command not found" partway through.
@@ -198,6 +242,11 @@ export default async function runExecutor(
     if (!skipBuild || !skipPush) {
       requirePodman();
     }
+    // Resolved in the preflight, not at the build step: an unbuildable path
+    // should stop the run before it provisions secrets and a database.
+    const containerfile = skipBuild
+      ? undefined
+      : resolveContainerfile(cwd, projectName, options.dockerfile);
 
     // ---- service client secret (node services authenticate to ADSP) ----
     // Upserted from the current .env.local so re-runs pick up a rotated secret.
@@ -463,7 +512,7 @@ EOF`,
       );
       run(
         'Podman build',
-        `podman build --platform=linux/amd64 -f .openshift/${projectName}/Dockerfile -t ${imageRef} .`,
+        `podman build --platform=linux/amd64 -f ${containerfile} -t ${imageRef} .`,
         cwd,
       );
     }

--- a/packages/nx-oc/src/executors/sandbox/schema.d.ts
+++ b/packages/nx-oc/src/executors/sandbox/schema.d.ts
@@ -14,4 +14,5 @@ export interface SandboxExecutorSchema {
   deployBackend?: boolean;
   importRetries?: number;
   registerDirectory?: boolean;
+  dockerfile?: string;
 }

--- a/packages/nx-oc/src/executors/sandbox/schema.json
+++ b/packages/nx-oc/src/executors/sandbox/schema.json
@@ -16,13 +16,21 @@
     },
     "database": {
       "type": "string",
-      "enum": ["none", "postgres", "mongo"],
+      "enum": [
+        "none",
+        "postgres",
+        "mongo"
+      ],
       "default": "none",
       "description": "Provision a shared sandbox database of this type before deploying. 'postgres' uses the CloudNativePG operator when available and falls back to the plain Deployment otherwise."
     },
     "appType": {
       "type": "string",
-      "enum": ["node", "frontend", "dotnet"],
+      "enum": [
+        "node",
+        "frontend",
+        "dotnet"
+      ],
       "description": "Application type. Detected from the project configuration when omitted."
     },
     "imageTag": {
@@ -53,8 +61,15 @@
     "registerDirectory": {
       "type": "boolean",
       "default": false,
-      "description": "After a successful rollout, register the service in the ADSP directory under the tenant's namespace (register-once — skips if the entry already exists). Only applies to node and dotnet app types. Requires an active adsp login with the directory-admin role."
+      "description": "After a successful rollout, register the service in the ADSP directory under the tenant's namespace (register-once \u2014 skips if the entry already exists). Only applies to node and dotnet app types. Requires an active adsp login with the directory-admin role."
+    },
+    "dockerfile": {
+      "type": "string",
+      "description": "Path to the container build file, relative to the workspace root. Defaults to .openshift/<project>/Dockerfile, falling back to .openshift/<project>/Containerfile. Set this when the file lives elsewhere -- e.g. a repository-root Dockerfile, which the OpenShift container-contract preflight and the Government Developer Station both look for."
     }
   },
-  "required": ["sandboxProject", "registry"]
+  "required": [
+    "sandboxProject",
+    "registry"
+  ]
 }

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -59,6 +59,7 @@ nx run <%= projectName %>:sandbox --skipBuild --skipPush   # reuse the pushed im
 nx run <%= projectName %>:sandbox --imageTag=<tag>         # push/import under a different tag
 nx run <%= projectName %>:sandbox --importRetries=8        # more import retries on a slow cluster
 nx run <%= projectName %>:sandbox --registerDirectory      # register in ADSP directory after rollout (opt-in)
+nx run <%= projectName %>:sandbox --dockerfile=Dockerfile  # build file elsewhere (e.g. a repo-root Dockerfile)
 <% if (appType === 'frontend') { %>nx run <%= projectName %>:sandbox --deployBackend           # deploy each paired backend (its own sandbox) first
 <% } %>```
 <% if (appType === 'frontend') { %>


### PR DESCRIPTION
Resolves item **#4** of `2026-08-25-nx-tools-plugin-defects-email.md` — the last open item in that report.

## Why

The executor hardcoded `-f .openshift/<project>/Dockerfile` with no override, which put it in direct conflict with the OpenShift deploy contract: the container-contract preflight reads the **repository root**, and the Government Developer Station lists only projects with a root-level Dockerfile.

So a project satisfying that contract could not use this executor, and a project using this executor could not satisfy the contract. That was reported from a real workspace which moved its Dockerfile to the root and watched the build route stop working — with the reporter noting the next team to hit it would conclude their own move broke the build, rather than that the executor can't follow it.

## What

`--dockerfile=<path>`, relative to the workspace root, **defaulting to today's path** so every existing generated target is byte-identical.

When it isn't set, resolution tries `.openshift/<project>/Dockerfile` then `.openshift/<project>/Containerfile`. Podman treats the two names as equivalent, and the sandbox generator emits `Dockerfile` — so the second is a fallback, not a preference (there's a test pinning that precedence).

**Resolved in the preflight, not at the build step.** This executor's whole posture is to fail before the expensive part, and a missing build file would otherwise surface several minutes in — after secrets and a database had already been provisioned. Error messages are specific: a non-existent `--dockerfile` names the value given; no build file at all lists both candidates and points at the generator. `--skipBuild` needs no build file and doesn't look for one.

Build context stays `.`, which is what a root Dockerfile wants anyway.

## Verification

7 new tests in `sandbox.spec.ts` covering: the unchanged default, the Containerfile fallback, Dockerfile-preferred-when-both, an explicit override, fail-fast on a bad override, fail-fast with nothing provisioned when no file exists, and `--skipBuild` needing none.

`nx-oc` 167 tests (160 existing + 7), build, lint (0 errors) pass; `nx-adsp` 197 pass as a dependent. `secretlint` clean. The updated `schema.json` is confirmed packaged by the build.

Docs updated in three places: the generated `SANDBOX.md` runbook example list, the repo `AGENTS.md` option list, and a new "Container build file" entry under the sandbox section's *key wiring to preserve*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)