### PR TITLE
feat(nx-adsp): give generated staff views a side-menu nav entry

### DIFF
--- a/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.ts
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.ts
@@ -7,6 +7,7 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import { insertVueRoute } from '../../utils/vue-router';
+import { insertSideMenuItem } from '../../utils/vue-side-menu';
 import vueComponentsGenerator, {
   vueComponentsImportPath,
 } from '../vue-components/vue-components';
@@ -80,6 +81,12 @@ export default async function (host: Tree, options: Schema) {
     componentImportPath: `../views/${normalizedOptions.listViewFileName}.vue`,
     requiresAuth: normalizedOptions.requiresAuth,
     layout: 'wide',
+  });
+
+  // The list is the nav destination; the edit form is reached from it.
+  insertSideMenuItem(host, normalizedOptions.projectRoot, {
+    label: normalizedOptions.heading,
+    to: normalizedOptions.route,
   });
 
   await formatFiles(host);

--- a/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/AGENTS.md__tmpl__
@@ -234,34 +234,31 @@ mark what's meant to be edited.
    { path: '/queue', component: () => import('../views/QueueView.vue'), meta: { layout: 'wide' } }
    { path: '/apply', component: () => import('../views/ApplyView.vue'), meta: { layout: 'form' } }
    ```
-3. **For the `internal` layout: add a nav link to `src/App.vue`.** The generated shell only
-   populates `accountItems`; primary navigation lives in `primaryItems` (or `secondaryItems`).
-   `AppSideMenu` emits one `itemClick` for all slots — the generated `onItemClick` already
-   dispatches by `item.to`: items with a `to` route, items without sign in/out. Add only
-   `primaryItems`:
+3. **For the `internal` layout: check the side-menu nav.** `src/App.vue` has a plain
+   `primaryItems` array — the app's own navigation list, seeded with Home. Each `vue-*-view`
+   generator that adds a staff screen appends its entry automatically, so a generated route is
+   navigable without you doing anything.
+
+   It is a literal array, not derived from the router, on purpose: nav order, grouping and
+   labels are decisions this app owns. Reorder, relabel, group into `secondaryItems`, or prune
+   freely — the generators only ever append, and never touch an entry that already exists for
+   that route.
 
    ```typescript
-   // In <script setup> — route, router, and onItemClick are already in the generated App.vue:
-   // Icon names from the GoA icon set: design.alberta.ca/components/icons
-   const primaryItems = computed(() => [
-     { label: 'Home',       to: '/',           icon: 'home', current: route.path === '/' },
-     { label: 'My Feature', to: '/my-feature', icon: 'list', current: route.path.startsWith('/my-feature') },
-   ])
+   const primaryItems = [
+     { label: 'Home', to: '/', icon: 'home' },
+     { label: 'Review queue', to: '/queue' },   // added by vue-workspace-view
+   ];
    ```
 
-   ```html
-   <!-- In <template>, add :primary-items to <AppSideMenu>
-        (@item-click="onItemClick" is already wired in the generated shell): -->
-   <AppSideMenu
-     heading="..."
-     :primary-items="primaryItems"
-     :account-items="accountItems"
-     @item-click="onItemClick"
-   >
-   ```
+   Two things worth adding by hand: **`icon`** is effectively required —
+   `goa-work-side-menu-item` renders a blank item without one, and the generators can't guess it
+   (icon names: [design.alberta.ca/components/icons](https://design.alberta.ca/components/icons)).
+   And **`current`** for active highlighting, e.g. `current: route.path.startsWith('/queue')`,
+   which needs the `route` already in scope.
 
-   The `header` layout has no side menu — add route-level breadcrumbs or a secondary nav
-   directly inside the view component instead.
+   The `header` layout has no side menu, so it has no `primaryItems` array and the generators
+   skip the step silently — use route-level breadcrumbs or a nav inside the view instead.
 
 ## Backend API calls (proxy setup)
 

--- a/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-app/files/src/App.vue__tmpl__
@@ -32,6 +32,14 @@ function signInAgain() {
 }
 <% if (layout === 'internal') { %>
 
+// The app's main navigation. Every `vue-*-view` generator that adds a staff
+// screen appends an entry here, and it is yours to reorder, relabel, group or
+// prune -- a generated app is a starting point, not a fixed shell. Items are
+// `{ label, to }`; add `icon` for a leading icon or `badge` for a count.
+const primaryItems = [
+  { label: 'Home', to: '/' },
+];
+
 // AppSideMenu's items are presentational — it doesn't know about Keycloak or
 // routing; it just renders whatever's passed and emits itemClick on click.
 const accountItems = computed(() => [
@@ -56,6 +64,7 @@ function onItemClick(item: { to?: string }) {
 <% if (layout === 'internal') { %>
   <AppSideMenu
     heading="<%= projectName %>"
+    :primary-items="primaryItems"
     :account-items="accountItems"
     @item-click="onItemClick"
   >

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.spec.ts
@@ -193,6 +193,12 @@ describe('Vue App Generator', () => {
     expect(app).toContain('<AppFooter />');
   }, 30000);
 
+  it('the header layout has no side-menu nav array (there is no side menu)', async () => {
+    await generator(host, options);
+    const app = host.read('apps/test/src/App.vue').toString();
+    expect(app).not.toContain('primaryItems');
+  });
+
   it('--layout=internal generates an AppSideMenu shell instead of AppHeader/AppFooter', async () => {
     await generator(host, { ...options, layout: 'internal' });
 
@@ -206,6 +212,12 @@ describe('Vue App Generator', () => {
     expect(app).toContain('<AppSideMenu');
     expect(app).toContain('heading="test"');
     expect(app).toContain(':account-items="accountItems"');
+    // A plain, editable nav array -- the app's own list, seeded with Home and
+    // appended to by each staff view generator. Not derived from the router:
+    // nav order, grouping and labels are the owning team's decisions.
+    expect(app).toContain(':primary-items="primaryItems"');
+    expect(app).toContain('const primaryItems = [');
+    expect(app).toContain("{ label: 'Home', to: '/' },");
     expect(app).toContain('@item-click="onItemClick"');
     // The content gutter is shared regardless of shell choice.
     expect(app).toContain('<AppLayout');

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
@@ -9,6 +9,13 @@ import { Schema } from './schema';
 
 // Mirrors the shape vue-app's own template generates -- vue-workspace-view
 // retrofits into this file, so the fixture must match what it actually looks for.
+const APP_VUE_INTERNAL_FIXTURE = `<script setup lang="ts">
+const primaryItems = [
+  { label: 'Home', to: '/' },
+];
+</script>
+`;
+
 const ROUTER_FIXTURE = `import { createRouter, createWebHistory } from 'vue-router';
 import HomeView from '../views/HomeView.vue';
 
@@ -41,6 +48,7 @@ describe('Vue Workspace View Generator', () => {
     host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
     addProjectConfiguration(host, 'test', { root: 'apps/test' });
     host.write('apps/test/src/router/index.ts', ROUTER_FIXTURE);
+    host.write('apps/test/src/App.vue', APP_VUE_INTERNAL_FIXTURE);
   });
 
   it('throws when --project does not exist', async () => {
@@ -263,6 +271,13 @@ describe('Vue Workspace View Generator', () => {
     expect(view).toContain(':per-page-count="50"');
   }, 30000);
 
+  it('adds nothing to the side menu when the app has no App.vue', async () => {
+    host.delete('apps/test/src/App.vue');
+    // A header-layout app has no side menu; adding a staff view to one must not
+    // fail, it simply has no nav to join.
+    await expect(generator(host, baseOptions)).resolves.not.toThrow();
+  });
+
   it('inserts the route into router/index.ts, requiring auth by default', async () => {
     await generator(host, baseOptions);
 
@@ -274,6 +289,10 @@ describe('Vue Workspace View Generator', () => {
     expect(routerTs).toContain('requiresAuth: true');
     // A data table asks for the wide variant -- the generator knows it emitted one.
     expect(routerTs).toContain("layout: 'wide'");
+    // A staff queue is a nav destination, so the generator adds it to the
+    // app's side-menu list rather than leaving the route reachable only by URL.
+    const appVue = host.read('apps/test/src/App.vue').toString();
+    expect(appVue).toContain("to: '/applications'");
     expect(routerTs).toContain("{ path: '/', component: HomeView }");
   }, 30000);
 

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.ts
@@ -7,6 +7,7 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import { insertVueRoute } from '../../utils/vue-router';
+import { insertSideMenuItem } from '../../utils/vue-side-menu';
 import vueComponentsGenerator, {
   vueComponentsImportPath,
 } from '../vue-components/vue-components';
@@ -100,6 +101,12 @@ export default async function (host: Tree, options: Schema) {
     requiresAuth: normalizedOptions.requiresAuth,
     // A multi-column table at the 1000px default wraps every cell.
     layout: 'wide',
+  });
+
+  // No-op on a header-layout app, which has no side menu.
+  insertSideMenuItem(host, normalizedOptions.projectRoot, {
+    label: normalizedOptions.heading,
+    to: normalizedOptions.route,
   });
 
   await formatFiles(host);

--- a/packages/nx-adsp/src/utils/vue-side-menu.spec.ts
+++ b/packages/nx-adsp/src/utils/vue-side-menu.spec.ts
@@ -1,0 +1,71 @@
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { insertSideMenuItem } from './vue-side-menu';
+
+const INTERNAL_APP = `<script setup lang="ts">
+const primaryItems = [
+  { label: 'Home', to: '/' },
+];
+</script>
+`;
+
+// A header-layout app has no side menu at all, so no array to insert into.
+const HEADER_APP = `<script setup lang="ts">
+const accountItems = computed(() => []);
+</script>
+`;
+
+describe('insertSideMenuItem', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  it('inserts an item into the app nav array', () => {
+    host.write('apps/staff/src/App.vue', INTERNAL_APP);
+    insertSideMenuItem(host, 'apps/staff', {
+      label: 'Review queue',
+      to: '/queue',
+    });
+    const app = host.read('apps/staff/src/App.vue').toString();
+    expect(app).toContain("{ label: 'Review queue', to: '/queue' },");
+    // The seeded Home entry survives.
+    expect(app).toContain("{ label: 'Home', to: '/' },");
+  });
+
+  it('is idempotent on the same route', () => {
+    host.write('apps/staff/src/App.vue', INTERNAL_APP);
+    const item = { label: 'Review queue', to: '/queue' };
+    insertSideMenuItem(host, 'apps/staff', item);
+    insertSideMenuItem(host, 'apps/staff', item);
+    const app = host.read('apps/staff/src/App.vue').toString();
+    expect(app.split("to: '/queue'").length - 1).toBe(1);
+  });
+
+  it('does not re-add a route already present under a different label', () => {
+    host.write('apps/staff/src/App.vue', INTERNAL_APP);
+    insertSideMenuItem(host, 'apps/staff', { label: 'Queue', to: '/queue' });
+    insertSideMenuItem(host, 'apps/staff', { label: 'Renamed', to: '/queue' });
+    const app = host.read('apps/staff/src/App.vue').toString();
+    expect(app).toContain("label: 'Queue'");
+    expect(app).not.toContain("label: 'Renamed'");
+  });
+
+  it('is a silent no-op on a header-layout app with no side menu', () => {
+    host.write('apps/public/src/App.vue', HEADER_APP);
+    expect(() =>
+      insertSideMenuItem(host, 'apps/public', {
+        label: 'Review queue',
+        to: '/queue',
+      }),
+    ).not.toThrow();
+    expect(host.read('apps/public/src/App.vue').toString()).toBe(HEADER_APP);
+  });
+
+  it('is a silent no-op when there is no App.vue at all', () => {
+    expect(() =>
+      insertSideMenuItem(host, 'apps/missing', { label: 'X', to: '/x' }),
+    ).not.toThrow();
+  });
+});

--- a/packages/nx-adsp/src/utils/vue-side-menu.ts
+++ b/packages/nx-adsp/src/utils/vue-side-menu.ts
@@ -1,0 +1,53 @@
+import { Tree } from '@nx/devkit';
+
+export interface SideMenuItemSpec {
+  /** Nav label shown in the side menu, e.g. 'Review queue'. */
+  label: string;
+  /** Route path the item navigates to, e.g. '/queue'. */
+  to: string;
+}
+
+// Deterministic text insertion into vue-app's `primaryItems` array, mirroring
+// insertVueRoute's approach for the same reason: the template's shape is fixed,
+// so a targeted anchor beats pulling in an AST library for one array entry.
+//
+// The array is a plain literal in App.vue rather than something derived from the
+// router, deliberately: a generated app is an opinionated starting point, and
+// nav order, grouping and labels are decisions the owning team should be able to
+// read and change in one obvious place -- not behaviour resolved at runtime by
+// the shell that every app then has to work around.
+const ANCHOR = 'const primaryItems = [';
+
+/**
+ * Adds a nav item to a generated app's side menu.
+ *
+ * A no-op when the app has no `primaryItems` array. That is the signal the app
+ * was generated with `--layout=header` (a public app has no side menu at all),
+ * so adding a staff view to it should not fail or warn -- there is simply no nav
+ * to add to.
+ *
+ * Idempotent: re-running a generator, or two generators claiming the same path,
+ * leaves one entry.
+ */
+export function insertSideMenuItem(
+  host: Tree,
+  projectRoot: string,
+  item: SideMenuItemSpec,
+): void {
+  const appPath = `${projectRoot}/src/App.vue`;
+  const content = host.read(appPath)?.toString();
+  if (content === undefined) return;
+
+  const anchorIndex = content.indexOf(ANCHOR);
+  if (anchorIndex === -1) return;
+
+  if (content.includes(`to: '${item.to}'`)) return;
+
+  const insertAt = anchorIndex + ANCHOR.length;
+  host.write(
+    appPath,
+    content.slice(0, insertAt) +
+      `\n  { label: '${item.label}', to: '${item.to}' },` +
+      content.slice(insertAt),
+  );
+}


### PR DESCRIPTION
Sixth of the seven tier-2 items. Generating a staff app with three screens produced three routes reachable **only by typing URLs** — the side menu rendered a heading, one account item, and nothing navigable.

`AppSideMenu` accepts `primaryItems`, but `App.vue` passed only `accountItems` (sign in/out). The generated `AGENTS.md` documented adding nav items as a manual step without saying the app is unnavigable until you do.

## What changed

`vue-app`'s internal layout emits a plain `primaryItems` array seeded with Home, and `vue-workspace-view` and `vue-admin-crud` append their entry — the *list* for admin-crud, not the edit form, since the form is reached from the list.

```typescript
const primaryItems = [
  { label: 'Home', to: '/', icon: 'home' },
  { label: 'Review queue', to: '/queue' },   // added by vue-workspace-view
];
```

## Why a literal array, not derived from the router

The alternative was computing nav from routes carrying a `meta.nav` label — reusing the meta mechanism from #445, fewer moving parts, and `current` highlighting for free. **Rejected deliberately.**

A generator produces an opinionated starting point. Deriving nav at runtime bakes a *policy* — nav is every route with a flag, ordered by registration — into a shell every app inherits and would then have to work against. Order, grouping and labels are the owning team's decisions, so they belong in one visible list that team can read and change.

## `insertSideMenuItem`

Mirrors `insertVueRoute`: deterministic text insertion at a fixed anchor, no AST library for one array entry.

- **Silent no-op when the array is absent.** That's the signal the app was generated with `--layout=header` and has no side menu — adding a staff view to a public app shouldn't fail, there's simply no nav to join. Tested, including the no-`App.vue` case.
- **Idempotent by route.** Re-running a generator, or two generators claiming one path, leaves one entry — including when the second call uses a different label.

## Docs

The AGENTS.md section described hand-writing the whole computed array, which is now wrong. Rewritten to say what the generators do, that the array is yours to reorder and prune, and to name the two things they can't supply: **`icon`** (`goa-work-side-menu-item` renders blank without one, and the generator can't guess it) and **`current`** for active highlighting.

## Verification

27 suites, 208 tests (was 201): 5 for the new utility, plus generator assertions that the internal layout gets the array and the header layout doesn't.

## Tier 2 status

| Item | |
|---|---|
| `meta.layout` | merged #445 |
| `formatDate` for date columns | merged #444 |
| `--filters` wiring `FilterBar` | merged #445 |
| `Stepper` `step` | merged #445 |
| staff shell scroll containment | merged #446 |
| **staff nav entries** | **this PR** |
| richer field types | remaining |

🤖 Generated with [Claude Code](https://claude.com/claude-code)