### PR TITLE
docs(nx-agent): fix the lineage README's stale behaviour and req-002's false premise

### DIFF
--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -415,14 +415,35 @@ retrospective that already exists throws rather than silently overwriting or dup
 Scans the whole workspace for `project-docs/` artifacts and `project-docs-ancestors` references —
 across both doc frontmatter and code comments — and writes the resulting graph to
 `.nx-agent/lineage.json` (gitignored automatically; it's fully derived from other files, so
-committing it would just create a second, driftable source of truth). Throws if it finds a
-reference that doesn't resolve to anything; reports an artifact nothing references yet (an orphan)
-without failing, since that's a normal, temporary state, not a mistake.
+committing it would just create a second, driftable source of truth). Every violation it finds is
+**recorded in the output rather than aborting the write** — the consumer that acts on one is a
+script reading that file (`agent-delivery`'s task-identification), not a human reading this
+console, so aborting would take every unrelated fact in the graph down over one dangling reference
+and disable the very mechanism that reports it.
+
+Five violation categories, three of which `--strict` fails on:
+
+| Category          | What it is                                                       | Under `--strict` |
+| ----------------- | ---------------------------------------------------------------- | ---------------- |
+| `brokenRefs`      | a reference whose target doesn't exist                           | **fails**        |
+| `unparseableRefs` | a reference token that doesn't fit the `<type>[:<id>]` grammar   | **fails**        |
+| `yamlErrors`      | frontmatter that doesn't parse as YAML                           | **fails**        |
+| `orphans`         | nothing references it yet (see below)                            | reported only    |
+| `unscoped`        | missing an _expected_ ancestor type (see `artifact-schema.json`) | reported only    |
+
+The bottom two never fail, in either mode: an artifact nothing implements yet is a normal,
+temporary state, not a mistake. `resolutionStatus` is reported alongside them but is a status
+rather than a violation.
 
 ```bash
 npx nx g @abgov/nx-agent:project-docs-lineage
 npx nx g @abgov/nx-agent:project-docs-lineage --dry-run   # compute and report, write nothing
+npx nx g @abgov/nx-agent:project-docs-lineage --strict     # non-zero exit on a violation, for a gate
 ```
+
+Use `--strict` as a gate, not to build the graph: Nx rolls a generator's staged write back when it
+throws, so a failing `--strict` run deliberately produces no `lineage.json` at all. Anything that
+needs both the graph and the exit code has to run it twice.
 
 The `project-docs-ancestors` convention itself: a directive used identically in frontmatter (a YAML
 list) and code comments (comma-separated on one line), shaped `<type>[:<id>][#fragment]`. `type` is
@@ -435,8 +456,9 @@ An optional project qualifier (`<project>/type:id`) scopes the reference to that
 `project-docs/` instead of the workspace root's — never implicit, even from within that same
 project, so a reference's meaning never depends on where it's found.
 
-Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself (or `--dry-run`
-it in your own CI) after adding or changing a reference.
+Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself after adding or
+changing a reference, and `--strict` it in your own CI if you want a broken reference to fail the
+build (`--dry-run` alone reports without affecting the exit code).
 
 Also reports which `open-question`/`blocker` artifacts are still open versus resolved — see
 `resolutionStatus` below.
@@ -507,9 +529,14 @@ prose, same as an `orphan` doesn't try to distinguish "temporary" from "abandone
 
 `@abgov/nx-agent` also exports two read functions — its first public, importable API; everything
 else in the package is consumed only via `nx g @abgov/nx-agent:x`. Meant for a caller that needs a
-stable contract (an ESLint rule, an agent resolving context for a file it's about to touch), not
-one that wants to parse `.nx-agent/lineage.json` directly — that file's exact shape stays an
-internal implementation detail, free to change as long as these signatures don't.
+stable contract in JS — an ESLint rule, or a build step resolving context for a file it's about to
+touch — not one that wants to parse `.nx-agent/lineage.json` directly, since that file's exact
+shape stays an internal implementation detail, free to change as long as these signatures don't.
+
+An **agent** is not that caller, deliberately: the generated `design`, `develop` and `discover`
+skills all instruct the agent to run the generator and read `lineage.json`'s `index` and
+`violations` instead, on the grounds that calling a JS API isn't something an agent does mid-task.
+So the split is agents read the file, JS callers use these functions, gates use `--strict`.
 
 ```typescript
 import { getAncestors, getDescendants } from '@abgov/nx-agent';

--- a/project-docs/requirements/lineage-registry-entry-carries-non-structural-frontmatter-metadata.md
+++ b/project-docs/requirements/lineage-registry-entry-carries-non-structural-frontmatter-metadata.md
@@ -26,6 +26,11 @@ rules:
          When: the registry entry is built;
          Then: metadata is {}"
     questions: []
-questions:
-  - "lineage.json is committed to the repository; should any class of frontmatter field be excluded from metadata on the grounds that project-docs/ artifacts could inadvertently contain sensitive content (e.g. an internal endpoint URL or credential pasted into a notes field)? Current proposal: pass all non-structural fields verbatim with no filtering. Advisory for development-tooling context."
+  - rule: no class of non-structural field is withheld from metadata on sensitive-content grounds
+    examples:
+      - "Given: a registered artifact whose frontmatter carries a notes field holding an internal endpoint URL;
+         When: the registry entry is built;
+         Then: metadata contains notes verbatim, neither filtered nor redacted"
+    questions: []
+questions: []
 ---


### PR DESCRIPTION
Findings 1 and 2 from an integrity review of the lineage system. Both are documentation/spec
defects — no behaviour changes, no code touched.

Each finding was re-derived against `2c6eb5e` before fixing; both still held.

## F1 — the README contradicted `schema.json`

`README.md:418` described the **pre-`836a6b1`** behaviour:

> Throws if it finds a reference that doesn't resolve to anything

…and `grep -c strict packages/nx-agent/README.md` returned **0**. Meanwhile `schema.json:5` and
`:11` documented record-don't-throw *and* the `--strict` write-rollback caveat correctly. Two
descriptions of one generator disagreed, and the stale one was in the file a reader reaches first.

That reintroduces at the documentation layer exactly what `836a6b1` fixed: someone wiring this into
CI on the README's description expects a non-zero exit on a broken reference, gets exit 0, and the
violation sits recorded in a gitignored file they aren't reading.

The section now names all five categories and which three `--strict` fails on. These were read off
the generator's own `failures` assembly (`project-docs-lineage.ts:92-105`), not paraphrased:

| Category | Under `--strict` |
| --- | --- |
| `brokenRefs`, `unparseableRefs`, `yamlErrors` | **fail** |
| `orphans`, `unscoped` | reported only |

`unparseableRefs` and `yamlErrors` appeared **nowhere** in the README before this, despite both
being strict failures.

Two adjacent stale sentences in the same section went with it:

- the CI advice recommended `--dry-run`, the one mode that cannot gate anything;
- **Programmatic access** named "an agent resolving context for a file it's about to touch" as an
  intended caller of `getAncestors`/`getDescendants`, while the shipped `design`, `develop` and
  `discover` skills all tell the agent to read `lineage.json` instead
  (`design/SKILL.md:43`: "not something an agent" does). The skills are right; the README was stale.

## F2 — `req-002`'s open question rested on a false premise

The question opened with *"lineage.json is committed to the repository"*, and that premise was the
whole basis for asking whether any frontmatter field should be withheld from `metadata` on
sensitive-content grounds.

It is not committed: `.gitignore:51` carries `.nx-agent/`, nothing named `lineage.json` is tracked,
the README says it is gitignored deliberately (a derived file would be a second driftable source of
truth), and `project-docs-lineage.ts`'s own comment relies on the same fact. Three of four in-repo
statements agreed — the requirement was the outlier, and the one place the fact was load-bearing.

So the exposure does not exist in the form described. A derived, gitignored file cannot carry a
pasted credential into the repository, and a credential pasted into a `project-docs/` artifact is
already exposed in that artifact — which *is* committed and *is* scanned, verified: `.husky/pre-commit`
pipes every staged file to `secretlint` with no path or extension filter, so `project-docs/*.md` is
covered. Filtering `metadata` would not have addressed it.

**Answered rather than reworded**: no filtering, for a better reason than the original proposal
gave. Requirement artifacts here are frontmatter-only (all four have zero body prose), so the answer
lands as a fourth rule with an example that makes it testable. Top-level `questions` is now `[]`,
matching its three siblings.

Verified the edit round-trips through the graph it specifies — `metadata` now carries its own new
rule:

```
key: requirements:lineage-registry-entry-carries-non-structural-frontmatter-metadata
id: req-002 | rules: 4 | questions: []
```

## Gate

- `nx test nx-agent` — 275 passed
- `nx lint nx-agent` — 0 errors (26 pre-existing warnings, untouched)
- `nx build nx-agent` — clean
- `project-docs-lineage --strict` — passes, no violations
- `secretlint` on changed files — clean
- YAML validated with `js-yaml` directly before trusting the lineage run, since a parse error there
  surfaces as `unscoped` rather than as an error

## Note for review

Typed `docs:`, so this triggers **no release** — the corrected README won't reach npm until the next
`feat`/`fix` on `nx-agent`. The GitHub copy is correct immediately, which is where most readers land.
Say so if you'd rather have it published now and I'll retype the first commit as a `fix`.

Findings 3–6 (cycle detection, `expectedAncestorTypes` validation, the ancestor-digest staleness
proposal, and versioning the `lineage.json` interface) are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
