### PR TITLE
chore(nx-adsp): bump web-components to 2.4.0 and design-tokens to 2.12.8

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -158,13 +158,13 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
     host,
     {
       '@abgov/angular-components': '5.3.0',
-      '@abgov/design-tokens': '2.12.0',
+      '@abgov/design-tokens': '2.12.8',
       // Pin exact (not ^2.0.0): angular-components 5.3.0 imports symbols added in
       // ui-components-common 2.3.0 (e.g. GoabWorkspaceLayoutScrollState), so a
       // lower 2.x resolves and fails the build. Keep this in lockstep with the
       // angular-components version above.
       '@abgov/ui-components-common': '2.3.0',
-      '@abgov/web-components': '2.3.0',
+      '@abgov/web-components': '2.4.0',
       'keycloak-angular': '^19.0.2',
       'keycloak-js': '^23.0.7',
       'zone.js': '~0.15.0',

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -148,9 +148,9 @@ export default async function (host: Tree, options: Schema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/design-tokens': '2.12.0',
+      '@abgov/design-tokens': '2.12.8',
       '@abgov/react-components': '7.3.0',
-      '@abgov/web-components': '2.3.0',
+      '@abgov/web-components': '2.4.0',
       '@reduxjs/toolkit': '^2.5.1',
       'keycloak-js': '^23.0.7',
       'react-redux': '^9.2.0',

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -153,8 +153,8 @@ export default async function (host: Tree, options: Schema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/design-tokens': '2.12.0',
-      '@abgov/web-components': '2.3.0',
+      '@abgov/design-tokens': '2.12.8',
+      '@abgov/web-components': '2.4.0',
       // keycloak-js is a transitive dependency of @dsb-norge/vue-keycloak-js;
       // don't pin it directly or the versions diverge into two copies.
       '@dsb-norge/vue-keycloak-js': '^3.0.0',

--- a/packages/nx-adsp/src/generators/vue-components/files/AGENTS.md__tmpl__
+++ b/packages/nx-adsp/src/generators/vue-components/files/AGENTS.md__tmpl__
@@ -66,6 +66,7 @@ inline styles.
 | A loading `<div>` or spinner markup | `<goa-skeleton type="…">` or `<goa-spinner>` | Skeletons match the shape they replace (`card`, `text`, `table`) |
 | A `<label>` + error `<span>` around an input | `<goa-form-item label="…" error="…">` | Wrap the `Goab*` input in this, don't restyle it |
 | A row of buttons with flex styling | `<goa-button-group alignment="…">` | |
+| A hand-built multi-select (checkbox list, chips) | `<goa-dropdown-multiselect>` | Added in web-components 2.4.0 |
 | A hand-built filter row above a table | `<FilterBar>` (this library) | Controls, collapse, active-filter chips and clear-all. It emits a query-ready values object; the *view* owns resetting the page, debouncing, and URL sync |
 
 Also available bare and worth knowing before hand-rolling: `goa-accordion`, `goa-details`,


### PR DESCRIPTION
All three frontend generators pinned `@abgov/web-components` at 2.3.0 and `@abgov/design-tokens` at 2.12.0. These are **exact pins, not ranges**, so a consuming app never picks up a fix until the plugin bumps — which makes a stale pin a decision rather than drift.

## Verified, not assumed

Diffed the two published packages' registered custom elements:

```
2.3.0: 93 elements | 2.4.0: 94 elements
added:   goa-dropdown-multiselect
removed: none
```

Then narrowed to the elements the templates actually bind and compared every registered prop name, including `attribute:` aliases. One change, additive: `goa-block` gains `stretch`. **Nothing we bind was removed or renamed**, so the bump is behaviour-preserving for existing generated output.

`design-tokens` moves within 2.12.x — patch only, and tokens are CSS variables.

The catalog gains a row for `goa-dropdown-multiselect`: a hand-built multi-select is exactly what the catalog exists to prevent, and the element is new enough that nobody would think to look for it.

## Deliberately not included

`@abgov/react-components` (7.3.0 → 7.4.0) and `@abgov/angular-components` (5.3.0 → 5.4.0) are also behind. They need their own export-surface check, and the script I wrote to diff them failed to split its arguments and returned an empty result — which is **not** evidence of no change. They stay pinned until checked properly rather than bumped on a bad signal.

## Also: `goa-fieldset` is not adoptable, contrary to what I suggested earlier

I had listed `goa-fieldset` as a likely axe-violation fix. Reading the source, that was wrong twice over:

- It lives in `components/form/` alongside `Form.svelte` and imports the whole relay-message machinery (`FieldsetBindMsg`, `FormPageContinueMsg`, `FormSetFieldsetMsg`). It's **part of the `goa-public-form` state machine**, not a standalone semantic grouping element — so adopting it drags in the same unstable form engine we declined in #450's write-up.
- None of the reported axe violations were about missing fieldsets. They are `aria-required-parent` on `goa-work-side-menu-item`, `aria-required-children` on `goa-form-stepper`, `aria-prohibited-attr` on `goa-form-step`, `aria-allowed-attr` on `goa-badge`'s icon, and `role-img-alt` on several icons — all inside `@abgov/web-components` and the plugin's pattern components.

220 tests, build, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)