### PR TITLE
feat(nx-adsp): tier 2 — emit what the generators already know

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -312,6 +312,7 @@ npx nx g @abgov/nx-adsp:vue-workspace-view my-app --name=applications --resource
 | `columns`      | Yes      | JSON array of table columns, in display order: `{ key, label, type?: "text"\|"date"\|"currency"\|"badge", sortable? }` (a JSON string — see note below) |
 | `detailRoute`  | No       | If set, each row gets a "View" action linking to `${detailRoute}/${row.id}` — typically a `vue-detail-view`'s route with the `:id` segment dropped      |
 | `filterable`   | No       | Whether to generate a debounced search input above the table. Defaults to `true`                                                                        |
+| `filters`      | No       | JSON array of filter controls rendered above the table by `FilterBar`, beyond the search box — `[{key,label,type:"dropdown"\|"date",options?,anyLabel?}]`. Values are sent as query parameters alongside `search`/`page`/`sort`. Omit for no filter bar |
 | `heading`      | No       | Page heading. Defaults to the view name, title-cased                                                                                                    |
 | `pageSize`     | No       | Rows per page. Defaults to `20`                                                                                                                         |
 | `requiresAuth` | No       | Whether the generated route requires authentication. Defaults to `true`                                                                                 |

--- a/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.spec.ts
@@ -177,7 +177,7 @@ describe('Vue Admin CRUD Generator', () => {
       "component: () => import('../views/RegionsEditView.vue')",
     );
     expect(
-      routerTs.split('meta: { requiresAuth: true }').length - 1,
+      routerTs.split('requiresAuth: true').length - 1,
     ).toBe(2);
     // The existing route is untouched, not replaced.
     expect(routerTs).toContain("{ path: '/', component: HomeView }");

--- a/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.ts
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.ts
@@ -73,11 +73,13 @@ export default async function (host: Tree, options: Schema) {
     path: `${normalizedOptions.route}/:id`,
     componentImportPath: `../views/${normalizedOptions.editViewFileName}.vue`,
     requiresAuth: normalizedOptions.requiresAuth,
+    layout: 'form',
   });
   insertVueRoute(host, normalizedOptions.projectRoot, normalizedOptions.project, {
     path: normalizedOptions.route,
     componentImportPath: `../views/${normalizedOptions.listViewFileName}.vue`,
     requiresAuth: normalizedOptions.requiresAuth,
+    layout: 'wide',
   });
 
   await formatFiles(host);

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/Stepper.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/Stepper.spec.ts__tmpl__
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import Stepper from './Stepper.vue';
+
+// goa-form-stepper's own `step` prop (1-based) drives the progress bar and the
+// current-step emphasis; goa-form-step's status enum has no "current" value.
+// Without it the element defaults to 1 and every page of a wizard shows step one
+// as current.
+const steps = [
+  { key: 'a', label: 'A', status: 'complete' as const },
+  { key: 'b', label: 'B', status: 'incomplete' as const },
+  { key: 'c', label: 'C', status: 'not-started' as const },
+];
+
+const stepAttr = (step?: number) =>
+  mount(Stepper, { props: step === undefined ? { steps } : { steps, step } })
+    .find('goa-form-stepper')
+    .attributes('step');
+
+describe('Stepper', () => {
+  it('forwards the current step to goa-form-stepper', () => {
+    expect(stepAttr(2)).toBe('2');
+    expect(stepAttr(3)).toBe('3');
+  });
+
+  it('defaults to the first step', () => {
+    expect(stepAttr()).toBe('1');
+  });
+
+  it('clamps out of range rather than handing the element a bad progress value', () => {
+    // goa-form-stepper sets a <progress> value from this; out of range yields a
+    // non-finite value that throws in the browser.
+    expect(stepAttr(0)).toBe('1');
+    expect(stepAttr(-5)).toBe('1');
+    expect(stepAttr(99)).toBe('3');
+  });
+
+  it('clamps to 1 when there are no steps', () => {
+    const el = mount(Stepper, { props: { steps: [], step: 4 } }).find('goa-form-stepper');
+    expect(el.attributes('step')).toBe('1');
+  });
+});

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/Stepper.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/Stepper.vue__tmpl__
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 // Wraps the real, native goa-form-stepper/goa-form-step pair (confirmed via
 // design.alberta.ca/components/form-stepper -- there wasn't one when the spec
 // this is based on was written, hence "nobody used a native GoA stepper"; that
@@ -17,12 +18,27 @@ export interface StepperStep {
   status: 'complete' | 'incomplete' | 'not-started';
 }
 
-const props = defineProps<{ steps: StepperStep[] }>();
+// `step` is goa-form-stepper's OWN prop (1-based) and is what drives the
+// progress bar and the current-step emphasis. Without it the element defaults
+// to 1, so every page of a wizard renders step one as current and the internal
+// <progress> sits at zero. goa-form-step's status enum has no "current" value —
+// that state lives on the parent, which is easy to miss when reading only the
+// child's API.
+const props = withDefaults(
+  defineProps<{ steps: StepperStep[]; step?: number }>(),
+  { step: 1 },
+);
+
+// Clamped: the element sets a <progress> value from this, and an out-of-range
+// number yields a non-finite value that throws in the browser.
+const currentStep = computed(() =>
+  Math.min(Math.max(props.step, 1), Math.max(props.steps.length, 1)),
+);
 const emit = defineEmits<{ select: [key: string] }>();
 </script>
 
 <template>
-  <goa-form-stepper>
+  <goa-form-stepper :step="currentStep">
     <goa-form-step
       v-for="(step, index) in props.steps"
       :key="step.key"

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -93,6 +93,14 @@ describe('Vue Components Generator', () => {
     const formattersSrc = host
       .read('libs/vue-components/src/lib/formatters.ts')
       .toString();
+    // goa-form-stepper's `step` prop drives the progress bar; without it every
+    // page of a wizard renders step one as current.
+    const stepper = host
+      .read('libs/vue-components/src/lib/patterns/Stepper.vue')
+      .toString();
+    expect(stepper).toContain(':step="currentStep"');
+    expect(stepper).toContain('Math.min(Math.max(props.step, 1)');
+
     expect(formattersSrc).toContain('DATE_ONLY');
     expect(formattersSrc).toContain('local.getFullYear() === year');
 
@@ -121,6 +129,7 @@ describe('Vue Components Generator', () => {
       'libs/vue-components/src/lib/patterns/FilterBar.spec.ts',
       'libs/vue-components/src/lib/primitives/GoabDatePicker.spec.ts',
       'libs/vue-components/src/lib/patterns/WorkspaceTable.spec.ts',
+      'libs/vue-components/src/lib/patterns/Stepper.spec.ts',
     ]) {
       expect(host.exists(spec)).toBeTruthy();
     }

--- a/packages/nx-adsp/src/generators/vue-detail-view/vue-detail-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-detail-view/vue-detail-view.spec.ts
@@ -153,6 +153,8 @@ describe('Vue Detail View Generator', () => {
       "component: () => import('../views/ApplicationDetailView.vue')",
     );
     expect(routerTs).toContain('meta: { requiresAuth: true }');
+    // A record info list is neither a table nor a form -- default width.
+    expect(routerTs).not.toContain('layout:');
     // The existing route is untouched, not replaced.
     expect(routerTs).toContain("{ path: '/', component: HomeView }");
   }, 30000);

--- a/packages/nx-adsp/src/generators/vue-intake-view/files/steps/src/views/__stepViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-intake-view/files/steps/src/views/__stepViewFileName__.vue__tmpl__
@@ -145,7 +145,7 @@ function goBack() {
 
 <template>
   <div>
-    <Stepper :steps="stepperSteps" @select="onStepperSelect" />
+    <Stepper :steps="stepperSteps" :step="<%= stepNumber %>" @select="onStepperSelect" />
 
     <goa-spacer vspacing="l" />
 

--- a/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.spec.ts
@@ -107,6 +107,14 @@ describe('Vue Intake View Generator', () => {
       .toString();
     // Last step in the list moves to review, not another step.
     expect(step2).toContain('/applications/${nextId}/review');
+    // Each step tells the Stepper which step it is (1-based) -- the generator
+    // knows, so the view doesn't re-derive it from the route. Without it every
+    // page renders step one as current.
+    expect(step1).toContain(':step="1"');
+    expect(step2).toContain(':step="2"');
+    // Single-column forms ask for the narrow variant.
+    const routerForm = host.read('apps/test/src/router/index.ts').toString();
+    expect(routerForm).toContain("layout: 'form'");
     // A required field gets a validation block + requirement="required"; an
     // explicitly non-required one gets neither.
     expect(step2).toContain("found.push({ message: 'Email is required.'");
@@ -156,7 +164,7 @@ describe('Vue Intake View Generator', () => {
       "component: () => import('../views/ApplicationConfirmationView.vue')",
     );
     expect(
-      routerTs.split('meta: { requiresAuth: true }').length - 1,
+      routerTs.split('requiresAuth: true').length - 1,
     ).toBe(4);
     // The existing route is untouched, not replaced.
     expect(routerTs).toContain("{ path: '/', component: HomeView }");

--- a/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.ts
@@ -86,6 +86,10 @@ export default async function (host: Tree, options: Schema) {
         stepFields: step.fields,
         stepperSteps,
         nextStepKey,
+        // 1-based, for goa-form-stepper's own `step` prop. The generator knows
+        // which step it is emitting; the view would otherwise have to re-derive
+        // it from the route.
+        stepNumber: index + 1,
         tmpl: '',
       },
     );
@@ -111,6 +115,7 @@ export default async function (host: Tree, options: Schema) {
     path: `${normalizedOptions.route}/:id/review`,
     componentImportPath: `../views/${reviewViewFileName}.vue`,
     requiresAuth: normalizedOptions.requiresAuth,
+    layout: 'form',
   });
   for (let i = steps.length - 1; i >= 0; i--) {
     const step = steps[i];
@@ -118,6 +123,7 @@ export default async function (host: Tree, options: Schema) {
       path: `${normalizedOptions.route}/:id/${step.key}`,
       componentImportPath: `../views/${stepViewFileName(step.key)}.vue`,
       requiresAuth: normalizedOptions.requiresAuth,
+      layout: 'form',
     });
   }
 

--- a/packages/nx-adsp/src/generators/vue-workspace-view/files/src/views/__viewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/files/src/views/__viewFileName__.vue__tmpl__
@@ -1,6 +1,13 @@
 <script setup lang="ts">
 import { ref, onMounted<% if (filterable) { %>, onUnmounted<% } %> } from 'vue';
-import { WorkspaceTable, formatCurrency, formatDate } from '<%= goaImportPath %>';
+import {
+  WorkspaceTable,
+<% if (filters.length) { -%>
+  FilterBar,
+<% } -%>
+  formatCurrency,
+  formatDate,
+} from '<%= goaImportPath %>';
 import { useApi } from '../composables/useApi';
 
 const { list } = useApi();
@@ -23,6 +30,38 @@ const sortDir = ref<'asc' | 'desc'>('asc');
 <% if (filterable) { -%>
 const search = ref('');
 let searchDebounce: ReturnType<typeof setTimeout> | undefined;
+<% } -%>
+
+<% if (filters.length) { -%>
+// A ref, not a const: a dropdown's options can be fetched (load them in `load`
+// or a second call and assign into the matching descriptor) without changing
+// FilterBar's contract.
+const filterDescriptors = ref([
+<% filters.forEach(function (filter) { -%>
+  {
+    key: '<%- filter.key %>',
+    label: '<%- filter.label %>',
+    type: '<%- filter.type %>' as const,
+<% if (filter.type === 'dropdown') { -%>
+    options: <%- JSON.stringify(filter.options ?? []) %>,
+<% if (filter.anyLabel) { -%>
+    anyLabel: '<%- filter.anyLabel %>',
+<% } -%>
+<% } -%>
+  },
+<% }); -%>
+]);
+
+// Query-ready values, keyed by filter. FilterBar owns the controls and the
+// chips; the page reset and the reload below belong here because `page` is this
+// view's state.
+const filterValues = ref<Record<string, string>>({});
+
+function onFiltersChange(next: Record<string, string>) {
+  filterValues.value = next;
+  page.value = 1;
+  void load();
+}
 <% } -%>
 
 const PAGE_SIZE = <%= pageSize %>;
@@ -48,6 +87,9 @@ async function load() {
 <% } -%>
       sortBy: sortBy.value,
       sortDir: sortDir.value,
+<% if (filters.length) { -%>
+      filters: filterValues.value,
+<% } -%>
     });
     if (sequence !== loadSequence) return;
     rows.value = result.rows;
@@ -114,6 +156,16 @@ onUnmounted(() => {
       placeholder="Search..."
       width="320px"
       @_change="onSearchInput"
+    />
+
+    <goa-spacer vspacing="l" />
+<% } -%>
+<% if (filters.length) { -%>
+
+    <FilterBar
+      :filters="filterDescriptors"
+      :model-value="filterValues"
+      @update:model-value="onFiltersChange"
     />
 
     <goa-spacer vspacing="l" />

--- a/packages/nx-adsp/src/generators/vue-workspace-view/schema.d.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/schema.d.ts
@@ -5,6 +5,16 @@ export interface WorkspaceViewColumn {
   sortable?: boolean;
 }
 
+export interface WorkspaceViewFilter {
+  key: string;
+  label: string;
+  type: 'dropdown' | 'date';
+  /** Dropdown only. Omit and populate `filterDescriptors` at runtime to fetch them. */
+  options?: { value: string; label: string }[];
+  /** Dropdown only. Label for the "no filter" choice. Defaults to "Any". */
+  anyLabel?: string;
+}
+
 export interface Schema {
   project: string;
   name: string;
@@ -16,6 +26,8 @@ export interface Schema {
    * also accepted for programmatic callers (e.g. tests).
    */
   columns: string | WorkspaceViewColumn[];
+  /** Same JSON-string-on-the-CLI reasoning as `columns`. */
+  filters?: string | WorkspaceViewFilter[];
   detailRoute?: string;
   heading?: string;
   pageSize?: number;
@@ -23,11 +35,13 @@ export interface Schema {
   requiresAuth?: boolean;
 }
 
-export interface NormalizedSchema extends Omit<Schema, 'columns'> {
+export interface NormalizedSchema extends Omit<Schema, 'columns' | 'filters'> {
   projectRoot: string;
   /** PascalCase view name with a "ListView" suffix, e.g. ApplicationsListView. */
   viewFileName: string;
   columns: WorkspaceViewColumn[];
+  /** Empty when --filters wasn't given, so the template can skip the FilterBar. */
+  filters: WorkspaceViewFilter[];
   heading: string;
   pageSize: number;
   filterable: boolean;

--- a/packages/nx-adsp/src/generators/vue-workspace-view/schema.json
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/schema.json
@@ -35,6 +35,10 @@
       "type": "string",
       "description": "JSON array of table columns, in display order -- e.g. '[{\"key\":\"status\",\"label\":\"Status\",\"type\":\"badge\",\"sortable\":true}]'. Each item: { key, label, type?: \"text\"|\"date\"|\"currency\"|\"badge\" (default \"text\"), sortable?: boolean }. A plain array is also accepted when this generator is invoked programmatically. Nx's CLI option coercion only supports comma-separated primitive lists for array-typed schema properties, not JSON -- a JSON string is the only CLI syntax that actually survives Nx's own arg parsing for a structured list like this."
     },
+    "filters": {
+      "type": "string",
+      "description": "JSON array of filter controls rendered above the table by FilterBar, beyond the --filterable search box -- e.g. '[{\"key\":\"status\",\"label\":\"Status\",\"type\":\"dropdown\",\"options\":[{\"value\":\"open\",\"label\":\"Open\"}]},{\"key\":\"from\",\"label\":\"From\",\"type\":\"date\"}]'. Each item: { key, label, type: \"dropdown\"|\"date\", options?: [{value,label}], anyLabel? }. Values are sent as query parameters alongside search/page/sort, so the API decides what each key means. Omit for no filter bar. Same JSON-string-on-the-CLI reasoning as --columns."
+    },
     "detailRoute": {
       "type": "string",
       "description": "If set, each row gets a \"View\" action linking to `${detailRoute}/${row.id}` -- typically a vue-detail-view's route with the :id segment dropped. Omit to leave the actions column for manual customization."
@@ -59,6 +63,12 @@
       "default": true
     }
   },
-  "required": ["project", "name", "resource", "route", "columns"],
+  "required": [
+    "project",
+    "name",
+    "resource",
+    "route",
+    "columns"
+  ],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
@@ -206,7 +206,9 @@ describe('Vue Workspace View Generator', () => {
     expect(routerTs).toContain(
       "component: () => import('../views/ApplicationsListView.vue')",
     );
-    expect(routerTs).toContain('meta: { requiresAuth: true }');
+    expect(routerTs).toContain('requiresAuth: true');
+    // A data table asks for the wide variant -- the generator knows it emitted one.
+    expect(routerTs).toContain("layout: 'wide'");
     expect(routerTs).toContain("{ path: '/', component: HomeView }");
   }, 30000);
 

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
@@ -149,6 +149,71 @@ describe('Vue Workspace View Generator', () => {
     expect(view).toContain('searchDebounce');
   }, 30000);
 
+  describe('--filters', () => {
+    const filters = JSON.stringify([
+      {
+        key: 'status',
+        label: 'Status',
+        type: 'dropdown',
+        options: [{ value: 'open', label: 'Open' }],
+        anyLabel: 'All statuses',
+      },
+      { key: 'from', label: 'From', type: 'date' },
+    ]);
+
+    it('wires the shared FilterBar and sends the values as query filters', async () => {
+      await generator(host, { ...baseOptions, filters });
+      const view = host
+        .read('apps/test/src/views/ApplicationsListView.vue')
+        .toString();
+
+      expect(view).toContain('FilterBar');
+      expect(view).toContain(':filters="filterDescriptors"');
+      expect(view).toContain('@update:model-value="onFiltersChange"');
+      // The values object goes straight through useApi's adapter.
+      expect(view).toContain('filters: filterValues.value');
+      // The view owns the page reset, not FilterBar -- it owns `page`.
+      expect(view).toContain('page.value = 1');
+      // Descriptors are a ref so fetched dropdown options can be assigned in.
+      expect(view).toContain('const filterDescriptors = ref([');
+      expect(view).toContain("anyLabel: 'All statuses'");
+      expect(view).toContain("type: 'date' as const");
+    });
+
+    it('leaves output byte-identical when --filters is omitted', async () => {
+      await generator(host, baseOptions);
+      const without = host
+        .read('apps/test/src/views/ApplicationsListView.vue')
+        .toString();
+      expect(without).not.toContain('FilterBar');
+      expect(without).not.toContain('filterValues');
+      expect(without).not.toContain('onFiltersChange');
+    });
+
+    it('rejects a filter type it cannot render, naming the offender', async () => {
+      await expect(
+        generator(host, {
+          ...baseOptions,
+          filters: JSON.stringify([
+            { key: 'x', label: 'X', type: 'checkbox' },
+          ]),
+        }),
+      ).rejects.toThrow('--filters[].type must be "dropdown" or "date"; got "checkbox" for "x".');
+    });
+
+    it('accepts a real array, the form a programmatic caller passes', async () => {
+      await generator(host, {
+        ...baseOptions,
+        filters: [{ key: 'status', label: 'Status', type: 'dropdown' }],
+      });
+      const view = host
+        .read('apps/test/src/views/ApplicationsListView.vue')
+        .toString();
+      expect(view).toContain('FilterBar');
+      expect(view).toContain('options: []');
+    });
+  });
+
   it('omits onUnmounted along with the debounce when --filterable=false', async () => {
     // onUnmounted exists only to clear the search debounce, so importing it
     // unconditionally would be an unused import and fail the generated lint.

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.ts
@@ -10,7 +10,12 @@ import { insertVueRoute } from '../../utils/vue-router';
 import vueComponentsGenerator, {
   vueComponentsImportPath,
 } from '../vue-components/vue-components';
-import { NormalizedSchema, Schema, WorkspaceViewColumn } from './schema';
+import {
+  NormalizedSchema,
+  Schema,
+  WorkspaceViewColumn,
+  WorkspaceViewFilter,
+} from './schema';
 
 // Nx's own CLI option coercion (coerceTypesInOptions in nx/src/utils/params)
 // only knows how to split an array-typed option on commas -- it has no JSON
@@ -29,6 +34,25 @@ function parseColumns(columns: Schema['columns']): WorkspaceViewColumn[] {
   return parsed;
 }
 
+// Same JSON-string-on-the-CLI reasoning as parseColumns above.
+function parseFilters(filters: Schema['filters']): WorkspaceViewFilter[] {
+  if (filters === undefined || filters === '') return [];
+  const parsed = typeof filters === 'string' ? JSON.parse(filters) : filters;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      '--filters must be a JSON array of { key, label, type: "dropdown"|"date", options?, anyLabel? } objects.',
+    );
+  }
+  for (const filter of parsed) {
+    if (filter.type !== 'dropdown' && filter.type !== 'date') {
+      throw new Error(
+        `--filters[].type must be "dropdown" or "date"; got "${filter.type}" for "${filter.key}".`,
+      );
+    }
+  }
+  return parsed;
+}
+
 function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const { root: projectRoot } = readProjectConfiguration(host, options.project);
 
@@ -37,6 +61,7 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
     ...options,
     projectRoot,
     columns: parseColumns(options.columns),
+    filters: parseFilters(options.filters),
     viewFileName: `${className}ListView`,
     // className is PascalCase (e.g. "Applications") -- space it out for a
     // readable default heading ("Applications").

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.ts
@@ -73,6 +73,8 @@ export default async function (host: Tree, options: Schema) {
     path: normalizedOptions.route,
     componentImportPath: `../views/${normalizedOptions.viewFileName}.vue`,
     requiresAuth: normalizedOptions.requiresAuth,
+    // A multi-column table at the 1000px default wraps every cell.
+    layout: 'wide',
   });
 
   await formatFiles(host);

--- a/packages/nx-adsp/src/utils/vue-router.ts
+++ b/packages/nx-adsp/src/utils/vue-router.ts
@@ -5,6 +5,13 @@ export interface VueRouteSpec {
   /** Relative import path passed to () => import(...), e.g. '../views/FooView.vue'. */
   componentImportPath: string;
   requiresAuth?: boolean;
+  /**
+   * Content width for the view, read by App.vue's `contentWidth` and passed to
+   * AppLayout. Omit for the 1000px default; a generator emitting a data table
+   * should say 'wide' and one emitting a single-column form 'form', since it
+   * already knows which it produced.
+   */
+  layout?: 'wide' | 'form';
 }
 
 // Deterministic text insertion, not an AST edit -- vue-app's router/index.ts
@@ -32,8 +39,12 @@ export function insertVueRoute(
     );
   }
 
-  const metaLine = route.requiresAuth
-    ? `\n      meta: { requiresAuth: true },`
+  const metaEntries = [
+    ...(route.requiresAuth ? ['requiresAuth: true'] : []),
+    ...(route.layout ? [`layout: '${route.layout}'`] : []),
+  ];
+  const metaLine = metaEntries.length
+    ? `\n      meta: { ${metaEntries.join(', ')} },`
     : '';
   const routeSnippet =
     `{\n` +


### PR DESCRIPTION
Tier 2 of the independent-agent evaluation. Three of the five items; the two I stopped short of are called out at the bottom with the reason.

## 1. Route layout width

`App.vue` already computes `contentWidth` from `route.meta.layout` and passes it to `AppLayout`, which implements `page`/`wide`/`form`. **No generator set it**, so a seven-column table and a four-field form both rendered at the 1000px default — every reference number and date wrapping onto three lines.

`VueRouteSpec` gains `layout`, and each generator states what it just produced:

| Generator | Width |
|---|---|
| `vue-workspace-view` | `wide` |
| `vue-admin-crud` list | `wide` |
| `vue-admin-crud` edit | `form` |
| `vue-intake-view` steps + review | `form` |
| `vue-detail-view` | default — a record info list is neither a table nor a form |

## 2. Stepper position

`Stepper` rendered a bare `<goa-form-stepper>` and declared only `steps`, but the element registers its own 1-based `step` prop — that's what drives the progress bar and the current-step emphasis, because `goa-form-step`'s status enum has **no "current" value**. Unset, the element defaults to 1, so every page of a wizard showed step one as current with the internal `<progress>` at zero. The component's comment reasoned carefully about the child's enum and missed that the state lives on the parent.

`step` is clamped: the element derives a `<progress>` value from it, and out of range yields a non-finite value that throws in the browser. The intake generator passes each step's own number, since it knows which step it's emitting.

Verified by mounting `Stepper` in a real Vue harness — forwarding, default, clamping both ends, empty-steps. That spec ships with the library.

## 3. `vue-workspace-view --filters`

`FilterBar` shipped in the library and **no generator reached it**, so a generated list offered only the search box. The evaluating agent found it by reading `vue-components/src/index.ts`, not from any doc, and wired it by hand — the sharpest "the plugin already has this" finding in its report.

```
--filters '[{"key":"status","label":"Status","type":"dropdown",
             "options":[{"value":"open","label":"Open"}]},
            {"key":"from","label":"From","type":"date"}]'
```

Same JSON-string-on-the-CLI shape as `--columns`, same reason (Nx's array coercion splits on commas, no JSON support), and a real array works for programmatic callers.

The split follows the component's own contract: `FilterBar` owns controls, collapse, chips and clear-all and emits one query-ready values object; the **view** owns resetting `page` and reloading, because `page` is view state and a presentational component can't reach it. Values go through `useApi`'s `filters`, so a backend naming them differently is an adapter edit.

Descriptors are emitted as a `ref`, not a `const` — dropdown options are often fetched (the source app populated one from `/api/v1/gateways`), and a ref lets a consumer assign them in. An `optionsResource` option that fetches them is **deliberately not here**: it needs its own decision about which keys map to value/label.

Absent `--filters`, output is unchanged — asserted. An unrenderable type fails at generation naming the offending key.

## Not in this PR

- **Richer field types** for `vue-intake-view`/`vue-admin-crud` (`date`, `select`, `number`, `textarea`). Mechanical but touches two schemas, two templates and their tests; better reviewed on its own.
- **Staff nav entries per generated route.** This one needs a decision rather than code: `vue-app` never passes `primary-items` to `AppSideMenu` at all, so there's no array to append to. Adding one means `vue-app` emitting an empty nav array purely so view generators can insert into it — a structural change to the app shell, not just "emit what you know."

## Verification

201 nx-adsp tests (197 + 4 new), build, lint 0 errors; `secretlint` clean; docs-site option table updated.

Worth noting one process failure of mine: my `grep` filter on the test output hid a `Test suite failed to run` (no `›` in that line) and I nearly proceeded on a green-looking run that had silently dropped 15 tests to a TS1501 regex-flag error. Caught by comparing the total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)