### PR TITLE
feat(nx-adsp): sort tables with goa-table-sort-header instead of hand-rolled headers

### DIFF
--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/WorkspaceTable.spec.ts__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/WorkspaceTable.spec.ts__tmpl__
@@ -31,3 +31,50 @@ describe('WorkspaceTable pagination wiring', () => {
     }
   });
 });
+
+const sortProps = {
+  columns: [
+    { key: 'name', label: 'Name', sortable: true },
+    { key: 'plain', label: 'Plain' },
+  ],
+  rows: [{ name: 'a', plain: 'b' }],
+  loading: false,
+  error: null,
+  sortBy: 'name',
+  sortDir: 'desc' as const,
+};
+
+describe('WorkspaceTable native sorting', () => {
+  it('renders goa-table-sort-header only for sortable columns', () => {
+    const w = mount(WorkspaceTable, { props: sortProps });
+    expect(w.findAll('goa-table-sort-header')).toHaveLength(1);
+    expect(w.find('goa-table-sort-header').attributes('name')).toBe('name');
+  });
+
+  it('tells the header the current direction, and none for other columns', () => {
+    const w = mount(WorkspaceTable, { props: sortProps });
+    expect(w.find('goa-table-sort-header').attributes('direction')).toBe('desc');
+    const other = mount(WorkspaceTable, { props: { ...sortProps, sortBy: 'plain' } });
+    expect(other.find('goa-table-sort-header').attributes('direction')).toBe('none');
+  });
+
+  it('enables single sort mode on the table', () => {
+    expect(mount(WorkspaceTable, { props: sortProps }).find('goa-table').attributes('sort-mode')).toBe('single');
+  });
+
+  it("translates goa-table's numeric sortDir to asc/desc", async () => {
+    const w = mount(WorkspaceTable, { props: sortProps });
+    const table = w.find('goa-table').element;
+    table.dispatchEvent(new CustomEvent('_sort', { detail: { sortBy: 'name', sortDir: -1 } }));
+    table.dispatchEvent(new CustomEvent('_sort', { detail: { sortBy: 'name', sortDir: 1 } }));
+    expect(w.emitted('sort')).toEqual([['name', 'desc'], ['name', 'asc']]);
+  });
+
+  it('ignores an unsorted (0) event with no column', async () => {
+    const w = mount(WorkspaceTable, { props: sortProps });
+    w.find('goa-table').element.dispatchEvent(
+      new CustomEvent('_sort', { detail: { sortBy: '', sortDir: 0 } }),
+    );
+    expect(w.emitted('sort')).toBeUndefined();
+  });
+});

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/WorkspaceTable.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/WorkspaceTable.vue__tmpl__
@@ -5,9 +5,13 @@
 // consuming view can render badges, formatted values, or action buttons per
 // column without this component knowing anything about the domain.
 //
-// No native GoA sortable-header component exists (checked -- there isn't
-// one), so a sortable column header is hand-rolled here using the standard
-// WAI-ARIA "sortable table header" pattern (aria-sort + a real button), not
+// Sortable headers use the native goa-table-sort-header inside a goa-table with
+// sort-mode="single": the element owns the aria-sort, the direction cycling and
+// the visual affordance. An earlier version of this comment asserted no native
+// sortable-header component existed -- it had shipped since 2.0.0. Check the
+// installed package's registered elements rather than trusting a note like that.
+//
+// The superseded hand-rolled version used the standard
 // invented from scratch.
 import { useSlots } from 'vue';
 import GoabButton from '../primitives/GoabButton.vue';
@@ -44,19 +48,23 @@ withDefaults(
 const emit = defineEmits<{
   retry: [];
   pageChange: [page: number];
-  sort: [key: string];
+  /**
+   * goa-table owns the direction cycling, so both parts arrive together and the
+   * consuming view no longer toggles a direction itself.
+   */
+  sort: [sortBy: string, sortDir: 'asc' | 'desc'];
 }>();
 
 const slots = useSlots();
 
-function ariaSort(
-  column: WorkspaceTableColumn,
-  sortBy?: string,
-  sortDir?: 'asc' | 'desc',
-): 'ascending' | 'descending' | 'none' | undefined {
-  if (!column.sortable) return undefined;
-  if (sortBy !== column.key) return 'none';
-  return sortDir === 'desc' ? 'descending' : 'ascending';
+// goa-table reports direction numerically -- 1 ascending, -1 descending, 0
+// unsorted -- while useApi's ListQuery and every generated view speak
+// 'asc' | 'desc'. Translating here keeps that difference in one place.
+function onNativeSort(event: Event) {
+  const detail = (event as CustomEvent<{ sortBy: string; sortDir: number }>)
+    .detail;
+  if (!detail?.sortBy) return;
+  emit('sort', detail.sortBy, detail.sortDir < 0 ? 'desc' : 'asc');
 }
 </script>
 
@@ -77,25 +85,20 @@ function ariaSort(
     </goa-callout>
 
     <template v-else>
-      <goa-table width="100%">
+      <!-- sort-mode="single" makes goa-table aggregate its sort headers and
+           emit one _sort event; the headers own their own aria-sort and
+           direction cycling, which this component used to hand-roll. -->
+      <goa-table width="100%" sort-mode="single" @_sort="onNativeSort">
         <thead>
           <tr>
-            <th
-              v-for="column in columns"
-              :key="column.key"
-              :aria-sort="ariaSort(column, sortBy, sortDir)"
-            >
-              <button
+            <th v-for="column in columns" :key="column.key">
+              <goa-table-sort-header
                 v-if="column.sortable"
-                type="button"
-                class="sort-button"
-                @click="emit('sort', column.key)"
+                :name="column.key"
+                :direction="column.key === sortBy ? sortDir : 'none'"
               >
                 {{ column.label }}
-                <span aria-hidden="true">{{
-                  sortBy === column.key ? (sortDir === 'desc' ? '▼' : '▲') : ''
-                }}</span>
-              </button>
+              </goa-table-sort-header>
               <template v-else>{{ column.label }}</template>
             </th>
             <th v-if="slots.actions" />
@@ -133,17 +136,3 @@ function ariaSort(
   </div>
 </template>
 
-<style scoped>
-.sort-button {
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  font-weight: inherit;
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--goa-space-2xs, 0.25rem);
-}
-</style>

--- a/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/WorkspaceTable.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/src/lib/patterns/WorkspaceTable.vue__tmpl__
@@ -88,12 +88,25 @@ function onNativeSort(event: Event) {
       <!-- sort-mode="single" makes goa-table aggregate its sort headers and
            emit one _sort event; the headers own their own aria-sort and
            direction cycling, which this component used to hand-roll. -->
-      <goa-table width="100%" sort-mode="single" @_sort="onNativeSort">
+      <!-- The V2 flag is set on both the table and its sort headers: each
+           defaults to version 1, and this workspace is on the V2 design system
+           (the same reason goa-app-header and goa-pagination carry it). Without
+           it the table and its headers render V1 styling inside a V2 app.
+           sort-mode="single" is goa-table's default but stated explicitly: it
+           decides whether the table emits _sort or _multisort, so the listener
+           below only makes sense alongside it. -->
+      <goa-table
+        width="100%"
+        version="2"
+        sort-mode="single"
+        @_sort="onNativeSort"
+      >
         <thead>
           <tr>
             <th v-for="column in columns" :key="column.key">
               <goa-table-sort-header
                 v-if="column.sortable"
+                version="2"
                 :name="column.key"
                 :direction="column.key === sortBy ? sortDir : 'none'"
               >

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -81,6 +81,20 @@ describe('Vue Components Generator', () => {
     const table = host
       .read('libs/vue-components/src/lib/patterns/WorkspaceTable.vue')
       .toString();
+    // Sorting is the native element's job: goa-table-sort-header inside a
+    // goa-table with sort-mode="single". The hand-rolled button + manual
+    // aria-sort is gone, and the comment that claimed no native component
+    // existed is corrected.
+    expect(table).toContain('<goa-table-sort-header');
+    expect(table).toContain('sort-mode="single"');
+    expect(table).toContain('@_sort="onNativeSort"');
+    // Binding forms, not bare words -- the component's own comment explains that
+    // the element owns aria-sort, so the word legitimately appears in it.
+    expect(table).not.toContain(':aria-sort=');
+    expect(table).not.toContain('class="sort-button"');
+    // goa-table reports 1/-1/0; the rest of the stack speaks asc/desc.
+    expect(table).toContain("detail.sortDir < 0 ? 'desc' : 'asc'");
+
     for (const prop of [':pagenumber=', ':itemcount=', ':perpagecount=']) {
       expect(table).toContain(prop);
     }

--- a/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-components/vue-components.spec.ts
@@ -87,6 +87,18 @@ describe('Vue Components Generator', () => {
     // existed is corrected.
     expect(table).toContain('<goa-table-sort-header');
     expect(table).toContain('sort-mode="single"');
+    // goa-table and goa-table-sort-header both default to V1 styling; this
+    // workspace is on V2, the same reason goa-app-header and goa-pagination
+    // carry version="2".
+    // Asserted per element rather than by counting: a count is hostage to the
+    // literal appearing in a comment, which is how this assertion first broke.
+    const compactTable = table.replace(/\s+/g, ' ');
+    expect(compactTable).toContain(
+      '<goa-table width="100%" version="2" sort-mode="single"',
+    );
+    expect(compactTable).toContain(
+      '<goa-table-sort-header v-if="column.sortable" version="2"',
+    );
     expect(table).toContain('@_sort="onNativeSort"');
     // Binding forms, not bare words -- the component's own comment explains that
     // the element owns aria-sort, so the word legitimately appears in it.

--- a/packages/nx-adsp/src/generators/vue-workspace-view/files/src/views/__viewFileName__.vue__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/files/src/views/__viewFileName__.vue__tmpl__
@@ -111,13 +111,11 @@ function onPageChange(newPage: number) {
   void load();
 }
 
-function onSort(key: string) {
-  if (sortBy.value === key) {
-    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
-  } else {
-    sortBy.value = key;
-    sortDir.value = 'asc';
-  }
+// goa-table-sort-header owns the direction cycling and reports both parts, so
+// this no longer toggles anything -- it just records what the table decided.
+function onSort(key: string, dir: 'asc' | 'desc') {
+  sortBy.value = key;
+  sortDir.value = dir;
   page.value = 1;
   void load();
 }

--- a/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
+++ b/packages/nx-adsp/src/generators/vue-workspace-view/vue-workspace-view.spec.ts
@@ -104,6 +104,9 @@ describe('Vue Workspace View Generator', () => {
     expect(view).toContain("await list('applications', {");
     expect(view).toContain('pageSize: PAGE_SIZE');
     expect(view).toContain('rows.value = result.rows');
+    // The element decides the direction, so the view records rather than toggles.
+    expect(view).toContain("function onSort(key: string, dir: 'asc' | 'desc')");
+    expect(view).not.toContain("sortDir.value === 'asc' ? 'desc' : 'asc'");
     expect(view).toContain('itemCount.value = result.total');
     expect(view).not.toContain('apiFetch');
     expect(view).not.toContain('URLSearchParams');


### PR DESCRIPTION
First of the two "use the design system instead of hand-rolling it" items.

`WorkspaceTable` hand-rolled sortable headers — a bare `<button>`, a manual `aria-sort`, a unicode arrow and its own CSS — above a comment asserting:

> *"No native GoA sortable-header component exists (checked — there isn't one)"*

`goa-table-sort-header` has shipped since **@abgov/web-components 2.0.0** (2026-04-01), four months before this component was written, and in the version the plugin pins.

## What it uses now

`goa-table-sort-header` inside a `goa-table` with `sort-mode="single"`. The element owns the `aria-sort`, the direction cycling and the visual affordance. The component keeps only what's genuinely its own: translating `goa-table`'s numeric direction — `1` ascending, `-1` descending, `0` unsorted — into the `'asc' | 'desc'` that `useApi`'s `ListQuery` and every generated view speak.

## It moves a responsibility out of generated views too

Because the element cycles direction and reports both parts, `WorkspaceTable`'s `sort` event now carries `(sortBy, sortDir)`, so the generated view records what the table decided rather than toggling:

```diff
-function onSort(key: string) {
-  if (sortBy.value === key) {
-    sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
-  } else {
-    sortBy.value = key;
-    sortDir.value = 'asc';
-  }
+function onSort(key: string, dir: 'asc' | 'desc') {
+  sortBy.value = key;
+  sortDir.value = dir;
   page.value = 1;
   void load();
 }
```

That's the convergence argument in miniature — less generated code, and the behaviour comes from the design system rather than from each app's copy of a hand-rolled header.

## The comment

Replaced with what's true, plus the lesson: check the installed package's registered elements rather than trusting a note like that. The audit that found this checked every `goa-*` element and attribute against the installed package — this was one of five places the plugin hand-rolls something the design system provides. `goa-workspace-layout`, the `goa-public-form` family, `goa-one-column-layout` and `goa-fieldset` are the others.

## Verification

The event contract came out of a minified bundle, so I ran it in a real Vue harness before shipping: sortable columns get a header and plain ones don't, the current column receives its direction while others get `'none'`, `sort-mode` is set, numeric `-1`/`1` becomes `'desc'`/`'asc'`, and an unsorted event with no column is ignored. Those five tests ship with the library (7 total in `WorkspaceTable.spec.ts`).

201 nx-adsp tests, build, lint clean.

## Next

`goa-public-form` versus `vue-intake-view`'s hand-rolled wizard is the larger of the two and I'd rather scope it with you before rewriting — notes in the follow-up message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)