### PR TITLE
fix(nx-adsp): scroll the staff shell's content, not the whole document

### DIFF
--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppSideMenu.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/AppSideMenu.vue__tmpl__
@@ -86,8 +86,24 @@ const emit = defineEmits<{ itemClick: [item: AppSideMenuItem] }>();
 
 <style scoped>
 .app-side-menu {
-  min-height: 100vh;
+  /* Bounded height, so .app-side-menu-content's overflow-y below actually
+     engages. With min-height the flex container grows past the viewport, the
+     content pane never overflows within it, and the DOCUMENT scrolls instead --
+     carrying the side menu off the top, which is the one thing a persistent
+     nav must not do. The overflow-y rule below was always intended to be the
+     scroll container; it was simply inert.
+     dvh tracks mobile browser chrome; vh is the fallback for older engines. */
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
   display: flex;
+}
+
+.app-side-menu > goa-work-side-menu {
+  /* A nav longer than the viewport scrolls within its own column rather than
+     being clipped by the container's overflow: hidden. */
+  overflow-y: auto;
+  flex: 0 0 auto;
 }
 
 .app-side-menu-content {

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -93,6 +93,16 @@ describe('Vue Components Generator', () => {
     const formattersSrc = host
       .read('libs/vue-components/src/lib/formatters.ts')
       .toString();
+    // The staff shell must scroll its content, not the document -- otherwise
+    // the persistent side menu scrolls off the top. Verified in a real browser;
+    // this pins the rule so it can't regress to min-height.
+    const sideMenu = host
+      .read('libs/vue-components/src/lib/patterns/AppSideMenu.vue')
+      .toString();
+    expect(sideMenu).toContain('height: 100dvh');
+    expect(sideMenu).toContain('overflow: hidden');
+    expect(sideMenu).not.toContain('min-height: 100vh');
+
     // goa-form-stepper's `step` prop drives the progress bar; without it every
     // page of a wizard renders step one as current.
     const stepper = host


### PR DESCRIPTION
Reported from looking at a real generated staff app: the internal layout scrolls the document, so the persistent side menu scrolls off the top — the one thing a persistent nav must not do.

## The intent was already in the code, and inert

`.app-side-menu-content` has `overflow-y: auto`, but the container was `min-height: 100vh`. The flex container therefore grows past the viewport, the content pane never overflows *within* it, and the document becomes the scroll container instead.

Measured in the running app before the fix (Chromium, 1280×700):

```
document.scrollHeight        1256   (viewport 700)  → document scrolls
main.scrollHeight === clientHeight  → the overflow-y rule never engages
menu top: 0 → -400 after scrolling 400px
```

## The fix

Bound the container's height so the existing rule works: `height: 100dvh` with `100vh` as the fallback for older engines, plus `overflow: hidden`. The nav column gets its own `overflow-y: auto` so a menu longer than the viewport scrolls rather than being clipped by that `overflow: hidden`.

## Verified in a browser, both viewports

| | 1280×700 | 390×844 |
|---|---|---|
| document scrolls | no | no |
| content pane scrolls | yes | yes |
| menu top through a content scroll | 0 → 0 | 0 → 0 |
| content reaches its bottom | yes | yes |
| pagination lands in viewport | yes | yes |

The last two rows matter as much as the first: the obvious way to get this wrong is to trade a scroll bug for a clipping bug, so the probe checks the end of the content is still reachable at both widths.

A generator assertion pins the rule (`height: 100dvh`, `overflow: hidden`, and no `min-height: 100vh`) so it can't regress — CSS layout isn't meaningfully testable in jsdom, so the browser probe is the real verification and the assertion is the guard.

## One thing left deliberately undone

`goa-workspace-layout` exists in `@abgov/web-components` with exactly the right slots — `side-menu`, `page-header`, `default`, `page-footer`, `push-drawer` — and is used **nowhere** in this plugin. Adopting it is very likely the structurally correct answer rather than hand-rolling a flex shell, and it would be the fourth instance of the pattern where the design system already has the element.

But it's a rewrite of the component every internal app depends on, and it needs its own visual verification. This change fixes the reported defect without pre-empting that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)