### PR TITLE
feat(nx-adsp): support date, select, number and textarea fields

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -333,7 +333,7 @@ npx nx g @abgov/nx-adsp:vue-admin-crud my-app --name=regions --resource=regions 
 | `name`          | Yes      | View name, e.g. `regions` generates `src/views/RegionsListView.vue` and `src/views/RegionsEditView.vue`                                                             |
 | `resource`      | Yes      | API resource path segment — fetches `/api/<resource>` (list), `/api/<resource>/:id` (load one), `POST /api/<resource>` (create), `PUT /api/<resource>/:id` (update) |
 | `route`         | Yes      | List route path added to `router/index.ts`, e.g. `/regions`. The edit/create route is added as `${route}/:id` (visiting `${route}/new` creates)                     |
-| `fields`        | Yes      | JSON array of fields, in display/form order: `{ key, label, type?: "text"\|"checkbox", required? }` (a JSON string — see note below)                                |
+| `fields`        | Yes      | JSON array of fields, in display/form order: `{ key, label, type?: "text"\|"textarea"\|"number"\|"date"\|"select"\|"checkbox", options? (select), required? }` (a JSON string — see note below)                                |
 | `heading`       | No       | List page heading. Defaults to the view name, title-cased                                                                                                           |
 | `singularLabel` | No       | Singular label used in "Create <label>"/"Edit <label>" headings and buttons. Defaults to `--heading` (override for irregular plurals)                               |
 | `requiresAuth`  | No       | Whether the generated routes require authentication. Defaults to `true`                                                                                             |
@@ -342,7 +342,7 @@ npx nx g @abgov/nx-adsp:vue-admin-crud my-app --name=regions --resource=regions 
 
 ### vue-intake-view
 
-Adds a route-per-step intake wizard (`Stepper` + `StepErrorSummary`, a required read-only review step, and a confirmation page) to an existing `vue-app` project. Cross-step state is server-persisted — each step PUTs/POSTs to `/api/<resource>/:id` and refetches on mount, so there's no client-side draft caching. Every field is currently a plain text input.
+Adds a route-per-step intake wizard (`Stepper` + `StepErrorSummary`, a required read-only review step, and a confirmation page) to an existing `vue-app` project. Cross-step state is server-persisted — each step PUTs/POSTs to `/api/<resource>/:id` and refetches on mount, so there's no client-side draft caching. Fields support `text`, `textarea`, `number`, `date` and `select` types; a number is submitted as a number and a date as `YYYY-MM-DD`.
 
 ```bash
 npx nx g @abgov/nx-adsp:vue-intake-view my-app --name=application --resource=applications --route=/applications --steps='[{"key":"personal-info","label":"Personal information","fields":[{"key":"fullName","label":"Full name"}]}]'

--- a/packages/nx-adsp/src/generators/vue-admin-crud/files/src/views/__editViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/files/src/views/__editViewFileName__.vue__tmpl__
@@ -2,7 +2,27 @@
 import { reactive, ref, computed, watch, onUnmounted } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { useKeycloak } from '@dsb-norge/vue-keycloak-js';
-import { GoabInput, GoabCheckbox } from '<%= goaImportPath %>';
+import {
+<% if (fields.some((f) => !f.type || f.type === 'text' || f.type === 'number')) { -%>
+  GoabInput,
+<% } -%>
+<% if (fields.some((f) => f.type === 'textarea')) { -%>
+  GoabTextarea,
+<% } -%>
+<% if (fields.some((f) => f.type === 'date')) { -%>
+  GoabDatePicker,
+<% } -%>
+<% if (fields.some((f) => f.type === 'select')) { -%>
+  GoabDropdown,
+<% } -%>
+<% if (fields.some((f) => f.type === 'checkbox')) { -%>
+  GoabCheckbox,
+<% } -%>
+<% if (fields.some((f) => f.type === 'date')) { -%>
+  fromIsoDateString,
+  toIsoDateString,
+<% } -%>
+} from '<%= goaImportPath %>';
 import { useApi } from '../composables/useApi';
 
 const route = useRoute();
@@ -15,7 +35,7 @@ const isNew = computed(() => idParam.value === 'new' || idParam.value === '');
 
 const form = reactive({
 <% fields.forEach(function (field) { -%>
-  <%- field.key %>: <%- field.type === 'checkbox' ? 'false' : "''" %>,
+  <%- field.key %>: <%- field.type === 'checkbox' ? 'false' : field.type === 'date' ? 'undefined as Date | undefined' : "''" %>,
 <% }); -%>
 });
 
@@ -37,7 +57,15 @@ async function load() {
   try {
     const data = await get('<%= resource %>', idParam.value);
 <% fields.forEach(function (field) { -%>
+<% if (field.type === 'date') { -%>
+    if (data['<%= field.key %>'] !== undefined)
+      form.<%= field.key %> = fromIsoDateString(data['<%= field.key %>']);
+<% } else if (field.type === 'number') { -%>
+    if (data['<%= field.key %>'] !== undefined)
+      form.<%= field.key %> = String(data['<%= field.key %>']);
+<% } else { -%>
     if (data['<%= field.key %>'] !== undefined) form.<%= field.key %> = data['<%= field.key %>'];
+<% } -%>
 <% }); -%>
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : 'Failed to load.';
@@ -77,8 +105,34 @@ function validate(): boolean {
   let valid = true;
 <% fields.forEach(function (field) { -%>
 <% if (field.type !== 'checkbox' && field.required !== false) { -%>
+<% if (field.type === 'date') { -%>
+  if (!form.<%= field.key %>) {
+    errors.<%= field.key %> = '<%= field.label %> is required.';
+    valid = false;
+  } else {
+    errors.<%= field.key %> = undefined;
+  }
+<% } else if (field.type === 'number') { -%>
+  if (form.<%= field.key %> === '') {
+    errors.<%= field.key %> = '<%= field.label %> is required.';
+    valid = false;
+  } else if (!Number.isFinite(Number(form.<%= field.key %>))) {
+    errors.<%= field.key %> = '<%= field.label %> must be a number.';
+    valid = false;
+  } else {
+    errors.<%= field.key %> = undefined;
+  }
+<% } else { -%>
   if (!form.<%= field.key %> || !form.<%= field.key %>.trim()) {
     errors.<%= field.key %> = '<%= field.label %> is required.';
+    valid = false;
+  } else {
+    errors.<%= field.key %> = undefined;
+  }
+<% } -%>
+<% } else if (field.type === 'number') { -%>
+  if (form.<%= field.key %> !== '' && !Number.isFinite(Number(form.<%= field.key %>))) {
+    errors.<%= field.key %> = '<%= field.label %> must be a number.';
     valid = false;
   } else {
     errors.<%= field.key %> = undefined;
@@ -88,13 +142,29 @@ function validate(): boolean {
   return valid;
 }
 
+// The form model holds what each CONTROL needs (a Date for a picker, a string
+// for a number input); the API wants wire types. Converting here keeps that
+// difference in one place instead of at every call site.
+function payload() {
+  return {
+    ...form,
+<% fields.forEach(function (field) { -%>
+<% if (field.type === 'number') { -%>
+    <%- field.key %>: form.<%- field.key %> === '' ? null : Number(form.<%- field.key %>),
+<% } else if (field.type === 'date') { -%>
+    <%- field.key %>: toIsoDateString(form.<%- field.key %>) || null,
+<% } -%>
+<% }); -%>
+  };
+}
+
 async function onSubmit() {
   if (!validate()) return;
   saving.value = true;
   saveError.value = null;
   try {
     // Create vs. update — which verb and path that means is the adapter's call.
-    await save('<%= resource %>', isNew.value ? null : idParam.value, form);
+    await save('<%= resource %>', isNew.value ? null : idParam.value, payload());
     successMessage.value = isNew.value ? '<%= singularLabel %> created.' : '<%= singularLabel %> saved.';
     redirectTimer = setTimeout(() => router.push('<%= route %>'), 600);
   } catch (e) {
@@ -135,12 +205,28 @@ onUnmounted(() => {
     <form v-else @submit.prevent="onSubmit">
 <% fields.forEach(function (field) { -%>
 <% if (field.type === 'checkbox') { -%>
-      <goa-form-item label="<%= field.label %>">
+      <!-- The checkbox carries its own label via `text`; goa-form-item must not
+           repeat it, or it renders twice. -->
+      <goa-form-item>
         <GoabCheckbox v-model="form.<%= field.key %>" name="<%= field.key %>" text="<%= field.label %>" />
       </goa-form-item>
 <% } else { -%>
       <goa-form-item label="<%= field.label %>"<% if (field.required !== false) { %> requirement="required"<% } %> :error="errors.<%= field.key %>">
+<% if (field.type === 'textarea') { -%>
+        <GoabTextarea v-model="form.<%= field.key %>" name="<%= field.key %>" />
+<% } else if (field.type === 'number') { -%>
+        <GoabInput v-model="form.<%= field.key %>" name="<%= field.key %>" type="number" />
+<% } else if (field.type === 'date') { -%>
+        <GoabDatePicker v-model="form.<%= field.key %>" name="<%= field.key %>" />
+<% } else if (field.type === 'select') { -%>
+        <GoabDropdown v-model="form.<%= field.key %>" name="<%= field.key %>">
+<% (field.options || []).forEach(function (option) { -%>
+          <goa-dropdown-item value="<%- option.value %>" label="<%- option.label %>" />
+<% }); -%>
+        </GoabDropdown>
+<% } else { -%>
         <GoabInput v-model="form.<%= field.key %>" name="<%= field.key %>" type="text" />
+<% } -%>
       </goa-form-item>
 <% } -%>
 <% }); -%>

--- a/packages/nx-adsp/src/generators/vue-admin-crud/schema.d.ts
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/schema.d.ts
@@ -1,7 +1,9 @@
 export interface AdminCrudField {
   key: string;
   label: string;
-  type?: 'text' | 'checkbox';
+  type?: 'text' | 'textarea' | 'number' | 'date' | 'select' | 'checkbox';
+  /** `select` only. Rendered as goa-dropdown-item children. */
+  options?: { value: string; label: string }[];
   required?: boolean;
 }
 

--- a/packages/nx-adsp/src/generators/vue-admin-crud/schema.json
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/schema.json
@@ -33,7 +33,7 @@
     },
     "fields": {
       "type": "string",
-      "description": "JSON array of fields, in display/form order -- e.g. '[{\"key\":\"name\",\"label\":\"Name\"},{\"key\":\"active\",\"label\":\"Active\",\"type\":\"checkbox\"}]'. Each item: { key, label, type?: \"text\"|\"checkbox\" (default \"text\"), required?: boolean (default true for \"text\", ignored for \"checkbox\") }. A plain array is also accepted when this generator is invoked programmatically."
+      "description": "JSON array of fields, in display/form order -- e.g. '[{\"key\":\"name\",\"label\":\"Name\"},{\"key\":\"quota\",\"label\":\"Quota\",\"type\":\"number\"},{\"key\":\"region\",\"label\":\"Region\",\"type\":\"select\",\"options\":[{\"value\":\"north\",\"label\":\"North\"}]}]'. Each item: { key, label, type?: \"text\"|\"textarea\"|\"number\"|\"date\"|\"select\"|\"checkbox\" (default \"text\"), options?: [{value,label}] (select only), required?: boolean }. A number field is submitted as a number and a date as YYYY-MM-DD built from local calendar parts. A plain array is also accepted when invoked programmatically. Nx's CLI option coercion only supports comma-separated primitive lists for array-typed schema properties, not JSON -- a JSON string is the only CLI syntax that survives Nx's own arg parsing."
     },
     "heading": {
       "type": "string",
@@ -49,6 +49,12 @@
       "default": true
     }
   },
-  "required": ["project", "name", "resource", "route", "fields"],
+  "required": [
+    "project",
+    "name",
+    "resource",
+    "route",
+    "fields"
+  ],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.spec.ts
@@ -94,7 +94,11 @@ describe('Vue Admin CRUD Generator', () => {
     expect(view).not.toContain('errors.active');
     // Create vs. update is expressed as a null id; which verb and path that
     // becomes is decided by useApi's adapter.
-    expect(view).toContain("await save('regions', isNew.value ? null : idParam.value, form)");
+    // payload(), not the raw form: the model holds what the controls need, the
+    // API wants wire types.
+    expect(view).toContain(
+      "await save('regions', isNew.value ? null : idParam.value, payload())",
+    );
     expect(view).toContain("await get('regions', idParam.value)");
     expect(view).not.toContain('apiFetch');
     expect(view).not.toContain("'PUT'");
@@ -116,6 +120,104 @@ describe('Vue Admin CRUD Generator', () => {
     expect(view).toContain('Create Regions');
     expect(view).toContain('Edit Regions');
   }, 30000);
+
+  describe('field types', () => {
+    const allTypes = JSON.stringify([
+      { key: 'name', label: 'Name' },
+      { key: 'notes', label: 'Notes', type: 'textarea', required: false },
+      { key: 'quota', label: 'Quota', type: 'number' },
+      { key: 'effective', label: 'Effective', type: 'date' },
+      {
+        key: 'region',
+        label: 'Region',
+        type: 'select',
+        options: [
+          { value: 'north', label: 'North' },
+          { value: 'south', label: 'South' },
+        ],
+      },
+      { key: 'active', label: 'Active', type: 'checkbox' },
+    ]);
+
+    it('renders the right control for each type', async () => {
+      await generator(host, { ...baseOptions, fields: allTypes });
+      const view = host
+        .read('apps/test/src/views/RegionsEditView.vue')
+        .toString();
+      expect(view).toContain('<GoabInput v-model="form.name"');
+      expect(view).toContain('<GoabTextarea v-model="form.notes"');
+      expect(view).toContain('type="number"');
+      expect(view).toContain('<GoabDatePicker v-model="form.effective"');
+      expect(view).toContain('<GoabDropdown v-model="form.region"');
+      expect(view).toContain('<goa-dropdown-item value="north" label="North" />');
+      expect(view).toContain('<GoabCheckbox v-model="form.active"');
+    });
+
+    it('imports only the wrappers the field set actually uses', async () => {
+      await generator(host, {
+        ...baseOptions,
+        fields: JSON.stringify([{ key: 'name', label: 'Name' }]),
+      });
+      const view = host
+        .read('apps/test/src/views/RegionsEditView.vue')
+        .toString();
+      expect(view).toContain('GoabInput');
+      for (const unused of ['GoabTextarea', 'GoabDatePicker', 'GoabDropdown']) {
+        expect(view).not.toContain(unused);
+      }
+    });
+
+    it('submits a number as a number and a date as a local-calendar string', async () => {
+      await generator(host, { ...baseOptions, fields: allTypes });
+      const view = host
+        .read('apps/test/src/views/RegionsEditView.vue')
+        .toString();
+      expect(view).toContain("quota: form.quota === '' ? null : Number(form.quota)");
+      expect(view).toContain('effective: toIsoDateString(form.effective) || null');
+      // A stored YYYY-MM-DD comes back as a Date the picker can redisplay.
+      expect(view).toContain("fromIsoDateString(data['effective'])");
+    });
+
+    it('validates by type, not by assuming every value is a string', async () => {
+      await generator(host, { ...baseOptions, fields: allTypes });
+      const view = host
+        .read('apps/test/src/views/RegionsEditView.vue')
+        .toString();
+      // A number field's required check cannot be !value.trim().
+      expect(view).toContain("if (form.quota === '')");
+      expect(view).toContain('Quota must be a number.');
+      // A date field holds a Date, so truthiness is the check.
+      expect(view).toContain('if (!form.effective)');
+    });
+
+    it('does not label a checkbox twice', async () => {
+      await generator(host, { ...baseOptions, fields: allTypes });
+      const view = host
+        .read('apps/test/src/views/RegionsEditView.vue')
+        .toString();
+      // goa-form-item must not repeat the label the checkbox already carries.
+      expect(view).not.toContain('<goa-form-item label="Active"');
+      expect(view).toContain('text="Active"');
+    });
+
+    it('rejects a type it cannot render', async () => {
+      await expect(
+        generator(host, {
+          ...baseOptions,
+          fields: JSON.stringify([{ key: 'x', label: 'X', type: 'colour' }]),
+        }),
+      ).rejects.toThrow('got "colour" for "x"');
+    });
+
+    it('requires options for a select, since it cannot know the choices', async () => {
+      await expect(
+        generator(host, {
+          ...baseOptions,
+          fields: JSON.stringify([{ key: 'r', label: 'R', type: 'select' }]),
+        }),
+      ).rejects.toThrow(/options is required for the select field "r"/);
+    });
+  });
 
   it('uses --singularLabel over --heading for Create/Edit headings when both are set', async () => {
     await generator(host, {

--- a/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.ts
+++ b/packages/nx-adsp/src/generators/vue-admin-crud/vue-admin-crud.ts
@@ -29,6 +29,30 @@ function parseFields(fields: Schema['fields']): AdminCrudField[] {
   return parsed;
 }
 
+const FIELD_TYPES = [
+  'text',
+  'textarea',
+  'number',
+  'date',
+  'select',
+  'checkbox',
+] as const;
+
+function assertFieldTypes(fields: { key: string; type?: string; options?: unknown }[]) {
+  for (const field of fields) {
+    if (field.type && !FIELD_TYPES.includes(field.type as never)) {
+      throw new Error(
+        `--fields[].type must be one of ${FIELD_TYPES.join(', ')}; got "${field.type}" for "${field.key}".`,
+      );
+    }
+    if (field.type === 'select' && !Array.isArray(field.options)) {
+      throw new Error(
+        `--fields[].options is required for the select field "${field.key}" -- the generator cannot know its choices.`,
+      );
+    }
+  }
+}
+
 function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   const { root: projectRoot } = readProjectConfiguration(host, options.project);
 
@@ -39,7 +63,11 @@ function normalizeOptions(host: Tree, options: Schema): NormalizedSchema {
   return {
     ...options,
     projectRoot,
-    fields: parseFields(options.fields),
+    fields: (() => {
+      const fields = parseFields(options.fields);
+      assertFieldTypes(fields);
+      return fields;
+    })(),
     listViewFileName: `${className}ListView`,
     editViewFileName: `${className}EditView`,
     heading,

--- a/packages/nx-adsp/src/generators/vue-components/files/src/index.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/index.ts__tmpl__
@@ -34,6 +34,8 @@ export { default as StepErrorSummary } from './lib/patterns/StepErrorSummary.vue
 export { default as FilterBar } from './lib/patterns/FilterBar.vue';
 
 export {
+  fromIsoDateString,
+  toIsoDateString,
   formatCurrency,
   formatDate,
   formatDateTime,

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/formatters.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/formatters.ts__tmpl__
@@ -62,6 +62,29 @@ function toValidDate(value: unknown): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/**
+ * A Date as local-calendar YYYY-MM-DD, for the wire -- a query parameter, a JSON
+ * body. NOT display: use formatDate for that.
+ *
+ * Built from local parts, never toISOString(): that routes through UTC, and the
+ * UTC day of a local-midnight Date is the previous day anywhere west of
+ * Greenwich. In Alberta (UTC-6/-7) it files every date one day early.
+ */
+export function toIsoDateString(value: unknown): string {
+  const date = toValidDate(value);
+  if (!date) return '';
+  const pad = (part: number) => String(part).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/**
+ * The inverse: a stored YYYY-MM-DD back to a Date at local midnight, so the
+ * calendar date a user picked is the calendar date a picker redisplays.
+ */
+export function fromIsoDateString(value: unknown): Date | undefined {
+  return toValidDate(value) ?? undefined;
+}
+
 /** Date without a time component, e.g. `2026-08-28` → `2026-08-28`. */
 export function formatDate(value: unknown): string {
   const date = toValidDate(value);

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/FilterBar.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/FilterBar.vue__tmpl__
@@ -21,6 +21,7 @@ import { computed } from 'vue';
 import GoabDropdown from '../primitives/GoabDropdown.vue';
 import GoabDatePicker from '../primitives/GoabDatePicker.vue';
 import GoabButton from '../primitives/GoabButton.vue';
+import { fromIsoDateString, toIsoDateString } from '../formatters';
 
 export interface FilterOption {
   value: string;
@@ -71,29 +72,18 @@ const dateValues = computed(() =>
       .map((filter) => [
         filter.key,
         model.value[filter.key]
-          ? fromIsoDate(model.value[filter.key])
+          ? fromIsoDateString(model.value[filter.key])
           : undefined,
       ]),
   ),
 );
-
-// Local-calendar YYYY-MM-DD -- see the header note on why not toISOString().
-function toIsoDate(date: Date): string {
-  const pad = (part: number) => String(part).padStart(2, '0');
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
-}
-
-function fromIsoDate(value: string): Date | undefined {
-  const [year, month, day] = value.split('-').map(Number);
-  return year && month && day ? new Date(year, month - 1, day) : undefined;
-}
 
 function set(key: string, value: string) {
   model.value = { ...model.value, [key]: value };
 }
 
 function setDate(key: string, date: Date | undefined) {
-  set(key, date ? toIsoDate(date) : '');
+  set(key, toIsoDateString(date));
 }
 
 function clearAll() {

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -129,8 +129,13 @@ describe('Vue Components Generator', () => {
     }
     // Local calendar parts, not UTC: in Alberta new Date('2026-08-28') is
     // 27 Aug 18:00 local, so a stored date would render as the day before.
-    expect(filterBar).toContain('function toIsoDate');
-    expect(filterBar).toContain('function fromIsoDate');
+    // The local-parts date conversion lives in formatters now, used by
+    // FilterBar and by every generated date field, so the rule has one home.
+    expect(filterBar).toContain('toIsoDateString');
+    expect(filterBar).toContain('fromIsoDateString');
+    expect(filterBar).not.toContain('function toIsoDate');
+    expect(formattersSrc).toContain('export function toIsoDateString');
+    expect(formattersSrc).toContain('export function fromIsoDateString');
     // The call form, not the bare name: the component's own comments explain why
     // toISOString() is wrong, so the name legitimately appears in them.
     expect(filterBar).not.toContain('date.toISOString()');

--- a/packages/nx-adsp/src/generators/vue-intake-view/files/shared/src/views/__reviewViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-intake-view/files/shared/src/views/__reviewViewFileName__.vue__tmpl__
@@ -2,6 +2,9 @@
 import { ref, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { GoabCheckbox } from '<%= goaImportPath %>';
+<% if (steps.some((s) => s.fields.some((f) => f.type === 'date'))) { -%>
+import { formatDate } from '<%= goaImportPath %>';
+<% } -%>
 import { useApi } from '../composables/useApi';
 
 const route = useRoute();
@@ -79,7 +82,11 @@ async function onSubmit() {
         <dl>
 <% step.fields.forEach(function (field) { -%>
           <dt><%- field.label %></dt>
+<% if (field.type === 'date') { -%>
+          <dd>{{ formatDate(record['<%- field.key %>']) }}</dd>
+<% } else { -%>
           <dd>{{ record['<%- field.key %>'] ?? '—' }}</dd>
+<% } -%>
 <% }); -%>
         </dl>
       </goa-container>

--- a/packages/nx-adsp/src/generators/vue-intake-view/files/steps/src/views/__stepViewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-intake-view/files/steps/src/views/__stepViewFileName__.vue__tmpl__
@@ -1,7 +1,24 @@
 <script setup lang="ts">
 import { reactive, ref, computed, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import { Stepper, StepErrorSummary, GoabInput } from '<%= goaImportPath %>';
+import {
+  Stepper,
+  StepErrorSummary,
+<% if (stepFields.some((f) => !f.type || f.type === 'text' || f.type === 'number')) { -%>
+  GoabInput,
+<% } -%>
+<% if (stepFields.some((f) => f.type === 'textarea')) { -%>
+  GoabTextarea,
+<% } -%>
+<% if (stepFields.some((f) => f.type === 'date')) { -%>
+  GoabDatePicker,
+  fromIsoDateString,
+  toIsoDateString,
+<% } -%>
+<% if (stepFields.some((f) => f.type === 'select')) { -%>
+  GoabDropdown,
+<% } -%>
+} from '<%= goaImportPath %>';
 import { useApi } from '../composables/useApi';
 
 const STEPS = [
@@ -19,7 +36,7 @@ const isNew = computed(() => idParam.value === 'new' || idParam.value === '');
 
 const form = reactive({
 <% stepFields.forEach(function (field) { -%>
-  <%- field.key %>: '',
+  <%- field.key %>: <%- field.type === 'date' ? 'undefined as Date | undefined' : "''" %>,
 <% }); -%>
 });
 
@@ -53,7 +70,15 @@ async function load() {
     const data = await get('<%= resource %>', idParam.value);
     completedSteps.value = Array.isArray(data.completedSteps) ? data.completedSteps : [];
 <% stepFields.forEach(function (field) { -%>
+<% if (field.type === 'date') { -%>
+    if (data['<%- field.key %>'] !== undefined)
+      form.<%- field.key %> = fromIsoDateString(data['<%- field.key %>']);
+<% } else if (field.type === 'number') { -%>
+    if (data['<%- field.key %>'] !== undefined)
+      form.<%- field.key %> = String(data['<%- field.key %>']);
+<% } else { -%>
     if (data['<%- field.key %>'] !== undefined) form.<%- field.key %> = data['<%- field.key %>'];
+<% } -%>
 <% }); -%>
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : 'Failed to load.';
@@ -67,7 +92,7 @@ async function load() {
 // rather than reassigned.
 function resetForm() {
 <% stepFields.forEach(function (field) { -%>
-  form.<%- field.key %> = '';
+  form.<%- field.key %> = <%- field.type === 'date' ? 'undefined' : "''" %>;
 <% }); -%>
   errors.value = [];
   completedSteps.value = [];
@@ -94,8 +119,24 @@ function validate(): boolean {
   const found: { message: string; anchor?: string }[] = [];
 <% stepFields.forEach(function (field) { -%>
 <% if (field.required !== false) { -%>
+<% if (field.type === 'date') { -%>
+  if (!form.<%- field.key %>) {
+    found.push({ message: '<%- field.label %> is required.', anchor: '#field-<%- field.key %>' });
+  }
+<% } else if (field.type === 'number') { -%>
+  if (form.<%- field.key %> === '') {
+    found.push({ message: '<%- field.label %> is required.', anchor: '#field-<%- field.key %>' });
+  } else if (!Number.isFinite(Number(form.<%- field.key %>))) {
+    found.push({ message: '<%- field.label %> must be a number.', anchor: '#field-<%- field.key %>' });
+  }
+<% } else { -%>
   if (!form.<%- field.key %> || !form.<%- field.key %>.trim()) {
     found.push({ message: '<%- field.label %> is required.', anchor: '#field-<%- field.key %>' });
+  }
+<% } -%>
+<% } else if (field.type === 'number') { -%>
+  if (form.<%- field.key %> !== '' && !Number.isFinite(Number(form.<%- field.key %>))) {
+    found.push({ message: '<%- field.label %> must be a number.', anchor: '#field-<%- field.key %>' });
   }
 <% } -%>
 <% }); -%>
@@ -118,8 +159,17 @@ async function onSaveAndContinue() {
   saving.value = true;
   saveError.value = null;
   try {
+    // The form model holds what each control needs (a Date for a picker, a
+    // string for a number input); the API wants wire types.
     const body = {
       ...form,
+<% stepFields.forEach(function (field) { -%>
+<% if (field.type === 'number') { -%>
+      <%- field.key %>: form.<%- field.key %> === '' ? null : Number(form.<%- field.key %>),
+<% } else if (field.type === 'date') { -%>
+      <%- field.key %>: toIsoDateString(form.<%- field.key %>) || null,
+<% } -%>
+<% }); -%>
       completedSteps: [...new Set([...completedSteps.value, '<%- stepKey %>'])],
     };
     // A create has to answer with the new record's id for the wizard to advance
@@ -164,7 +214,21 @@ function goBack() {
 
 <% stepFields.forEach(function (field) { -%>
       <goa-form-item id="field-<%- field.key %>" label="<%- field.label %>"<% if (field.required !== false) { %> requirement="required"<% } %>>
+<% if (field.type === 'textarea') { -%>
+        <GoabTextarea v-model="form.<%- field.key %>" name="<%- field.key %>" />
+<% } else if (field.type === 'number') { -%>
+        <GoabInput v-model="form.<%- field.key %>" name="<%- field.key %>" type="number" />
+<% } else if (field.type === 'date') { -%>
+        <GoabDatePicker v-model="form.<%- field.key %>" name="<%- field.key %>" />
+<% } else if (field.type === 'select') { -%>
+        <GoabDropdown v-model="form.<%- field.key %>" name="<%- field.key %>">
+<% (field.options || []).forEach(function (option) { -%>
+          <goa-dropdown-item value="<%- option.value %>" label="<%- option.label %>" />
+<% }); -%>
+        </GoabDropdown>
+<% } else { -%>
         <GoabInput v-model="form.<%- field.key %>" name="<%- field.key %>" type="text" />
+<% } -%>
       </goa-form-item>
 <% }); -%>
 

--- a/packages/nx-adsp/src/generators/vue-intake-view/schema.d.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/schema.d.ts
@@ -1,6 +1,9 @@
 export interface IntakeViewField {
   key: string;
   label: string;
+  type?: 'text' | 'textarea' | 'number' | 'date' | 'select';
+  /** `select` only. Rendered as goa-dropdown-item children. */
+  options?: { value: string; label: string }[];
   required?: boolean;
 }
 

--- a/packages/nx-adsp/src/generators/vue-intake-view/schema.json
+++ b/packages/nx-adsp/src/generators/vue-intake-view/schema.json
@@ -33,7 +33,7 @@
     },
     "steps": {
       "type": "string",
-      "description": "JSON array of steps, in order -- e.g. '[{\"key\":\"personal-info\",\"label\":\"Personal information\",\"fields\":[{\"key\":\"fullName\",\"label\":\"Full name\"}]}]'. Each item: { key, label, fields: [{ key, label, required?: boolean (default true) }] }. A plain array is also accepted when this generator is invoked programmatically. Every field is currently a plain text input -- see the generated AGENTS.md note for other field types."
+      "description": "JSON array of steps, in order -- e.g. '[{\"key\":\"personal-info\",\"label\":\"Personal information\",\"fields\":[{\"key\":\"fullName\",\"label\":\"Full name\"},{\"key\":\"born\",\"label\":\"Date of birth\",\"type\":\"date\"}]}]'. Each item: { key, label, fields: [...] }. Each field: { key, label, type?: \"text\"|\"textarea\"|\"number\"|\"date\"|\"select\" (default \"text\"), options?: [{value,label}] (select only, required for it), required?: boolean (default true) }. A number field is submitted as a number and a date as YYYY-MM-DD built from local calendar parts, not UTC. A plain array is also accepted when this generator is invoked programmatically. Nx's CLI option coercion only supports comma-separated primitive lists for array-typed schema properties, not JSON -- a JSON string is the only CLI syntax that survives Nx's own arg parsing."
     },
     "requiresAuth": {
       "type": "boolean",
@@ -41,6 +41,12 @@
       "default": true
     }
   },
-  "required": ["project", "name", "resource", "route", "steps"],
+  "required": [
+    "project",
+    "name",
+    "resource",
+    "route",
+    "steps"
+  ],
   "additionalProperties": false
 }

--- a/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-intake-view/vue-intake-view.spec.ts
@@ -138,6 +138,78 @@ describe('Vue Intake View Generator', () => {
     expect(review).toContain('/applications/${idParam.value}/confirmation');
   }, 30000);
 
+  describe('field types', () => {
+    const typedSteps = JSON.stringify([
+      {
+        key: 'details',
+        label: 'Details',
+        fields: [
+          { key: 'name', label: 'Name' },
+          { key: 'story', label: 'Story', type: 'textarea', required: false },
+          { key: 'count', label: 'Count', type: 'number' },
+          { key: 'occurred', label: 'Occurred', type: 'date' },
+          {
+            key: 'species',
+            label: 'Species',
+            type: 'select',
+            options: [{ value: 'wolf', label: 'Wolf' }],
+          },
+        ],
+      },
+      { key: 'review-it', label: 'Review it', fields: [] },
+    ]);
+
+    it('renders the right control for each type', async () => {
+      await generator(host, { ...baseOptions, steps: typedSteps });
+      const step = host
+        .read('apps/test/src/views/DetailsStepView.vue')
+        .toString();
+      expect(step).toContain('<GoabTextarea v-model="form.story"');
+      expect(step).toContain('type="number"');
+      expect(step).toContain('<GoabDatePicker v-model="form.occurred"');
+      expect(step).toContain('<goa-dropdown-item value="wolf" label="Wolf" />');
+    });
+
+    it('coerces number and date on save', async () => {
+      await generator(host, { ...baseOptions, steps: typedSteps });
+      const step = host
+        .read('apps/test/src/views/DetailsStepView.vue')
+        .toString();
+      expect(step).toContain("count: form.count === '' ? null : Number(form.count)");
+      expect(step).toContain('occurred: toIsoDateString(form.occurred) || null');
+      expect(step).toContain("fromIsoDateString(data['occurred'])");
+    });
+
+    it('validates a number and a date without assuming a string', async () => {
+      await generator(host, { ...baseOptions, steps: typedSteps });
+      const step = host
+        .read('apps/test/src/views/DetailsStepView.vue')
+        .toString();
+      expect(step).toContain("if (form.count === '')");
+      expect(step).toContain('Count must be a number.');
+      expect(step).toContain('if (!form.occurred)');
+    });
+
+    it('formats a date field on the review view rather than printing it raw', async () => {
+      await generator(host, { ...baseOptions, steps: typedSteps });
+      const review = host
+        .read('apps/test/src/views/ApplicationReviewView.vue')
+        .toString();
+      expect(review).toContain("formatDate(record['occurred'])");
+    });
+
+    it('every field is still a text input when no types are given', async () => {
+      await generator(host, baseOptions);
+      const step = host
+        .read('apps/test/src/views/PersonalInfoStepView.vue')
+        .toString();
+      expect(step).toContain('type="text"');
+      for (const unused of ['GoabTextarea', 'GoabDatePicker', 'GoabDropdown']) {
+        expect(step).not.toContain(unused);
+      }
+    });
+  });
+
   it('generates a confirmation view showing the reference number', async () => {
     await generator(host, baseOptions);
     const confirmation = host


### PR DESCRIPTION
**Closes tier 2.** `vue-admin-crud` supported `text` and `checkbox`; `vue-intake-view` declared no types at all — every field rendered as a text input. All 14 fields in the evaluation build came out that way, and the developer converted them by hand to a date picker, three dropdowns, number inputs and textareas.

Both generators now take `text | textarea | number | date | select` (plus `checkbox` for admin-crud), each rendering a wrapper that already existed. Only the wrappers a field set actually uses get imported, so a text-only form is unchanged and carries no unused imports into the generated lint.

## The control is the easy part

Types change four other things, and those are the real work:

- **Wire types.** The form model holds what a *control* needs — a `Date` for a picker, a string for a number input — while the API wants a number and a date string. Both generators now build an explicit payload instead of submitting the raw form, so a currency field stops persisting `"55"` where the backend wants `55`.
- **Validation.** A number field's required check can't be `!value.trim()`, and a date field holds a `Date`, so truthiness is the test. A non-required number is still checked for being numeric when present.
- **Load.** A stored `YYYY-MM-DD` is parsed back to a `Date`, so a picker redisplays the date that was saved.
- **Review.** A date on the intake review renders through `formatDate` rather than printing raw, matching the other views.

## Date conversion extracted rather than copied a third time

`toIsoDateString` / `fromIsoDateString` now live in the shared formatters, built from local calendar parts. `FilterBar` had them privately and is repointed at the shared pair.

This matters more than tidiness: it's the conversion where a third copy gets it wrong. Through UTC, a local-midnight `Date` is the previous day in Alberta — the bug fixed in #442 and again in #444. One home, one rule.

## Also fixed, same lines

admin-crud rendered a checkbox's label twice — once on `goa-form-item`, once as the checkbox's own `text` — displaying "Eligible for compensation | Eligible for compensation". Reported as defect 8 in the evaluation.

## Failing early

Both generators reject a type they can't render, naming the offending key, and a `select` without `options` — the generator can't know the choices, so failing at generation beats emitting an empty dropdown.

## Two stale doc claims removed

The intake schema said *"Every field is currently a plain text input — see the generated AGENTS.md note for other field types."* **That note has never existed anywhere in the plugin** — it was the dangling pointer the evaluating agent hit at the exact moment it most needed help. The docs site repeated the same claim.

## Verification

213 tests (was 208): 7 for admin-crud field types, 5 for intake, covering each control, the coercion, per-type validation, the checkbox label, and both rejection paths. Plus a test that a type-less field set still emits only `GoabInput` — no behaviour change for existing callers. Build and lint clean, `secretlint` clean.

## Tier 2 complete

| Item | |
|---|---|
| `meta.layout` | #445 |
| `formatDate` for date columns | #444 |
| `--filters` wiring `FilterBar` | #445 |
| `Stepper` `step` | #445 |
| staff shell scroll containment | #446 |
| staff nav entries | #447 |
| **richer field types** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)