### PR TITLE
docs: state the Vue template spacing convention for this repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,6 +381,44 @@ Key wiring to preserve when editing:
 
 ---
 
+### Vue template spacing
+
+`.vue__tmpl__` templates have no shared spacing convention, and the gap between two stacked
+elements is the thing most easily got wrong here: it looks correct in the template and only
+shows up once the view is rendered. Use whichever of these fits, and don't invent a fourth:
+
+| Between                                                      | Use                                                                | Not                                                                            |
+| ------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Page-level sections (heading, filter bar, table, pagination) | `<goa-spacer vspacing="…">` — the existing pattern in 11 templates | a margin-only `<div>`, or scoped CSS                                           |
+| Stacked `goa-form-item`s                                     | `mb="l"` on each item                                              | nothing — `mb` defaults to none, so they render **flush**                      |
+| A horizontal group                                           | `<goa-block gap="…" direction="row">`                              | `mb` on the children as well — the block already spaces them (see `FilterBar`) |
+| A genuine two-column grid, e.g. a label/value list           | scoped CSS `display: grid` + `gap`                                 | a bare `<dl>`, whose terms and values also render flush                        |
+
+Two rules that come from real defects, not theory:
+
+- **`goa-form-item` and a bare `<dl>` are the two things that do not space themselves.**
+  Everything else in the catalog carries its own margins, which is why the "drop a
+  `goa-spacer` between blocks and let children sort themselves out" habit works until you
+  hit one of those two. `vue-admin-crud`'s edit view and every `vue-intake-view` step
+  shipped with fields touching; the intake review page — the check-your-answers page —
+  shipped with every answer running into the next.
+- **If you fix spacing in one view, check the sibling generator that renders the same
+  shape.** `vue-detail-view` styled its label/value list; the intake review page rendering
+  the same label/value pairs did not, and stayed unstyled for exactly that reason. The
+  eslint slot rule and the side-menu icon defaults had the same history.
+
+Verify by rendering, not by reading. The measurement that found both defects was
+`getBoundingClientRect()` on consecutive siblings in a real browser — a 0px gap between two
+block children with no `goa-spacer` between them is the signal. Note that a 0px gap is
+_correct_ next to a `goa-spacer` (the spacer **is** the gap) and between adjacent `<li>`s
+(line-height separates text), so don't fix those.
+
+Consuming-workspace guidance for the same trap lives in the generated
+`vue-components/AGENTS.md` catalog — that file is for someone writing app code, this section
+is for someone editing a template here. Both need it; they are different readers.
+
+---
+
 ## OpenShift Notes
 
 - `nx-oc` generators produce `.openshift/` YAML manifests from EJS templates named `*.yml__tmpl__`.


### PR DESCRIPTION
Docs-only, one file. Complements #453 (which fixes the two defects) by putting the rule where it would have prevented them.

## Why here rather than in the generated catalog

This repo's `AGENTS.md` had **no Vue template conventions at all** — it covers generator anatomy, `__tmpl__` naming, nginx headers and sandbox wiring, but nothing about how a `.vue__tmpl__` should space its elements.

That matters because of who made the mistakes. Both spacing defects in #453 were authored **here**, in this repo's templates. #453 also added a note to the generated `vue-components/AGENTS.md` catalog, but that file is read by someone writing app code in a consuming workspace — it never reaches whoever is editing a generator template. Two different readers, both real; this fills the gap for the second.

## What it says

The four mechanisms and when to use each:

| Between | Use |
| --- | --- |
| Page-level sections | `<goa-spacer vspacing="…">` — the existing pattern in 11 templates |
| Stacked `goa-form-item`s | `mb="l"` — `mb` defaults to none, so they render flush |
| A horizontal group | `<goa-block gap="…" direction="row">`, and *not* `mb` on the children too |
| A genuine two-column grid | scoped CSS `display: grid` + `gap` |

Plus two rules drawn from the actual defects rather than from theory:

- **`goa-form-item` and a bare `<dl>` are the only two things that don't space themselves.** Everything else in the catalog carries its own margins, which is why the prevailing "drop a `goa-spacer` between blocks and let children sort themselves out" habit works right until you hit one of those two.
- **If you fix spacing in one view, check the sibling generator rendering the same shape.** `vue-detail-view` styled its label/value list; the intake review page rendering the same label/value pairs did not. This is the third instance of that history — the eslint slot rule was disabled for the lib and not the app, and the side-menu icon default landed in one generator and not the other.

And that verification means rendering and measuring, not reading — including which 0px gaps are *correct* (next to a `goa-spacer`, which **is** the gap; and between adjacent `<li>`s, where line-height separates the text), so the next person doesn't "fix" a false positive.

Placed beside the **nginx and frontend security headers** section, which documents the same kind of cross-generator invariant.

## Note

The "11 templates" figure is counted, not estimated — I had written 10 from an earlier miscount and corrected it before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)