### PR TITLE
feat(nx-adsp): pin the ADSP SDK MCP server to a dev dependency

### DIFF
--- a/docs/nx-adsp/nx-adsp.md
+++ b/docs/nx-adsp/nx-adsp.md
@@ -50,8 +50,9 @@ Some generators require additional peer dependencies:
 
 ### init
 
-Sets up nx-adsp's own workspace-root concerns: registers the ADSP SDK MCP server
-(`@abgov/adsp-sdk-mcp-server`) in `.mcp.json`, and shared VS Code settings. Every app/service
+Sets up nx-adsp's own workspace-root concerns: installs the ADSP SDK MCP server
+(`@abgov/adsp-sdk-mcp-server`) as a dev dependency and registers it in `.mcp.json`, and shared
+VS Code settings. Every app/service
 generator below already runs this as one of its own steps — always run it directly right after
 installing the plugin, too, so grounded ADSP platform knowledge (tenant/realm/role model,
 `@abgov/adsp-service-sdk` reference) is available immediately, not only once you've scaffolded
@@ -63,10 +64,22 @@ npx nx g @abgov/nx-adsp:init
 ```
 
 No options. Idempotent — merges into existing `.mcp.json`/`.vscode/settings.json` without
-clobbering another server, a customized `adsp-sdk` entry, or unrelated settings; safe to re-run.
-Project-scoped MCP servers only load at session start, so reconnect (or restart) your MCP client
-after running this before relying on the new tools — the generator's own output says so as a
-reminder.
+clobbering another server, a customized `adsp-sdk` entry, a version you've pinned yourself, or
+unrelated settings; safe to re-run. Project-scoped MCP servers only load at session start, so
+install dependencies and then reconnect (or restart) your MCP client after running this before
+relying on the new tools — the generator's own output says so as a reminder.
+
+The server is a dev dependency rather than an on-demand `npx -y` fetch so that the version your
+agent executes is the one your lockfile resolved and `npm audit` can see — along with its
+transitive dependencies. The `.mcp.json` entry uses `npx --no`, which prefers the local install
+over anything in npm's `_npx` cache, and refuses to reach the registry for a version you haven't
+installed. Plain `npx` would fetch and run one silently, because npm assumes `--yes` whenever
+stdin isn't a TTY, as it never is for a stdio MCP server.
+
+One caveat worth knowing: `--no` treats an already-populated `_npx` cache entry as satisfying the
+request, so on a machine that previously ran the `npx -y` form it will use that cached copy rather
+than erroring. Run `npm install` before relying on the pin — with the dependency present, the
+local copy always wins.
 
 ---
 

--- a/packages/nx-adsp/README.md
+++ b/packages/nx-adsp/README.md
@@ -101,8 +101,9 @@ deploy details.
 
 ### `init`
 
-Sets up nx-adsp's own workspace-root concerns: registers the ADSP SDK MCP server
-(`@abgov/adsp-sdk-mcp-server`) in `.mcp.json`, and shared VS Code settings. Every app/service
+Sets up nx-adsp's own workspace-root concerns: installs the ADSP SDK MCP server
+(`@abgov/adsp-sdk-mcp-server`) as a dev dependency and registers it in `.mcp.json`, and shared
+VS Code settings. Every app/service
 generator below already runs this as one of its own steps — always run it directly right after
 installing the plugin, too, so grounded ADSP platform knowledge (tenant/realm/role model,
 `@abgov/adsp-service-sdk` reference) is available immediately, not only once you've scaffolded
@@ -114,10 +115,22 @@ npx nx g @abgov/nx-adsp:init
 ```
 
 No options. Idempotent — merges into existing `.mcp.json`/`.vscode/settings.json` without
-clobbering another server, a customized `adsp-sdk` entry, or unrelated settings; safe to re-run.
-Project-scoped MCP servers only load at session start, so reconnect (or restart) your MCP client
-after running this before relying on the new tools — the generator's own output says so as a
-reminder.
+clobbering another server, a customized `adsp-sdk` entry, a version you've pinned yourself, or
+unrelated settings; safe to re-run. Project-scoped MCP servers only load at session start, so
+install dependencies and then reconnect (or restart) your MCP client after running this before
+relying on the new tools — the generator's own output says so as a reminder.
+
+The server is a dev dependency rather than an on-demand `npx -y` fetch so that the version your
+agent executes is the one your lockfile resolved and `npm audit` can see — along with its
+transitive dependencies. The `.mcp.json` entry uses `npx --no`, which prefers the local install
+over anything in npm's `_npx` cache, and refuses to reach the registry for a version you haven't
+installed. Plain `npx` would fetch and run one silently, because npm assumes `--yes` whenever
+stdin isn't a TTY, as it never is for a stdio MCP server.
+
+One caveat worth knowing: `--no` treats an already-populated `_npx` cache entry as satisfying the
+request, so on a machine that previously ran the `npx -y` form it will use that cached copy rather
+than erroring. Run `npm install` before relying on the pin — with the dependency present, the
+local copy always wins.
 
 ---
 

--- a/packages/nx-adsp/migrations.json
+++ b/packages/nx-adsp/migrations.json
@@ -6,6 +6,12 @@
       "description": "Wrap express-service's generated src/migrate.ts drizzle migrate() call in a Postgres advisory lock, so concurrent init containers serialize instead of racing.",
       "implementation": "./src/migrations/add-migrate-advisory-lock/add-migrate-advisory-lock",
       "prompt": "./src/migrations/add-migrate-advisory-lock/add-migrate-advisory-lock.md"
+    },
+    "pin-adsp-mcp-server": {
+      "version": "13.33.0",
+      "description": "Pin the adsp-sdk MCP server in .mcp.json to an @abgov/adsp-sdk-mcp-server dev dependency, so the version an agent executes is the one the lockfile resolved rather than whatever npx fetches at session start.",
+      "implementation": "./src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server",
+      "prompt": "./src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.md"
     }
   }
 }

--- a/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
+++ b/packages/nx-adsp/src/generators/express-service/express-service.spec.ts
@@ -95,7 +95,7 @@ describe('Express Service Generator', () => {
     const mcp = readJson(host, '.mcp.json');
     expect(mcp.mcpServers['adsp-sdk']).toEqual({
       command: 'npx',
-      args: ['-y', '@abgov/adsp-sdk-mcp-server'],
+      args: ['--no', '@abgov/adsp-sdk-mcp-server'],
     });
     // Agents are pointed at the tools, not left to guess the SDK.
     const agents = host.read('apps/test/AGENTS.md').toString();

--- a/packages/nx-adsp/src/generators/init/init.spec.ts
+++ b/packages/nx-adsp/src/generators/init/init.spec.ts
@@ -16,7 +16,7 @@ describe('nx-adsp init generator', () => {
     const mcp = readJson(host, '.mcp.json');
     expect(mcp.mcpServers['adsp-sdk']).toEqual({
       command: 'npx',
-      args: ['-y', '@abgov/adsp-sdk-mcp-server'],
+      args: ['--no', '@abgov/adsp-sdk-mcp-server'],
     });
   });
 
@@ -36,6 +36,32 @@ describe('nx-adsp init generator', () => {
       command: 'node',
       args: ['/local/build/main.js'],
     });
+  });
+
+  it('adds the MCP server as a dev dependency, so the lockfile pins what runs', async () => {
+    await generator(host);
+
+    const packageJson = readJson(host, 'package.json');
+    expect(
+      packageJson.devDependencies['@abgov/adsp-sdk-mcp-server'],
+    ).toBeDefined();
+    expect(
+      packageJson.dependencies?.['@abgov/adsp-sdk-mcp-server'],
+    ).toBeUndefined();
+  });
+
+  it('does not bump a version a team has already pinned', async () => {
+    writeJson(host, 'package.json', {
+      name: 'test-workspace',
+      devDependencies: { '@abgov/adsp-sdk-mcp-server': '1.11.0' },
+    });
+
+    await generator(host);
+
+    const packageJson = readJson(host, 'package.json');
+    expect(packageJson.devDependencies['@abgov/adsp-sdk-mcp-server']).toBe(
+      '1.11.0',
+    );
   });
 
   it('reminds that a session reconnect is needed before the MCP server is usable', async () => {

--- a/packages/nx-adsp/src/generators/init/init.ts
+++ b/packages/nx-adsp/src/generators/init/init.ts
@@ -1,5 +1,6 @@
 import { Tree, formatFiles, installPackagesTask } from '@nx/devkit';
-import { addAdspMcpServer, addVsCodeSettings } from '../../utils/quality';
+import { addVsCodeSettings } from '../../utils/quality';
+import { addAdspMcpServer } from '../../utils/mcp';
 
 // express-service writes CLIENT_SECRET, DATABASE_URL, and MONGODB_URI to
 // .env.local — these must be gitignored before any generator run can commit.

--- a/packages/nx-adsp/src/generators/init/init.ts
+++ b/packages/nx-adsp/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { Tree, formatFiles } from '@nx/devkit';
+import { Tree, formatFiles, installPackagesTask } from '@nx/devkit';
 import { addAdspMcpServer, addVsCodeSettings } from '../../utils/quality';
 
 // express-service writes CLIENT_SECRET, DATABASE_URL, and MONGODB_URI to
@@ -38,4 +38,10 @@ export default async function (host: Tree) {
   addAdspMcpServer(host);
   addVsCodeSettings(host);
   await formatFiles(host);
+  // addAdspMcpServer adds a dev dependency, so standalone runs need the install.
+  // App/service generators discard this and return their own install task —
+  // same package.json in the same Tree, so the dependency still lands.
+  return () => {
+    installPackagesTask(host);
+  };
 }

--- a/packages/nx-adsp/src/generators/init/schema.json
+++ b/packages/nx-adsp/src/generators/init/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/schema",
   "id": "NxAdspInit",
   "title": "nx-adsp workspace setup",
-  "description": "Sets up nx-adsp's own workspace-root concerns: registers the @abgov/adsp-sdk-mcp-server MCP server in .mcp.json, and shared VS Code settings. Run once per workspace, right after installing @abgov/nx-adsp — every app/service generator (express-service, react-app, angular-app, vue-app) already calls this as one of its own steps, but running it standalone lets grounded ADSP platform knowledge be available before any app exists, e.g. during a design pass. Idempotent — safe to re-run, never clobbers a customized entry.",
+  "description": "Sets up nx-adsp's own workspace-root concerns: installs the @abgov/adsp-sdk-mcp-server MCP server as a dev dependency and registers it in .mcp.json, and shared VS Code settings. Run once per workspace, right after installing @abgov/nx-adsp — every app/service generator (express-service, react-app, angular-app, vue-app) already calls this as one of its own steps, but running it standalone lets grounded ADSP platform knowledge be available before any app exists, e.g. during a design pass. Idempotent — safe to re-run, never clobbers a customized entry or a version you've pinned yourself.",
   "type": "object",
   "properties": {},
   "required": [],

--- a/packages/nx-adsp/src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.md
+++ b/packages/nx-adsp/src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.md
@@ -1,0 +1,36 @@
+# Pin the ADSP SDK MCP server
+
+The codemod half of this migration has already run. It rewrote the workspace-root
+`.mcp.json` `adsp-sdk` entry from `npx -y @abgov/adsp-sdk-mcp-server` to
+`npx --no @abgov/adsp-sdk-mcp-server` and added `@abgov/adsp-sdk-mcp-server` to
+`devDependencies` — **unless** the entry had been customised, in which case it warned and
+left it alone. Your job is only the customised case.
+
+## Why the change
+
+npm assumes `--yes` whenever stdin isn't a TTY, which is always true for a stdio MCP
+server. So the old `npx -y` form fetched and executed whatever the registry resolved at
+session start — the server _and_ its transitive dependencies
+(`@modelcontextprotocol/sdk`, `zod`, `@abgov/adsp-cli`), outside the lockfile and
+invisible to `npm audit`. `--no` resolves the local install instead and fails loudly if
+it's missing, so the version your agent executes is the one your lockfile pinned.
+
+## What to do
+
+Check `agentContext` for the entry that was skipped. If there is none, there is nothing
+to do — stop here and say so.
+
+Otherwise, read the `adsp-sdk` entry in `.mcp.json` and decide:
+
+- **It points at a local build** (e.g. `node /path/to/main.js`) — deliberate. Leave it,
+  and say why you left it.
+- **It runs `npx` in any other form** — pin it. Add
+  `@abgov/adsp-sdk-mcp-server` to `devDependencies` (use the version already named in the
+  entry's args if there is one, otherwise `^1.12.1`), then set the entry's `args` to
+  `["--no", "@abgov/adsp-sdk-mcp-server"]`. Preserve every other field on the entry, and
+  every other server in the file.
+
+Do not touch any other `mcpServers` entry — they belong to other plugins or to the team.
+
+Finish by telling the user to install dependencies and then reconnect their MCP client,
+since a project-scoped server loads only at session start.

--- a/packages/nx-adsp/src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.spec.ts
+++ b/packages/nx-adsp/src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.spec.ts
@@ -1,0 +1,134 @@
+import { readJson, Tree, writeJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './pin-adsp-mcp-server';
+
+const PACKAGE = '@abgov/adsp-sdk-mcp-server';
+
+describe('pin-adsp-mcp-server migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  });
+
+  function writeMcpJson(entry: unknown, others: Record<string, unknown> = {}) {
+    writeJson(tree, '.mcp.json', {
+      mcpServers: { ...others, 'adsp-sdk': entry },
+    });
+  }
+
+  it('rewrites the fetching entry to the pinned form and adds the dev dependency', async () => {
+    writeMcpJson({ command: 'npx', args: ['-y', PACKAGE] });
+
+    await migration(tree);
+
+    expect(readJson(tree, '.mcp.json').mcpServers['adsp-sdk']).toEqual({
+      command: 'npx',
+      args: ['--no', PACKAGE],
+    });
+    expect(
+      readJson(tree, 'package.json').devDependencies[PACKAGE],
+    ).toBeDefined();
+  });
+
+  it('leaves other MCP servers alone', async () => {
+    writeMcpJson(
+      { command: 'npx', args: ['-y', PACKAGE] },
+      { other: { command: 'other-cmd', args: ['-y', 'something'] } },
+    );
+
+    await migration(tree);
+
+    expect(readJson(tree, '.mcp.json').mcpServers.other).toEqual({
+      command: 'other-cmd',
+      args: ['-y', 'something'],
+    });
+  });
+
+  it('is idempotent, and backfills the dependency for an already-pinned entry', async () => {
+    writeMcpJson({ command: 'npx', args: ['--no', PACKAGE] });
+
+    await migration(tree);
+
+    expect(readJson(tree, '.mcp.json').mcpServers['adsp-sdk']).toEqual({
+      command: 'npx',
+      args: ['--no', PACKAGE],
+    });
+    expect(
+      readJson(tree, 'package.json').devDependencies[PACKAGE],
+    ).toBeDefined();
+  });
+
+  it('does not bump a version the workspace already chose', async () => {
+    writeJson(tree, 'package.json', {
+      name: 'test-workspace',
+      devDependencies: { [PACKAGE]: '1.11.0' },
+    });
+    writeMcpJson({ command: 'npx', args: ['-y', PACKAGE] });
+
+    await migration(tree);
+
+    expect(readJson(tree, 'package.json').devDependencies[PACKAGE]).toBe(
+      '1.11.0',
+    );
+  });
+
+  it('warns and skips a customised entry rather than rewriting it', async () => {
+    const custom = { command: 'node', args: ['/local/build/main.js'] };
+    writeMcpJson(custom);
+
+    const report = await migration(tree);
+
+    expect(readJson(tree, '.mcp.json').mcpServers['adsp-sdk']).toEqual(custom);
+    expect(
+      readJson(tree, 'package.json').devDependencies?.[PACKAGE],
+    ).toBeUndefined();
+    expect(report?.nextSteps.join('\n')).toContain('.mcp.json');
+    expect(report?.agentContext?.join('\n')).toContain('customised');
+  });
+
+  it('skips an entry that pins a version in args, since that is not the generated form', async () => {
+    const pinnedInArgs = { command: 'npx', args: ['-y', `${PACKAGE}@1.11.0`] };
+    writeMcpJson(pinnedInArgs);
+
+    const report = await migration(tree);
+
+    expect(readJson(tree, '.mcp.json').mcpServers['adsp-sdk']).toEqual(
+      pinnedInArgs,
+    );
+    expect(report?.nextSteps).toHaveLength(1);
+  });
+
+  it('does nothing when the workspace has no .mcp.json', async () => {
+    const report = await migration(tree);
+
+    expect(report).toBeUndefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies?.[PACKAGE],
+    ).toBeUndefined();
+  });
+
+  it('does nothing when .mcp.json has no adsp-sdk server', async () => {
+    writeJson(tree, '.mcp.json', {
+      mcpServers: { other: { command: 'other-cmd', args: [] } },
+    });
+
+    const report = await migration(tree);
+
+    expect(report).toBeUndefined();
+    expect(
+      readJson(tree, 'package.json').devDependencies?.[PACKAGE],
+    ).toBeUndefined();
+  });
+
+  it('warns and leaves an unparseable .mcp.json untouched', async () => {
+    tree.write('.mcp.json', '{ not json');
+    const warn = jest.spyOn(console, 'warn').mockImplementation();
+
+    const report = await migration(tree);
+
+    expect(report).toBeUndefined();
+    expect(tree.read('.mcp.json', 'utf-8')).toBe('{ not json');
+    warn.mockRestore();
+  });
+});

--- a/packages/nx-adsp/src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.ts
+++ b/packages/nx-adsp/src/migrations/pin-adsp-mcp-server/pin-adsp-mcp-server.ts
@@ -1,0 +1,136 @@
+import {
+  addDependenciesToPackageJson,
+  formatFiles,
+  logger,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
+
+const MCP_PATH = '.mcp.json';
+const SERVER_KEY = 'adsp-sdk';
+const PACKAGE = '@abgov/adsp-sdk-mcp-server';
+
+// The version this migration pins to, and the entry it knows how to rewrite,
+// are both frozen literals rather than imports from utils/quality.ts. A
+// released migration has to keep applying the same change forever, so reading
+// the live value would let a later edit there silently change what this
+// migration does to an old workspace.
+const PINNED_VERSION = '^1.12.1';
+const PRIOR_ENTRY = { command: 'npx', args: ['-y', PACKAGE] };
+const PINNED_ENTRY = { command: 'npx', args: ['--no', PACKAGE] };
+
+// Only ever compared against the two-key entry this generator emits, so key
+// order is the sole structural difference JSON.stringify can't see — and
+// `args` is the one field whose order is meaningful.
+function isEntry(value: unknown, expected: Record<string, unknown>): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const keys = Object.keys(value);
+  if (keys.length !== Object.keys(expected).length) return false;
+  return keys.every(
+    (key) =>
+      JSON.stringify((value as Record<string, unknown>)[key]) ===
+      JSON.stringify(expected[key]),
+  );
+}
+
+// Retrofits the supply-chain fix into workspaces scaffolded with the earlier
+// `npx -y @abgov/adsp-sdk-mcp-server` entry. npm assumes `--yes` whenever stdin
+// isn't a TTY — always the case for a stdio MCP server — so that form fetches
+// and executes whatever the registry currently resolves, outside the lockfile
+// and invisible to `npm audit`, together with its transitive dependencies.
+//
+// A migration is the only route to an already-scaffolded workspace: init
+// deliberately never clobbers an existing `adsp-sdk` entry (a team may have
+// pinned it or repointed it at a local build), so re-running it would add the
+// dependency and leave the fetching command form in place.
+interface MigrationReport {
+  nextSteps: string[];
+  agentContext?: string[];
+}
+
+export default async function pinAdspMcpServer(
+  tree: Tree,
+): Promise<MigrationReport | undefined> {
+  // No .mcp.json, or no entry in it, means nx-adsp's init never ran here —
+  // there's no server to pin, and adding the dependency would be noise.
+  if (!tree.exists(MCP_PATH)) {
+    return undefined;
+  }
+
+  let entry: unknown;
+  try {
+    entry = JSON.parse(tree.read(MCP_PATH, 'utf-8') ?? '{}')?.mcpServers?.[
+      SERVER_KEY
+    ];
+  } catch {
+    logger.warn(
+      `[nx-adsp] ${MCP_PATH} is not valid JSON — left untouched. Re-run ` +
+        `\`nx g @abgov/nx-adsp:init\` once it parses.`,
+    );
+    return undefined;
+  }
+
+  if (entry === undefined) {
+    return undefined;
+  }
+
+  // Already pinned, by a newer generator or a previous run of this migration.
+  // Still ensure the dependency is present: the entry is only a real pin if
+  // there's a local install for `--no` to resolve.
+  const alreadyPinned = isEntry(entry, PINNED_ENTRY);
+
+  if (!alreadyPinned && !isEntry(entry, PRIOR_ENTRY)) {
+    logger.warn(
+      `[nx-adsp] ${MCP_PATH}'s "${SERVER_KEY}" server is customised — left ` +
+        `untouched rather than rewritten.`,
+    );
+    return {
+      nextSteps: [
+        `${MCP_PATH}'s "${SERVER_KEY}" entry differs from the generated one, so it was ` +
+          `left as-is. If it still runs \`npx\` without \`--no\`, the version your agent ` +
+          `executes is whatever the registry resolves at session start — outside your ` +
+          `lockfile and invisible to \`npm audit\`. To pin it, add ${PACKAGE} to ` +
+          `devDependencies and change the entry's args to ` +
+          `${JSON.stringify(PINNED_ENTRY.args)}, keeping whatever else you've customised. ` +
+          `An entry deliberately pointing at a local build needs no change.`,
+      ],
+      agentContext: [
+        `${MCP_PATH} has a customised "${SERVER_KEY}" MCP server entry that this migration ` +
+          `did not rewrite. Read it, and unless it points at a local build, pin it: add ` +
+          `${PACKAGE} to devDependencies and set the entry's args to ` +
+          `${JSON.stringify(PINNED_ENTRY.args)}. Preserve any other customisation.`,
+      ],
+    };
+  }
+
+  addDependenciesToPackageJson(
+    tree,
+    {},
+    { [PACKAGE]: PINNED_VERSION },
+    'package.json',
+    // Respect a version the workspace already chose.
+    true,
+  );
+
+  if (!alreadyPinned) {
+    updateJson(tree, MCP_PATH, (json) => ({
+      ...json,
+      mcpServers: { ...json.mcpServers, [SERVER_KEY]: PINNED_ENTRY },
+    }));
+  }
+
+  await formatFiles(tree);
+  logger.info(
+    `[nx-adsp] Pinned the ${SERVER_KEY} MCP server to a ${PACKAGE} dev dependency.`,
+  );
+
+  return {
+    nextSteps: [
+      `Install dependencies, then reconnect (or restart) your MCP client — in that order. ` +
+        `\`npx --no\` will fall back to a copy left in npm's _npx cache by the previous ` +
+        `\`npx -y\` form, so until the dependency is actually installed you'd still be ` +
+        `running an unpinned version. Project-scoped MCP servers also load only at session ` +
+        `start, so the entry stays inert until the reconnect.`,
+    ],
+  };
+}

--- a/packages/nx-adsp/src/utils/mcp.ts
+++ b/packages/nx-adsp/src/utils/mcp.ts
@@ -1,0 +1,75 @@
+import {
+  addDependenciesToPackageJson,
+  Tree,
+  updateJson,
+  writeJson,
+} from '@nx/devkit';
+
+// Pinned rather than floating: `npx` resolves a bare package name against the
+// local project, so the lockfile entry this produces is what pins the server
+// and its whole transitive closure (@modelcontextprotocol/sdk, zod,
+// @abgov/adsp-cli) — none of which `npm audit` can see when the server is
+// fetched on demand instead. Bumping it for already-scaffolded workspaces
+// needs a migration; consuming workspaces on Dependabot/Renovate get a
+// reviewable PR instead of silent per-machine version drift.
+const ADSP_MCP_SERVER_VERSION = '^1.12.1';
+
+/**
+ * Registers the @abgov/adsp-sdk-mcp-server MCP server in the workspace-root
+ * `.mcp.json` so a coding agent (Claude Code and other MCP clients) can look up
+ * grounded ADSP docs and `@abgov/adsp-service-sdk` reference instead of guessing.
+ *
+ * It's a stdio knowledge server (no credentials), but wiring is not just config:
+ * it's also a dev dependency, so the version the client executes is the one the
+ * lockfile resolved and `npm audit` can see. `--no` is what makes that binding
+ * real — npm assumes `--yes` when stdin isn't a TTY, which is always the case for
+ * a stdio MCP server, so without it a resolution miss would silently fetch from
+ * the registry instead of failing. Merges into an existing `.mcp.json` and never
+ * clobbers a user-customized `adsp-sdk` entry (or a pinned version), so it's safe
+ * to re-run and to run for every generated service.
+ *
+ * The caller is responsible for the install task; every app/service generator
+ * already returns one for its own dependencies, and `init` returns one for this.
+ *
+ * The reconnect reminder lives here, not in each caller — project-scoped MCP
+ * servers load at session start, so a file write mid-session (whether from
+ * an app/service generator or the standalone `init` generator) leaves the
+ * entry configured but inert until the client reconnects, and every caller
+ * needs to say so, not just one.
+ */
+export function addAdspMcpServer(host: Tree): void {
+  const mcpPath = '.mcp.json';
+  const server = {
+    command: 'npx',
+    args: ['--no', '@abgov/adsp-sdk-mcp-server'],
+  };
+
+  addDependenciesToPackageJson(
+    host,
+    {},
+    { '@abgov/adsp-sdk-mcp-server': ADSP_MCP_SERVER_VERSION },
+    'package.json',
+    // A team may have pinned their own version; don't bump it out from under them.
+    true,
+  );
+
+  if (host.exists(mcpPath)) {
+    updateJson(host, mcpPath, (existing) => {
+      const mcpServers = { ...(existing?.mcpServers ?? {}) };
+      // Preserve an existing entry (a team may have pinned a version or repointed
+      // it at a local build) — only add ours when it isn't already configured.
+      mcpServers['adsp-sdk'] = mcpServers['adsp-sdk'] ?? server;
+      return { ...existing, mcpServers };
+    });
+  } else {
+    writeJson(host, mcpPath, { mcpServers: { 'adsp-sdk': server } });
+  }
+
+  console.log(
+    '\n✓ .mcp.json configures the ADSP SDK MCP server (adsp-sdk), pinned to the\n' +
+      '  @abgov/adsp-sdk-mcp-server dev dependency.\n' +
+      '  Project-scoped MCP servers load at session start, not on a mid-session file\n' +
+      '  change — install dependencies, then reconnect (or restart) your MCP client\n' +
+      '  before relying on it.\n',
+  );
+}

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -1,20 +1,10 @@
 import {
-  addDependenciesToPackageJson,
   readProjectConfiguration,
   Tree,
   updateJson,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
-
-// Pinned rather than floating: `npx` resolves a bare package name against the
-// local project, so the lockfile entry this produces is what pins the server
-// and its whole transitive closure (@modelcontextprotocol/sdk, zod,
-// @abgov/adsp-cli) — none of which `npm audit` can see when the server is
-// fetched on demand instead. Bumping it for already-scaffolded workspaces
-// needs a migration; consuming workspaces on Dependabot/Renovate get a
-// reviewable PR instead of silent per-machine version drift.
-const ADSP_MCP_SERVER_VERSION = '^1.12.1';
 
 /**
  * Rewrites the project-level eslint.config.mjs to add:
@@ -356,64 +346,4 @@ export function addVsCodeSettings(host: Tree): void {
   } else {
     writeJson(host, settingsPath, settings);
   }
-}
-
-/**
- * Registers the @abgov/adsp-sdk-mcp-server MCP server in the workspace-root
- * `.mcp.json` so a coding agent (Claude Code and other MCP clients) can look up
- * grounded ADSP docs and `@abgov/adsp-service-sdk` reference instead of guessing.
- *
- * It's a stdio knowledge server (no credentials), but wiring is not just config:
- * it's also a dev dependency, so the version the client executes is the one the
- * lockfile resolved and `npm audit` can see. `--no` is what makes that binding
- * real — npm assumes `--yes` when stdin isn't a TTY, which is always the case for
- * a stdio MCP server, so without it a resolution miss would silently fetch from
- * the registry instead of failing. Merges into an existing `.mcp.json` and never
- * clobbers a user-customized `adsp-sdk` entry (or a pinned version), so it's safe
- * to re-run and to run for every generated service.
- *
- * The caller is responsible for the install task; every app/service generator
- * already returns one for its own dependencies, and `init` returns one for this.
- *
- * The reconnect reminder lives here, not in each caller — project-scoped MCP
- * servers load at session start, so a file write mid-session (whether from
- * an app/service generator or the standalone `init` generator) leaves the
- * entry configured but inert until the client reconnects, and every caller
- * needs to say so, not just one.
- */
-export function addAdspMcpServer(host: Tree): void {
-  const mcpPath = '.mcp.json';
-  const server = {
-    command: 'npx',
-    args: ['--no', '@abgov/adsp-sdk-mcp-server'],
-  };
-
-  addDependenciesToPackageJson(
-    host,
-    {},
-    { '@abgov/adsp-sdk-mcp-server': ADSP_MCP_SERVER_VERSION },
-    'package.json',
-    // A team may have pinned their own version; don't bump it out from under them.
-    true,
-  );
-
-  if (host.exists(mcpPath)) {
-    updateJson(host, mcpPath, (existing) => {
-      const mcpServers = { ...(existing?.mcpServers ?? {}) };
-      // Preserve an existing entry (a team may have pinned a version or repointed
-      // it at a local build) — only add ours when it isn't already configured.
-      mcpServers['adsp-sdk'] = mcpServers['adsp-sdk'] ?? server;
-      return { ...existing, mcpServers };
-    });
-  } else {
-    writeJson(host, mcpPath, { mcpServers: { 'adsp-sdk': server } });
-  }
-
-  console.log(
-    '\n✓ .mcp.json configures the ADSP SDK MCP server (adsp-sdk), pinned to the\n' +
-      '  @abgov/adsp-sdk-mcp-server dev dependency.\n' +
-      '  Project-scoped MCP servers load at session start, not on a mid-session file\n' +
-      '  change — install dependencies, then reconnect (or restart) your MCP client\n' +
-      '  before relying on it.\n',
-  );
 }

--- a/packages/nx-adsp/src/utils/quality.ts
+++ b/packages/nx-adsp/src/utils/quality.ts
@@ -1,10 +1,20 @@
 import {
+  addDependenciesToPackageJson,
   readProjectConfiguration,
   Tree,
   updateJson,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
+
+// Pinned rather than floating: `npx` resolves a bare package name against the
+// local project, so the lockfile entry this produces is what pins the server
+// and its whole transitive closure (@modelcontextprotocol/sdk, zod,
+// @abgov/adsp-cli) — none of which `npm audit` can see when the server is
+// fetched on demand instead. Bumping it for already-scaffolded workspaces
+// needs a migration; consuming workspaces on Dependabot/Renovate get a
+// reviewable PR instead of silent per-machine version drift.
+const ADSP_MCP_SERVER_VERSION = '^1.12.1';
 
 /**
  * Rewrites the project-level eslint.config.mjs to add:
@@ -353,9 +363,17 @@ export function addVsCodeSettings(host: Tree): void {
  * `.mcp.json` so a coding agent (Claude Code and other MCP clients) can look up
  * grounded ADSP docs and `@abgov/adsp-service-sdk` reference instead of guessing.
  *
- * It's a stdio knowledge server (no credentials, run via npx), so wiring is just
- * config. Merges into an existing `.mcp.json` and never clobbers a user-customized
- * `adsp-sdk` entry, so it's safe to re-run and to run for every generated service.
+ * It's a stdio knowledge server (no credentials), but wiring is not just config:
+ * it's also a dev dependency, so the version the client executes is the one the
+ * lockfile resolved and `npm audit` can see. `--no` is what makes that binding
+ * real — npm assumes `--yes` when stdin isn't a TTY, which is always the case for
+ * a stdio MCP server, so without it a resolution miss would silently fetch from
+ * the registry instead of failing. Merges into an existing `.mcp.json` and never
+ * clobbers a user-customized `adsp-sdk` entry (or a pinned version), so it's safe
+ * to re-run and to run for every generated service.
+ *
+ * The caller is responsible for the install task; every app/service generator
+ * already returns one for its own dependencies, and `init` returns one for this.
  *
  * The reconnect reminder lives here, not in each caller — project-scoped MCP
  * servers load at session start, so a file write mid-session (whether from
@@ -365,7 +383,19 @@ export function addVsCodeSettings(host: Tree): void {
  */
 export function addAdspMcpServer(host: Tree): void {
   const mcpPath = '.mcp.json';
-  const server = { command: 'npx', args: ['-y', '@abgov/adsp-sdk-mcp-server'] };
+  const server = {
+    command: 'npx',
+    args: ['--no', '@abgov/adsp-sdk-mcp-server'],
+  };
+
+  addDependenciesToPackageJson(
+    host,
+    {},
+    { '@abgov/adsp-sdk-mcp-server': ADSP_MCP_SERVER_VERSION },
+    'package.json',
+    // A team may have pinned their own version; don't bump it out from under them.
+    true,
+  );
 
   if (host.exists(mcpPath)) {
     updateJson(host, mcpPath, (existing) => {
@@ -380,8 +410,10 @@ export function addAdspMcpServer(host: Tree): void {
   }
 
   console.log(
-    '\n✓ .mcp.json configures the ADSP SDK MCP server (adsp-sdk).\n' +
+    '\n✓ .mcp.json configures the ADSP SDK MCP server (adsp-sdk), pinned to the\n' +
+      '  @abgov/adsp-sdk-mcp-server dev dependency.\n' +
       '  Project-scoped MCP servers load at session start, not on a mid-session file\n' +
-      '  change — reconnect (or restart) your MCP client now before relying on it.\n',
+      '  change — install dependencies, then reconnect (or restart) your MCP client\n' +
+      '  before relying on it.\n',
   );
 }


### PR DESCRIPTION
## Why

`nx-adsp:init` wired the ADSP SDK knowledge server into the generated `.mcp.json` as
`npx -y @abgov/adsp-sdk-mcp-server`. That means the code an agent actually executes is whatever
the registry resolves at session start — the server *and* its transitive closure
(`@modelcontextprotocol/sdk`, `zod`, `@abgov/adsp-cli`, all on floating carets) — with:

- no lockfile entry, so no integrity check and no reproducibility;
- no visibility to `npm audit`, `Dependabot`, or CodeQL, in this repo or in the consuming
  workspace where `.mcp.json` lands;
- unsandboxed execution next to the developer's ambient credentials, and — via the agent-delivery
  harness's `register-mcp-servers.sh` — next to `GITHUB_TOKEN` on a CI runner;
- silent, per-machine version drift, so two developers can get different grounded answers about
  ADSP APIs with no signal anywhere.

`-y` wasn't even load-bearing for the silent fetch: npm assumes `--yes` whenever stdin isn't a
TTY, which is always true for a stdio MCP server.

## What changed

**`init` installs it instead of fetching it.** `addAdspMcpServer` adds
`@abgov/adsp-sdk-mcp-server@^1.12.1` to `devDependencies` with `keepExistingVersions`, so a
version a team pinned itself is respected, and emits `npx --no` in place of `npx -y`. `init`
returns an install task for standalone runs; app/service generators discard it and return their
own — same `package.json` in the same Tree, so the dependency still lands.

**A migration, because `init` alone can't reach existing workspaces.** `addAdspMcpServer`
deliberately never clobbers an existing `adsp-sdk` entry (a team may have repointed it at a local
build), so re-running `init` on an already-scaffolded workspace would add the dependency and leave
the fetching command form in place forever. `pin-adsp-mcp-server` rewrites the entry only when it
matches the verbatim prior form and warn-and-skips a customised one, with a paired prompt for that
judgment case. Its pinned version and prior-entry shape are frozen literals rather than imports
from `utils/quality.ts`, so a later edit there can't silently change what an already-released
migration does.

## Verified behaviour of `--no`

Measured, not assumed — the middle row is the guarantee, the third is a caveat worth knowing:

| State | What runs |
| --- | --- |
| dependency installed | the local copy — **beats** a warm `_npx` cache entry, so the lockfile governs |
| dependency missing, cold cache | hard error, exit 1: `npx canceled due to missing packages and no YES option` |
| dependency missing, cache warm from an earlier `npx -y` | silently runs the **stale cached copy** |

So `--no` can never pull a *newer* unpinned version from the registry, but it does treat a
populated `_npx` cache as satisfying the request. `npm install` therefore has to precede the MCP
client reconnect — the generator output, the README, and the migration's `nextSteps` all say so
explicitly.

## Note for review: the migration version

`13.33.0` is a prediction. `npm view @abgov/nx-adsp dist-tags` shows `latest: 13.32.0`, so it's
correct only if this lands as a `feat` — which is why the commit is typed `feat` rather than `fix`.
A `fix` would release `13.32.1` and the migration would then not run until a workspace reached
`13.33.0`. **The commit type and the migration version have to stay in agreement**, so please don't
squash this to a different type without bumping `migrations.json` to match.

## Module placement (second commit)

`addAdspMcpServer` lived in `utils/quality.ts`, which is per-project quality tooling — six of its
exports take a `projectRoot`/`projectName` and configure ESLint, Jest coverage, Semgrep, axe, or
Playwright for one project. The MCP function takes only the `Tree`, writes workspace-root files,
and after the first commit was also the only function in that module mutating `package.json`, with
a dependency-version constant sitting above the ESLint rules.

`refactor(nx-adsp): move the MCP server wiring out of the quality module` extracts it to
`utils/mcp.ts`, following the `utils/nginx.ts` precedent of one module per concern. Note
`utils/agent.ts` is a false friend — it's the ADSP agent-service consultation, a runtime
conversation with a platform agent, not coding-agent tooling. Behavior unchanged; the MCP wiring is
covered through the generators that call it, and `quality.spec.ts` never covered it.

Not bundled in: `addVsCodeSettings` has the same scope mismatch in `quality.ts` (Tree-only,
workspace-root) and is the other of `init`'s two imports. It predates this PR, so it's flagged
rather than moved.

## Gate

- `nx test nx-adsp` — 272 passed (10 new migration tests, 2 new `init` tests)
- `nx lint nx-adsp` — 0 errors (2 pre-existing warnings, untouched)
- `nx build nx-adsp` — clean; `build-assets.spec.ts` confirms the new prompt file resolves and ships
- `nx run nx-adsp-e2e:e2e` — passed (blocking)
- `secretlint` on changed files — clean

Out of scope, flagged not fixed: `npm audit` reports 19 pre-existing vulnerabilities (12 high) in
already-installed dependencies. This PR adds nothing to this repo's `package.json`, so none of it
originates here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

