### PR TITLE
fix(nx-oc): make the git remote URL patterns linear

### DIFF
--- a/packages/nx-oc/src/utils/git-utils.spec.ts
+++ b/packages/nx-oc/src/utils/git-utils.spec.ts
@@ -94,3 +94,65 @@ describe('getGitHubRepo', () => {
     expect(getGitHubRepo(undefined)).toBeUndefined();
   });
 });
+
+// CodeQL js/polynomial-redos flagged three patterns in this file. Both shapes
+// below were measured against the old regexes before the fix, and the inputs are
+// sized so the old code clearly exceeds the budget while the fixed code is ~0ms:
+//
+//   ssh prefix repeated:  2k -> 28ms,  8k -> 320ms      (quadratic)
+//   interior whitespace:  6k -> 20ms, 20k -> 150ms, 40k -> 584ms, 50k -> ~900ms
+//
+// CodeQL also named a repeated-`https://github.com/a` shape for the same rule.
+// That one measured linear on the old pattern (0.5ms at 8k, 2.2ms at 40k), so
+// there is deliberately no test for it -- it could never fail.
+//
+// The budget is generous on purpose: this asserts the quadratic blow-up is gone,
+// not the absolute speed of a CI machine.
+describe('remote URL parsing is not quadratic on hostile input', () => {
+  const BUDGET_MS = 250;
+
+  const elapsed = (run: () => void): number => {
+    const start = process.hrtime.bigint();
+    run();
+    return Number(process.hrtime.bigint() - start) / 1e6;
+  };
+
+  it('handles many repetitions of the ssh prefix quickly', () => {
+    const hostile = 'git@github.com:'.repeat(8000);
+    expect(elapsed(() => deriveRegistryFromRemote(hostile))).toBeLessThan(
+      BUDGET_MS,
+    );
+  });
+
+  // Interior whitespace with a non-space ending: this survives the trim, and it
+  // is what made the removed `\s*$` backtrack at every expansion.
+  it('handles interior whitespace with a non-space ending quickly', () => {
+    const hostile = `https://github.com/a${' '.repeat(50000)}x`;
+    expect(elapsed(() => getGitHubRepo(hostile))).toBeLessThan(BUDGET_MS);
+  });
+});
+
+// Anchoring is what makes the patterns linear, so it is asserted rather than
+// left implicit -- dropping the `^` would restore the quadratic behaviour while
+// every other test still passed.
+describe('remote URL parsing is anchored', () => {
+  it('does not match a github URL embedded mid-string', () => {
+    expect(
+      deriveRegistryFromRemote('file:///tmp/https://github.com/evil/repo/'),
+    ).toBeUndefined();
+    expect(
+      getGitHubRepo('file:///tmp/https://github.com/evil/repo.git'),
+    ).toBeUndefined();
+  });
+
+  it('still accepts the two forms git config actually returns', () => {
+    expect(deriveRegistryFromRemote('https://github.com/GovAlta/x.git')).toBe(
+      'ghcr.io/GovAlta',
+    );
+    expect(deriveRegistryFromRemote('git@github.com:GovAlta/x.git')).toBe(
+      'ghcr.io/GovAlta',
+    );
+    expect(getGitHubRepo('https://github.com/GovAlta/x.git')).toBe('GovAlta/x');
+    expect(getGitHubRepo('git@github.com:GovAlta/x.git')).toBe('GovAlta/x');
+  });
+});

--- a/packages/nx-oc/src/utils/git-utils.ts
+++ b/packages/nx-oc/src/utils/git-utils.ts
@@ -14,6 +14,30 @@ export function getGitRemoteUrl(): string | undefined {
   }
 }
 
+// The patterns below are all anchored at `^`, which is what keeps them linear.
+// Unanchored, the engine can retry the literal prefix at every position in the
+// string, so a value made of many repetitions of `git@github.com:` costs
+// O(n^2) — CodeQL js/polynomial-redos flagged three of these. A remote URL
+// always begins with its scheme, so anchoring costs nothing real; the one shape
+// it stops accepting is a scheme-prefixed spec like `git+https://github.com/...`,
+// which is an npm dependency specifier, not a value `git config
+// --get remote.origin.url` returns.
+//
+// Practical exposure was low — the only in-repo caller feeds these the developer's
+// own git config output at generator time — but these are re-exported from
+// nx-oc's public API, so a consumer can pass anything.
+const HTTPS_ORG = /^https:\/\/github\.com\/([^/]+)\//;
+const SSH_ORG = /^git@github\.com:([^/]+)\//;
+
+// `\s*$` is deliberately absent. It was not just redundant after the trim below
+// (it could only ever match empty there) — combined with the lazy `(.+?)` it was
+// the backtracking driver, and reachable even post-trim: a value with interior
+// whitespace and a non-space ending makes `\s*$` fail at every expansion.
+// Measured on the old pattern, 6 KB of that shape took 21ms; anchored and without
+// it, 0ms.
+const HTTPS_REPO = /^https:\/\/github\.com\/(.+?)(?:\.git)?$/;
+const SSH_REPO = /^git@github\.com:(.+?)(?:\.git)?$/;
+
 // Parses a GitHub remote URL and returns the ghcr.io registry for the org.
 // Handles both HTTPS (https://github.com/ORG/REPO.git) and
 // SSH (git@github.com:ORG/REPO.git) formats.
@@ -22,9 +46,7 @@ export function deriveRegistryFromRemote(
 ): string | undefined {
   if (!remoteUrl) return undefined;
   const url = remoteUrl.trim();
-  const httpsMatch = url.match(/https:\/\/github\.com\/([^/]+)\//);
-  const sshMatch = url.match(/git@github\.com:([^/]+)\//);
-  const org = httpsMatch?.[1] ?? sshMatch?.[1];
+  const org = url.match(HTTPS_ORG)?.[1] ?? url.match(SSH_ORG)?.[1];
   return org ? `ghcr.io/${org}` : undefined;
 }
 
@@ -32,7 +54,5 @@ export function deriveRegistryFromRemote(
 export function getGitHubRepo(remoteUrl?: string): string | undefined {
   if (!remoteUrl) return undefined;
   const url = remoteUrl.trim();
-  const httpsMatch = url.match(/https:\/\/github\.com\/(.+?)(?:\.git)?\s*$/);
-  const sshMatch = url.match(/git@github\.com:(.+?)(?:\.git)?\s*$/);
-  return httpsMatch?.[1] ?? sshMatch?.[1];
+  return url.match(HTTPS_REPO)?.[1] ?? url.match(SSH_REPO)?.[1];
 }


### PR DESCRIPTION
Clears the three open **CodeQL `js/polynomial-redos`** alerts (#4, #5, #6 — all high) in `packages/nx-oc/src/utils/git-utils.ts`.

## Both flagged shapes are real — measured, not assumed

Against the old patterns:

```
ssh prefix repeated:  2k -> 28ms,  8k -> 320ms                  (quadratic)
interior whitespace:  6k -> 20ms, 20k -> 150ms, 40k -> 584ms
```

Fixed: ~0ms in both cases.

## The fix

**Anchoring at `^` is the substantive change.** Unanchored, the engine retries the literal prefix at every position in the string, so `git@github.com:` repeated *n* times costs O(n²). A remote URL always begins with its scheme, so the anchor costs nothing real — the one shape it stops accepting is a scheme-prefixed spec like `git+https://github.com/…`, which is an npm dependency specifier rather than anything `git config --get remote.origin.url` returns.

**`\s*$` is also dropped** from the two repo patterns. It was useless after the existing `.trim()` — it could only ever match empty there — but not harmless: with the lazy `(.+?)` it was the backtracking driver, and reachable *post-trim*, since interior whitespace with a non-space ending makes it fail at every expansion.

## On severity

Exploitability was low. Every in-repo caller feeds these the developer's own `git config` output at generator time, so no trust boundary is crossed. They're flagged because `nx-oc/src/index.ts` re-exports the module, making them public API a consumer can pass anything to. **Fixed because it's cheap, not because it was dangerous.**

## The tests were verified to fail first

A timing guard that passes either way guards nothing, so each new test was run against the old patterns before being kept. Two earlier drafts did exactly that and were corrected rather than committed:

- The whitespace input was **too small to exceed the budget** — 20k spaces is 150ms against a 250ms budget, so it passed on the vulnerable code. Raised to 50k (~900ms).
- A repeated-`https://github.com/a` shape that CodeQL also names measured **linear** on the old pattern (0.5ms at 8k, 2.2ms at 40k). That test could never fail, so it was **deleted** rather than kept as reassurance.

Both facts are recorded in the spec so the budget can be re-derived. Anchoring is asserted directly as well, not only via timing — dropping a `^` would restore the quadratic behaviour while every other test still passed.

275 tests pass across the affected projects.

## Not addressed here: the six Dependabot alerts

Worth recording, because the current mitigation cannot work. All six (`ip-address` ×3, `undici` ×3) resolve inside **npm's own bundled dependency tree** (`node_modules/npm/node_modules/…`). npm ships its dependencies vendored, and `overrides` cannot re-resolve a bundled tree — so the declared `overrides: { "ip-address": "^10.3.1" }` has no effect on the copy that's actually flagged. The root `undici` override *did* work (7.29.0); every alert is against the bundled 6.27.0.

No `@abgov` package depends on `npm`, `undici` or `ip-address` — checked all five — so there's no exposure to consumers of the published packages. `npm` arrives transitively via `@semantic-release/npm`, making this release-tooling only. The override pins `npm ^11.19.0` while the registry is at 12.0.2; whether 12.x vendors patched copies needs checking before assuming it helps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)