### PR TITLE
feat(nx-agent): version, reshape and extend the lineage graph (E3, F3, F4, F5)

### DIFF
--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -143,7 +143,7 @@ pass genuinely resolved. Captures two things nothing else durably records:
 
 One file, written once this iteration's own work concludes, not a new checkpoint with its own
 gate — the generator self-registers the type (`expectedAncestorTypes: []`, `terminal: true`) so
-this type's own correctly-having-zero-descendants doesn't get reported as an orphan alongside a
+this type's own correctly-having-zero-descendants doesn't get reported as unreferenced alongside a
 genuine dead-end.
 
 ### Commit, when this pass actually generates something

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -57,7 +57,7 @@ scope here.
    `resolves` frontmatter field, also mirrored into `project-docs-ancestors`) is what makes a
    resolution structural — describe the aggregate and its invariants, resolving each named
    Question in the model's own text, with the `resolves:` reference as what a fresh reader (or
-   `project-docs-lineage`'s `resolutionStatus` field) can check without reading that prose.
+   `project-docs-lineage`'s `status.resolution` field) can check without reading that prose.
 
    If a Question needs real information nobody in this pass has, don't guess — stop and ask, or
    write an explicitly-marked placeholder decision if told to keep moving; a placeholder still

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -145,7 +145,7 @@ blocking status depends on whether this project has a CI backstop yet — see be
   already present in scaffolding before this pass touched anything is drift to flag, not a reason
   to block.
 - **`project-docs-lineage --strict`** blocks on a broken reference, as always — `--strict` is what
-  makes it fail the command rather than just record the reference in `lineage.json`. Its orphan/unscoped report
+  makes it fail the command rather than just record the reference in `lineage.json`. Its `status` report (unreferenced, unscoped)
   should be empty by the time a resource's code exists and correctly references its api-design.
 
 ### Independent code review — every pass

--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -96,7 +96,7 @@ written by a generator's own `--resolves <path>` flag (`feature`/`domain-term`/`
 `domain-model`) or by hand for a type with no generator yet (`api-design`, `ux-design`). Never a
 separate edit on the open-question/blocker file itself, and an unrelated later edit to the target
 doesn't count as resolving anything. `project-docs-lineage` reports resolution status directly
-(`violations.resolutionStatus.open`/`.resolved`) — nothing to compute or register by hand.
+(`status.resolution.open`/`.resolved`) — nothing to compute or register by hand.
 
 **`bug` also tracks open/resolved status this same generic way, but is resolved differently** — see
 `develop/SKILL.md`'s own bug-handling section; Discover never resolves one directly.
@@ -132,7 +132,7 @@ These check different things:
 - `project-docs-lineage`'s broken-reference check always blocks, regardless of mode — `--strict`
   is what turns a recorded broken reference into a failing command, and composes with
   `--dry-run` to check without writing anything. Its
-  `orphans` report is a graph fact (has Design picked this requirement up yet), not an
+  `unreferenced` report is a graph fact (has Design picked this requirement up yet), not an
   example-mapping check — it stays true even after perfect example-mapping, since nothing
   downstream exists yet.
 - `check-example-mapping.mjs` is the actual example-mapping gate: every `rules:` entry needs a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -737,7 +737,7 @@ is left or the `MAX_ITERATIONS` cap is hit.
 | Branch prefix | Signal types eligible                                               | Typical use                                                                                         |
 | ------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `feature/**`  | All (discover → design → develop → deploy)                          | Advancing a new capability from a `features:` artifact through to Deploy                            |
-| `fix/**`      | Resolution only (`broken:`, `unparseable:`, `yaml-error:`, `open:`) | Resolving a specific blocker, open question, broken/unparseable reference, or malformed frontmatter |
+| `fix/**`      | Resolution only (`broken:`, `unparseable:`, `yaml-error:`, `cycle:`, `schema-error:`, `open:`) | Resolving a specific blocker, open question, broken/unparseable reference, reference cycle, misspelled schema expectation, or malformed frontmatter |
 
 Both branch types derive artifact scope from the first commit (see below). The `fix/**`
 restriction is enforced independently of scope — a scoped fix branch only sees resolution

--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -446,7 +446,7 @@ resolves: [blockers:no-write-packages-credential-for-ghcr-sandbox-push]
 
 Self-registers its own `project-docs/artifact-schema.json` entry as `terminal: true` — a
 correctly-closed-out retrospective has zero descendants by design, so it's excluded from
-`project-docs-lineage`'s orphan report rather than flagged alongside a genuine dead-end. Re-adding a
+`project-docs-lineage`'s `unreferenced` report rather than flagged alongside a genuine dead-end. Re-adding a
 retrospective that already exists throws rather than silently overwriting or duplicating it.
 
 ---
@@ -694,7 +694,7 @@ an all-of list, not any-of: `domain-models` above requires an ancestor of _both_
 and `domain-terms`, not either — a model with only one is still missing part of the vocabulary it
 should be built from. An artifact whose type has an entry here but is missing an ancestor of one of
 the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
-as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
+as `unscoped` in `.nx-agent/lineage.json`'s `status`.
 
 `tracksResolution: true` is what makes `open-questions`/`blockers` show up in `status.resolution`
 (below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking

--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -195,7 +195,7 @@ resolves: []
 | `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this bug relates to, if already known — often genuinely empty until triaged      |
 
 A bug tracks open/resolved status the same generic way as `open-question`/`blocker`
-(`resolutionStatus.open`/`.resolved`), but resolves differently — see `develop/SKILL.md`'s bug-fixing
+(`status.resolution.open`/`.resolved`), but resolves differently — see `develop/SKILL.md`'s bug-fixing
 section in the `agent-delivery` output below. Investigating a bug and finding the _spec_ itself was
 wrong escalates to a real `blocker` against the implicated artifact; filing that blocker does not
 itself resolve the bug — only an `iteration-retrospective --resolves` naming the bug's own path does.
@@ -451,19 +451,171 @@ retrospective that already exists throws rather than silently overwriting or dup
 
 ---
 
+## `pin-ancestors`
+
+```bash
+npx nx g @abgov/nx-agent:pin-ancestors                              # whole workspace
+npx nx g @abgov/nx-agent:pin-ancestors --ancestor=domain-terms:case  # just this ancestor's descendants
+npx nx g @abgov/nx-agent:pin-ancestors --artifact=domain-models:x    # just this artifact's references
+```
+
+Records each resolved ancestor's current body digest on the `project-docs-ancestors` reference that
+names it, so `project-docs-lineage` can later report `status.stale`. Handles both YAML sequence
+styles the generators emit (block lists and flow lists) and **warns rather than skipping** on a
+form it can't rewrite — a silently unpinned reference is indistinguishable from a deliberately
+unpinned one, and would report nothing forever. A reference that doesn't resolve is left alone;
+that's a broken reference, and `project-docs-lineage` reports it as one.
+
+**Run it by hand. Never from a hook, a CI step, or a clean-run path.** A pin asserts _"I have read
+this ancestor as it stands"_ — a claim only a person can make. A blind bulk re-pin bakes in whatever
+drift already exists and then reports it as the floor. It's a separate generator rather than a
+`--repin` flag on `project-docs-lineage` for the same reason: that command reads and reports, and a
+mutation living next to `--strict` is how the check ends up silently dead in a workflow.
+
+Prefer `--ancestor`. "I revised one term, re-pin its descendants" is an act you can justify in a
+commit message; re-pinning the workspace is only ever "make the report stop." Because digests live
+in the committed artifact, either way the re-pin shows up in your own diff — which is what makes it
+reviewable, unlike a central baseline that re-seals where nobody looks.
+
+`resolves` lists are untouched: resolving an open question isn't a derivation, so the question's
+content moving doesn't invalidate the resolver.
+
 ## `project-docs-lineage`
 
 Scans the whole workspace for `project-docs/` artifacts and `project-docs-ancestors` references —
 across both doc frontmatter and code comments — and writes the resulting graph to
 `.nx-agent/lineage.json` (gitignored automatically; it's fully derived from other files, so
-committing it would just create a second, driftable source of truth). Throws if it finds a
-reference that doesn't resolve to anything; reports an artifact nothing references yet (an orphan)
-without failing, since that's a normal, temporary state, not a mistake.
+committing it would just create a second, driftable source of truth). Every violation it finds is
+**recorded in the output rather than aborting the write** — the consumer that acts on one is a
+script reading that file (`agent-delivery`'s task-identification), not a human reading this
+console, so aborting would take every unrelated fact in the graph down over one dangling reference
+and disable the very mechanism that reports it.
+
+Findings are split on a property intrinsic to the graph rather than on severity: **is the defect
+_in_ the graph, or is it a fact the graph is correctly reporting?**
+
+`integrity` means the graph can't be trusted as a graph. `--strict` fails on any of it, and that
+isn't configurable — a consumer asking "was this graph even constructible" isn't expressing a
+preference.
+
+| `integrity`       | What it is                                                             |
+| ----------------- | ---------------------------------------------------------------------- |
+| `brokenRefs`      | a declared edge whose endpoint doesn't exist                           |
+| `unparseableRefs` | a token that doesn't fit the `<type>[:<id>]` grammar at all            |
+| `yamlErrors`      | a node whose frontmatter couldn't be read, so its edges are unknown    |
+| `cycles`          | artifacts deriving from each other, so the ancestry is not a hierarchy |
+| `schemaErrors`    | an `expectedAncestorTypes` value misspelled from a real type           |
+
+`status` means the graph is sound and is telling you where the work stands. None of it fails
+`--strict`; gating on any of it is a project policy and belongs to you.
+
+| `status`       | What it is                                                            |
+| -------------- | --------------------------------------------------------------------- |
+| `resolution`   | `{ open, resolved }` — which `tracksResolution` artifacts are settled |
+| `unreferenced` | nothing derives from it yet (no inbound edges)                        |
+| `unscoped`     | every edge resolves, but an expected ancestor type is missing         |
+| `stale`        | a pinned ancestor was revised after this artifact derived from it     |
+
+`cycles` matters because `project-docs-ancestors` is a _derivation_ relation — two artifacts each
+declaring the other is contradictory, since neither can precede the other. Traversal always
+terminated safely on one; what it never did was say so, so `getAncestors(…, Infinity)` returned a
+correct-looking finite set that quietly omitted the fact that the ancestry wasn't a hierarchy.
+
+`schemaErrors` is deliberately narrow. A type is a literal `project-docs/` subfolder name with no
+authoritative list of valid ones, so an _unknown_ type is ambiguous — `requirements` expecting
+`product-briefs` before the first product brief exists looks identical to a misspelling, and
+flagging it would fail `--strict` on a correct schema. What is decidable is a value differing from a
+real type only by pluralization or case, which is the slip that actually happens (every type name is
+plural, so `bounded-context` is one keystroke from `bounded-contexts`). Those are reported with the
+type they meant, and are the only ones dropped from the `unscoped` check — one bad value would
+otherwise report every artifact of its type as unscoped, forever, pointing at artifacts that are
+correct.
+
+`stale` is the ancestor-digest mechanism. A reference may optionally record the ancestor's body
+digest at the time it was written — `domain-terms:case@a3f9c2e1b004` — and three states follow:
+
+| digest           | meaning                                             | report     |
+| ---------------- | --------------------------------------------------- | ---------- |
+| absent           | hand-authored, or predates adoption                 | **silent** |
+| present, matches | current                                             | silent     |
+| present, differs | the ancestor was revised after this derived from it | reported   |
+
+The silent first state is what makes it adoptable: turning this on reports nothing until something
+is deliberately pinned. Pin with `nx g @abgov/nx-agent:pin-ancestors`.
+
+**The digest covers the body only**, not frontmatter, and that isn't a shortcut. Recording a pin
+edits `project-docs-ancestors`, so a whole-file hash would make re-pinning a content change — one
+edit to a root would cascade staleness through the entire transitive descendancy in waves, each
+wave's fix triggering the next. A body digest stops at depth 1, and propagates one hop further
+exactly when a re-pin came _with_ a real revision, which is when descendants should look. It also
+keeps the hash independent of where a digest is stored, and avoids canonicalising a parsed YAML
+object to keep it stable.
+
+The cost is permanent rather than a wart to fix later: **a type that keeps its meaning in
+frontmatter is not covered at all.** `requirements` is that type — its `rules` _are_ the artifact —
+and they live there deliberately so a real YAML parser can read them (`check-example-mapping.mjs`
+had two regex-parsing bugs before the move). For those, a material change is a different artifact,
+not an edit.
+
+The body is normalised for line endings, trailing whitespace, and the blank line Prettier inserts
+after the frontmatter delimiter — that last one matters, since `formatFiles()` runs at the end of
+every generator and would otherwise invalidate a pin immediately after writing it.
+
+`status` is computed from **structure only** — edges and schema expectations. Status an artifact
+declares about itself in frontmatter (a `questions` list, a `status:` field) deliberately stays in
+`metadata`, passed through verbatim for you to interpret. The moment this computed a finding from
+one of those, it would have taken a position on your workflow, and being workflow-agnostic is what
+makes it consumable from outside.
 
 ```bash
 npx nx g @abgov/nx-agent:project-docs-lineage
 npx nx g @abgov/nx-agent:project-docs-lineage --dry-run   # compute and report, write nothing
+npx nx g @abgov/nx-agent:project-docs-lineage --strict     # non-zero exit on a violation, for a gate
+npx nx g @abgov/nx-agent:project-docs-lineage --json --quiet   # print the graph to stdout
 ```
+
+`--strict` on its own is a gate, not a way to build the graph: Nx rolls a generator's staged write
+back when it throws, so a failing `--strict` run deliberately produces no `lineage.json` at all.
+
+`--json` prints the same object to stdout instead of the human-readable summary — and because
+stdout isn't subject to that rollback, **`--json --strict` is the one invocation that yields both
+the graph and a failing exit code in a single run**. Pair it with `--quiet`, or Nx's own
+`NX Generating ...` banner lands on stdout ahead of the document.
+
+### The consumed shape
+
+`schemaVersion` versions the paths below, and only those. Everything else in the file is
+implementation detail and may change without a bump.
+
+| Path                          | Shape                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `schemaVersion`               | number — `1` today                                                                             |
+| `registry[<ref>]`             | `{ path, bodyDigest, ancestorRefs[], resolves[], metadata }`                                   |
+| `index[<ref>][]`              | `{ file, type?, metadata? }` — `type` only when the descendant is itself a registered artifact |
+| `integrity.brokenRefs[]`      | `{ ref, referencedFrom }`                                                                      |
+| `integrity.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
+| `integrity.yamlErrors[]`      | `{ path, error }`                                                                              |
+| `integrity.cycles[]`          | arrays of ref strings — one cycle each, first node not repeated                                |
+| `integrity.schemaErrors[]`    | `{ type, expectedAncestorType, didYouMean }`                                                   |
+| `status.resolution`           | `{ open[], resolved[] }`                                                                       |
+| `status.unreferenced[]`       | ref strings                                                                                    |
+| `status.unscoped[]`           | ref strings                                                                                    |
+| `status.stale[]`              | `{ artifact, ancestor, pinnedDigest, currentDigest }`                                          |
+| `violations`                  | **deprecated** — see below                                                                     |
+
+This records what is already load-bearing rather than adding a new promise. `agent-delivery`'s
+`task-identification.mjs` reads every one of those `violations` keys plus `registry[].ancestorRefs`,
+`registry[].path` and `index[].type`; the `design` and `develop` skills read `index` entries, and
+`discover` reads `status.resolution`. All of them are generated **write-if-missing**, so a
+workspace keeps its own copy and re-running the generator cannot repair a shape change — only a
+migration can. So pin `schemaVersion` and fail on an unexpected value rather than reading around a
+field that may have been renamed — `task-identification.mjs` does exactly that, and names both
+versions when they disagree.
+
+`violations` is a **deprecated** flat view of both containers, kept because those generated files
+can't be repaired by re-running the generator. It's assembled from the very same arrays as
+`integrity` and `status`, so it can't drift from them, and it will be removed at `schemaVersion` 2.
+Read the two containers instead.
 
 The `project-docs-ancestors` convention itself: a directive used identically in frontmatter (a YAML
 list) and code comments (comma-separated on one line), shaped `<type>[:<id>][#fragment]`. `type` is
@@ -476,11 +628,12 @@ An optional project qualifier (`<project>/type:id`) scopes the reference to that
 `project-docs/` instead of the workspace root's — never implicit, even from within that same
 project, so a reference's meaning never depends on where it's found.
 
-Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself (or `--dry-run`
-it in your own CI) after adding or changing a reference.
+Not yet wired into the pre-commit hook or an Nx inferred plugin — run it yourself after adding or
+changing a reference, and `--strict` it in your own CI if you want a broken reference to fail the
+build (`--dry-run` alone reports without affecting the exit code).
 
 Also reports which `open-question`/`blocker` artifacts are still open versus resolved — see
-`resolutionStatus` below.
+`status.resolution` below.
 
 ### `project-docs/artifact-schema.json`
 
@@ -496,9 +649,30 @@ whether its kind has a resolution lifecycle at all:
   "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] },
   "open-questions": { "expectedAncestorTypes": [], "tracksResolution": true },
   "blockers": { "expectedAncestorTypes": [], "tracksResolution": true },
-  "iteration-retrospectives": { "expectedAncestorTypes": [], "terminal": true }
+  "iteration-retrospectives": { "expectedAncestorTypes": [], "terminal": true },
+  "requirements": {
+    "expectedAncestorTypes": ["product-briefs"],
+    "digestFields": ["rules"]
+  }
 }
 ```
+
+`digestFields` names the frontmatter fields that carry a type's **content** rather than its
+bookkeeping, so they count toward its digest alongside the body (see `stale` above). It's a
+structural fact about where a type keeps its meaning, not a switch for whether the check runs.
+
+`requirements` is the only type that needs it, and measurably so: every other artifact kind has a
+639–6857 character body, while requirements have **none** — their `rules` _are_ the artifact, and
+they live in frontmatter deliberately so a real YAML parser can read them. So a change to `rules`
+marks descendants stale, while a `title` fix or an answered `question` does not. Absent or empty
+means body-only, which is right for every type that explains itself in prose, and a type with no
+`digestFields` keeps exactly the digest it had before this existed.
+
+One consequence worth knowing: because declared fields are hashed _alongside_ the body rather than
+instead of it, editing a requirement's rationale prose also marks its descendants stale. That
+over-fires slightly — rationale is explanatory, not contractual — but rationale is written once at
+creation, a requirement has few descendants, and the alternative (declared fields _replacing_ the
+body) would silently drop body coverage for any type that has meaningful content in both.
 
 `project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
 a hand-added entry for a custom artifact kind gets the same checks for free. `expectedAncestorTypes` is
@@ -508,29 +682,36 @@ should be built from. An artifact whose type has an entry here but is missing an
 the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
 as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 
-`tracksResolution: true` is what makes `open-questions`/`blockers` show up in `resolutionStatus`
+`tracksResolution: true` is what makes `open-questions`/`blockers` show up in `status.resolution`
 (below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking
 and gets settled by another artifact) gets the same open/resolved report for free by declaring it.
 
 `terminal: true` marks a type where zero descendants is what correct looks like, not a sign of
 neglect — a close-out/retrospective artifact, working exactly as intended, still has nothing ever
-built on top of it. See `orphans` below.
+built on top of it. See `unreferenced` below.
 
-### `orphans`
+### `unreferenced`
 
-`violations.orphans` lists every registered artifact nothing in the workspace references — the
+`status.unreferenced` lists every registered artifact nothing in the workspace references — the
 "nothing derives from it yet" case, distinct from `unscoped` (missing an _expected_ ancestor,
-the opposite direction). Two things feed correctly into what counts as "referenced":
+the opposite direction).
+
+Named for the mechanism rather than called `orphans`, which inverted the metaphor: references are
+backward-only, so this is an artifact with no _descendants_, while an orphan conventionally has no
+parents. In the direction derivation flows it's a leaf, minus the `terminal` types. The parentless
+case is `unscoped`.
+
+Two things feed correctly into what counts as "referenced":
 
 - A reference counts whether it's a plain `project-docs-ancestors` citation or a `resolves` one —
   a resolution is a real reference too, even when it's the only field naming the target (the normal
   shape for a hand-authored artifact, before its type earns a generator with a `--resolves` flag
   that would otherwise duplicate the ref into `project-docs-ancestors` for you).
-- A type with `terminal: true` is excluded from `orphans` entirely, regardless of descendant count.
+- A type with `terminal: true` is excluded from `unreferenced` entirely, regardless of descendant count.
 
-### `resolutionStatus`
+### `status.resolution`
 
-`violations.resolutionStatus` in `.nx-agent/lineage.json` splits every artifact whose type has
+`status.resolution` in `.nx-agent/lineage.json` splits every artifact whose type has
 `tracksResolution: true` into `open` and `resolved`:
 
 ```json
@@ -542,15 +723,20 @@ references it via `project-docs-ancestors`. That distinction matters: a `blocker
 `open-question` citing an existing one _because_ it's still unresolved would, under a looser
 "anything references it" test, get misread as having resolved it. A deferral (explicitly punted, not
 decided) isn't a third computed bucket — it stays `open`, with the _why_ left to the artifact's own
-prose, same as an `orphan` doesn't try to distinguish "temporary" from "abandoned."
+prose, same as `unreferenced` doesn't try to distinguish "temporary" from "abandoned."
 
 ### Programmatic access
 
 `@abgov/nx-agent` also exports two read functions — its first public, importable API; everything
 else in the package is consumed only via `nx g @abgov/nx-agent:x`. Meant for a caller that needs a
-stable contract (an ESLint rule, an agent resolving context for a file it's about to touch), not
-one that wants to parse `.nx-agent/lineage.json` directly — that file's exact shape stays an
-internal implementation detail, free to change as long as these signatures don't.
+stable contract in JS — an ESLint rule, or a build step resolving context for a file it's about to
+touch — not one that wants to parse `.nx-agent/lineage.json` directly, since that file's exact
+shape stays an internal implementation detail, free to change as long as these signatures don't.
+
+An **agent** is not that caller, deliberately: the generated `design`, `develop` and `discover`
+skills all instruct the agent to run the generator and read `lineage.json`'s `index` and
+`violations` instead, on the grounds that calling a JS API isn't something an agent does mid-task.
+So the split is agents read the file, JS callers use these functions, gates use `--strict`.
 
 ```typescript
 import { getAncestors, getDescendants } from '@abgov/nx-agent';
@@ -589,7 +775,7 @@ getAncestors(tree, 'apps/my-service/src/routes/collision-reports.ts', Infinity);
 Builds a single, self-contained HTML status report from the same data `project-docs-lineage`
 computes — a lineage graph (rendered with [Mermaid](https://mermaid.js.org/), inlined so the report
 needs nothing from `node_modules` to open), a status summary (counts per type, open vs. resolved,
-orphans, broken references), and a per-artifact table. Not committed — like `lineage.json`, it's
+unreferenced artifacts, broken references), and a per-artifact table. Not committed — like `lineage.json`, it's
 100% derived from other files, so it's gitignored automatically at wherever it's actually written.
 
 ```bash
@@ -608,7 +794,7 @@ of bad news is the point of a status report, not something to gate on.
 ### `--project` scoping
 
 `registry`/`index`/`violations` are always computed over the full workspace first, unconditionally —
-an artifact's orphan/resolved status is a workspace-wide fact, and building the index from only one
+an artifact's unreferenced/resolved status is a workspace-wide fact, and building the index from only one
 project's files would misclassify anything referenced across a project boundary (a cross-project
 reference is real, not a mistake). `--project` filters what's _rendered_, not what's computed: the
 summary/counts/table include only that project's own artifacts; the graph additionally shows each

--- a/docs/nx-agent/nx-agent.md
+++ b/docs/nx-agent/nx-agent.md
@@ -504,7 +504,7 @@ preference.
 | `unparseableRefs` | a token that doesn't fit the `<type>[:<id>]` grammar at all            |
 | `yamlErrors`      | a node whose frontmatter couldn't be read, so its edges are unknown    |
 | `cycles`          | artifacts deriving from each other, so the ancestry is not a hierarchy |
-| `schemaErrors`    | an `expectedAncestorTypes` value misspelled from a real type           |
+| `schemaErrors`    | an `artifact-schema.json` entry that can never do what it says         |
 
 `status` means the graph is sound and is telling you where the work stands. None of it fails
 `--strict`; gating on any of it is a project policy and belongs to you.
@@ -521,7 +521,10 @@ declaring the other is contradictory, since neither can precede the other. Trave
 terminated safely on one; what it never did was say so, so `getAncestors(…, Infinity)` returned a
 correct-looking finite set that quietly omitted the fact that the ancestry wasn't a hierarchy.
 
-`schemaErrors` is deliberately narrow. A type is a literal `project-docs/` subfolder name with no
+`schemaErrors` covers both declarations in `artifact-schema.json` that can never do what they say,
+and it is deliberately narrow about which it will claim.
+
+For `expectedAncestorTypes`: a type is a literal `project-docs/` subfolder name with no
 authoritative list of valid ones, so an _unknown_ type is ambiguous — `requirements` expecting
 `product-briefs` before the first product brief exists looks identical to a misspelling, and
 flagging it would fail `--strict` on a correct schema. What is decidable is a value differing from a
@@ -530,6 +533,17 @@ plural, so `bounded-context` is one keystroke from `bounded-contexts`). Those ar
 type they meant, and are the only ones dropped from the `unscoped` check — one bad value would
 otherwise report every artifact of its type as unscoped, forever, pointing at artifacts that are
 correct.
+
+For `digestFields`, the same two failures appear one property over, and both are otherwise silent:
+
+- a **structural field** (`project-docs-ancestors`, `resolves`) is excluded from `metadata` by
+  design, so declaring it contributes nothing and the digest quietly ignores it. Always wrong, so
+  always reported.
+- a **misspelled field** contributes `null` for every artifact, leaving the digest stable while it
+  stops tracking the field that was meant. Checked against the fields artifacts of that type
+  actually carry, and reported only on the same pluralization-or-case basis — a field nothing
+  carries yet is indistinguishable from one that will, and a substitution typo from a deliberate
+  choice.
 
 `stale` is the ancestor-digest mechanism. A reference may optionally record the ancestor's body
 digest at the time it was written — `domain-terms:case@a3f9c2e1b004` — and three states follow:
@@ -596,7 +610,7 @@ implementation detail and may change without a bump.
 | `integrity.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
 | `integrity.yamlErrors[]`      | `{ path, error }`                                                                              |
 | `integrity.cycles[]`          | arrays of ref strings — one cycle each, first node not repeated                                |
-| `integrity.schemaErrors[]`    | `{ type, expectedAncestorType, didYouMean }`                                                   |
+| `integrity.schemaErrors[]`    | `{ type, property, value, problem, didYouMean? }`                                              |
 | `status.resolution`           | `{ open[], resolved[] }`                                                                       |
 | `status.unreferenced[]`       | ref strings                                                                                    |
 | `status.unscoped[]`           | ref strings                                                                                    |

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -168,7 +168,7 @@ resolves: []
 | `projectDocsAncestors` | none                     | Paths to existing `project-docs/` artifacts this bug relates to, if already known — often genuinely empty until triaged      |
 
 A bug tracks open/resolved status the same generic way as `open-question`/`blocker`
-(`resolutionStatus.open`/`.resolved`), but resolves differently — see `develop/SKILL.md`'s bug-fixing
+(`status.resolution.open`/`.resolved`), but resolves differently — see `develop/SKILL.md`'s bug-fixing
 section in the `agent-delivery` output below. Investigating a bug and finding the _spec_ itself was
 wrong escalates to a real `blocker` against the implicated artifact; filing that blocker does not
 itself resolve the bug — only an `iteration-retrospective --resolves` naming the bug's own path does.
@@ -565,7 +565,7 @@ implementation detail and may change without a bump.
 This records what is already load-bearing rather than adding a new promise. `agent-delivery`'s
 `task-identification.mjs` reads every one of those `violations` keys plus `registry[].ancestorRefs`,
 `registry[].path` and `index[].type`; the `design` and `develop` skills read `index` entries, and
-`discover` reads `violations.resolutionStatus`. All of them are generated **write-if-missing**, so a
+`discover` reads `status.resolution`. All of them are generated **write-if-missing**, so a
 workspace keeps its own copy and re-running the generator cannot repair a shape change — only a
 migration can. So pin `schemaVersion` and fail on an unexpected value rather than reading around a
 field that may have been renamed — `task-identification.mjs` does exactly that, and names both
@@ -592,7 +592,7 @@ changing a reference, and `--strict` it in your own CI if you want a broken refe
 build (`--dry-run` alone reports without affecting the exit code).
 
 Also reports which `open-question`/`blocker` artifacts are still open versus resolved — see
-`resolutionStatus` below.
+`status.resolution` below.
 
 ### `project-docs/artifact-schema.json`
 
@@ -641,7 +641,7 @@ should be built from. An artifact whose type has an entry here but is missing an
 the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
 as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
 
-`tracksResolution: true` is what makes `open-questions`/`blockers` show up in `resolutionStatus`
+`tracksResolution: true` is what makes `open-questions`/`blockers` show up in `status.resolution`
 (below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking
 and gets settled by another artifact) gets the same open/resolved report for free by declaring it.
 

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -439,11 +439,41 @@ rather than a violation.
 npx nx g @abgov/nx-agent:project-docs-lineage
 npx nx g @abgov/nx-agent:project-docs-lineage --dry-run   # compute and report, write nothing
 npx nx g @abgov/nx-agent:project-docs-lineage --strict     # non-zero exit on a violation, for a gate
+npx nx g @abgov/nx-agent:project-docs-lineage --json --quiet   # print the graph to stdout
 ```
 
-Use `--strict` as a gate, not to build the graph: Nx rolls a generator's staged write back when it
-throws, so a failing `--strict` run deliberately produces no `lineage.json` at all. Anything that
-needs both the graph and the exit code has to run it twice.
+`--strict` on its own is a gate, not a way to build the graph: Nx rolls a generator's staged write
+back when it throws, so a failing `--strict` run deliberately produces no `lineage.json` at all.
+
+`--json` prints the same object to stdout instead of the human-readable summary — and because
+stdout isn't subject to that rollback, **`--json --strict` is the one invocation that yields both
+the graph and a failing exit code in a single run**. Pair it with `--quiet`, or Nx's own
+`NX Generating ...` banner lands on stdout ahead of the document.
+
+### The consumed shape
+
+`schemaVersion` versions the paths below, and only those. Everything else in the file is
+implementation detail and may change without a bump.
+
+| Path                           | Shape                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `schemaVersion`                | number — `1` today                                                                             |
+| `registry[<ref>]`              | `{ path, ancestorRefs[], resolves[], metadata }`                                               |
+| `index[<ref>][]`               | `{ file, type?, metadata? }` — `type` only when the descendant is itself a registered artifact |
+| `violations.brokenRefs[]`      | `{ ref, referencedFrom }`                                                                      |
+| `violations.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
+| `violations.yamlErrors[]`      | `{ path, error }`                                                                              |
+| `violations.orphans[]`         | ref strings                                                                                    |
+| `violations.unscoped[]`        | ref strings                                                                                    |
+| `violations.resolutionStatus`  | `{ open[], resolved[] }`                                                                       |
+
+This records what is already load-bearing rather than adding a new promise. `agent-delivery`'s
+`task-identification.mjs` reads every one of those `violations` keys plus `registry[].ancestorRefs`,
+`registry[].path` and `index[].type`; the `design` and `develop` skills read `index` entries, and
+`discover` reads `violations.resolutionStatus`. All of them are generated **write-if-missing**, so a
+workspace keeps its own copy and re-running the generator cannot repair a shape change — only a
+migration can. So pin `schemaVersion` and fail on an unexpected value rather than reading around a
+field that may have been renamed.
 
 The `project-docs-ancestors` convention itself: a directive used identically in frontmatter (a YAML
 list) and code comments (comma-separated on one line), shaped `<type>[:<id>][#fragment]`. `type` is

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -421,19 +421,33 @@ script reading that file (`agent-delivery`'s task-identification), not a human r
 console, so aborting would take every unrelated fact in the graph down over one dangling reference
 and disable the very mechanism that reports it.
 
-Five violation categories, three of which `--strict` fails on:
+Findings are split on a property intrinsic to the graph rather than on severity: **is the defect
+_in_ the graph, or is it a fact the graph is correctly reporting?**
 
-| Category          | What it is                                                       | Under `--strict` |
-| ----------------- | ---------------------------------------------------------------- | ---------------- |
-| `brokenRefs`      | a reference whose target doesn't exist                           | **fails**        |
-| `unparseableRefs` | a reference token that doesn't fit the `<type>[:<id>]` grammar   | **fails**        |
-| `yamlErrors`      | frontmatter that doesn't parse as YAML                           | **fails**        |
-| `orphans`         | nothing references it yet (see below)                            | reported only    |
-| `unscoped`        | missing an _expected_ ancestor type (see `artifact-schema.json`) | reported only    |
+`integrity` means the graph can't be trusted as a graph. `--strict` fails on any of it, and that
+isn't configurable — a consumer asking "was this graph even constructible" isn't expressing a
+preference.
 
-The bottom two never fail, in either mode: an artifact nothing implements yet is a normal,
-temporary state, not a mistake. `resolutionStatus` is reported alongside them but is a status
-rather than a violation.
+| `integrity`       | What it is                                                          |
+| ----------------- | ------------------------------------------------------------------- |
+| `brokenRefs`      | a declared edge whose endpoint doesn't exist                        |
+| `unparseableRefs` | a token that doesn't fit the `<type>[:<id>]` grammar at all         |
+| `yamlErrors`      | a node whose frontmatter couldn't be read, so its edges are unknown |
+
+`status` means the graph is sound and is telling you where the work stands. None of it fails
+`--strict`; gating on any of it is a project policy and belongs to you.
+
+| `status`     | What it is                                                            |
+| ------------ | --------------------------------------------------------------------- |
+| `resolution` | `{ open, resolved }` — which `tracksResolution` artifacts are settled |
+| `orphans`    | no inbound edges: nothing derives from it yet                         |
+| `unscoped`   | every edge resolves, but an expected ancestor type is missing         |
+
+`status` is computed from **structure only** — edges and schema expectations. Status an artifact
+declares about itself in frontmatter (a `questions` list, a `status:` field) deliberately stays in
+`metadata`, passed through verbatim for you to interpret. The moment this computed a finding from
+one of those, it would have taken a position on your workflow, and being workflow-agnostic is what
+makes it consumable from outside.
 
 ```bash
 npx nx g @abgov/nx-agent:project-docs-lineage
@@ -455,17 +469,18 @@ the graph and a failing exit code in a single run**. Pair it with `--quiet`, or 
 `schemaVersion` versions the paths below, and only those. Everything else in the file is
 implementation detail and may change without a bump.
 
-| Path                           | Shape                                                                                          |
-| ------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `schemaVersion`                | number — `1` today                                                                             |
-| `registry[<ref>]`              | `{ path, ancestorRefs[], resolves[], metadata }`                                               |
-| `index[<ref>][]`               | `{ file, type?, metadata? }` — `type` only when the descendant is itself a registered artifact |
-| `violations.brokenRefs[]`      | `{ ref, referencedFrom }`                                                                      |
-| `violations.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
-| `violations.yamlErrors[]`      | `{ path, error }`                                                                              |
-| `violations.orphans[]`         | ref strings                                                                                    |
-| `violations.unscoped[]`        | ref strings                                                                                    |
-| `violations.resolutionStatus`  | `{ open[], resolved[] }`                                                                       |
+| Path                          | Shape                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- |
+| `schemaVersion`               | number — `1` today                                                                             |
+| `registry[<ref>]`             | `{ path, ancestorRefs[], resolves[], metadata }`                                               |
+| `index[<ref>][]`              | `{ file, type?, metadata? }` — `type` only when the descendant is itself a registered artifact |
+| `integrity.brokenRefs[]`      | `{ ref, referencedFrom }`                                                                      |
+| `integrity.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
+| `integrity.yamlErrors[]`      | `{ path, error }`                                                                              |
+| `status.resolution`           | `{ open[], resolved[] }`                                                                       |
+| `status.orphans[]`            | ref strings                                                                                    |
+| `status.unscoped[]`           | ref strings                                                                                    |
+| `violations`                  | **deprecated** — see below                                                                     |
 
 This records what is already load-bearing rather than adding a new promise. `agent-delivery`'s
 `task-identification.mjs` reads every one of those `violations` keys plus `registry[].ancestorRefs`,
@@ -473,7 +488,13 @@ This records what is already load-bearing rather than adding a new promise. `age
 `discover` reads `violations.resolutionStatus`. All of them are generated **write-if-missing**, so a
 workspace keeps its own copy and re-running the generator cannot repair a shape change — only a
 migration can. So pin `schemaVersion` and fail on an unexpected value rather than reading around a
-field that may have been renamed.
+field that may have been renamed — `task-identification.mjs` does exactly that, and names both
+versions when they disagree.
+
+`violations` is a **deprecated** flat view of both containers, kept because those generated files
+can't be repaired by re-running the generator. It's assembled from the very same arrays as
+`integrity` and `status`, so it can't drift from them, and it will be removed at `schemaVersion` 2.
+Read the two containers instead.
 
 The `project-docs-ancestors` convention itself: a directive used identically in frontmatter (a YAML
 list) and code comments (comma-separated on one line), shaped `<type>[:<id>][#fragment]`. `type` is

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -407,7 +407,7 @@ resolves: [blockers:no-write-packages-credential-for-ghcr-sandbox-push]
 
 Self-registers its own `project-docs/artifact-schema.json` entry as `terminal: true` (see
 `project-docs-lineage` below) — a correctly-closed-out retrospective has zero descendants by design,
-so it's excluded from the orphan report rather than flagged alongside a genuine dead-end. Re-adding a
+so it's excluded from the `unreferenced` report rather than flagged alongside a genuine dead-end. Re-adding a
 retrospective that already exists throws rather than silently overwriting or duplicating it.
 
 ## `project-docs-lineage`
@@ -439,11 +439,11 @@ preference.
 `status` means the graph is sound and is telling you where the work stands. None of it fails
 `--strict`; gating on any of it is a project policy and belongs to you.
 
-| `status`     | What it is                                                            |
-| ------------ | --------------------------------------------------------------------- |
-| `resolution` | `{ open, resolved }` — which `tracksResolution` artifacts are settled |
-| `orphans`    | no inbound edges: nothing derives from it yet                         |
-| `unscoped`   | every edge resolves, but an expected ancestor type is missing         |
+| `status`       | What it is                                                            |
+| -------------- | --------------------------------------------------------------------- |
+| `resolution`   | `{ open, resolved }` — which `tracksResolution` artifacts are settled |
+| `unreferenced` | nothing derives from it yet (no inbound edges)                        |
+| `unscoped`     | every edge resolves, but an expected ancestor type is missing         |
 
 `cycles` matters because `project-docs-ancestors` is a _derivation_ relation — two artifacts each
 declaring the other is contradictory, since neither can precede the other. Traversal always
@@ -497,7 +497,7 @@ implementation detail and may change without a bump.
 | `integrity.cycles[]`          | arrays of ref strings — one cycle each, first node not repeated                                |
 | `integrity.schemaErrors[]`    | `{ type, expectedAncestorType, didYouMean }`                                                   |
 | `status.resolution`           | `{ open[], resolved[] }`                                                                       |
-| `status.orphans[]`            | ref strings                                                                                    |
+| `status.unreferenced[]`       | ref strings                                                                                    |
 | `status.unscoped[]`           | ref strings                                                                                    |
 | `violations`                  | **deprecated** — see below                                                                     |
 
@@ -565,23 +565,30 @@ and gets settled by another artifact) gets the same open/resolved report for fre
 
 `terminal: true` marks a type where zero descendants is what correct looks like, not a sign of
 neglect — a close-out/retrospective artifact, working exactly as intended, still has nothing ever
-built on top of it. See `orphans` below.
+built on top of it. See `unreferenced` below.
 
-### `orphans`
+### `unreferenced`
 
-`violations.orphans` lists every registered artifact nothing in the workspace references — the
+`status.unreferenced` lists every registered artifact nothing in the workspace references — the
 "nothing derives from it yet" case, distinct from `unscoped` (missing an _expected_ ancestor,
-the opposite direction). Two things feed correctly into what counts as "referenced":
+the opposite direction).
+
+Named for the mechanism rather than called `orphans`, which inverted the metaphor: references are
+backward-only, so this is an artifact with no _descendants_, while an orphan conventionally has no
+parents. In the direction derivation flows it's a leaf, minus the `terminal` types. The parentless
+case is `unscoped`.
+
+Two things feed correctly into what counts as "referenced":
 
 - A reference counts whether it's a plain `project-docs-ancestors` citation or a `resolves` one —
   a resolution is a real reference too, even when it's the only field naming the target (the normal
   shape for a hand-authored artifact, before its type earns a generator with a `--resolves` flag
   that would otherwise duplicate the ref into `project-docs-ancestors` for you).
-- A type with `terminal: true` is excluded from `orphans` entirely, regardless of descendant count.
+- A type with `terminal: true` is excluded from `unreferenced` entirely, regardless of descendant count.
 
-### `resolutionStatus`
+### `status.resolution`
 
-`violations.resolutionStatus` in `.nx-agent/lineage.json` splits every artifact whose type has
+`status.resolution` in `.nx-agent/lineage.json` splits every artifact whose type has
 `tracksResolution: true` into `open` and `resolved`:
 
 ```json
@@ -593,7 +600,7 @@ references it via `project-docs-ancestors`. That distinction matters: a `blocker
 `open-question` citing an existing one _because_ it's still unresolved would, under a looser
 "anything references it" test, get misread as having resolved it. A deferral (explicitly punted, not
 decided) isn't a third computed bucket — it stays `open`, with the _why_ left to the artifact's own
-prose, same as an `orphan` doesn't try to distinguish "temporary" from "abandoned."
+prose, same as `unreferenced` doesn't try to distinguish "temporary" from "abandoned."
 
 ### Programmatic access
 
@@ -645,7 +652,7 @@ getAncestors(tree, 'apps/my-service/src/routes/collision-reports.ts', Infinity);
 Builds a single, self-contained HTML status report from the same data `project-docs-lineage`
 computes — a lineage graph (rendered with [Mermaid](https://mermaid.js.org/), inlined so the report
 needs nothing from `node_modules` to open), a status summary (counts per type, open vs. resolved,
-orphans, broken references), and a per-artifact table. Not committed — like `lineage.json`, it's
+unreferenced artifacts, broken references), and a per-artifact table. Not committed — like `lineage.json`, it's
 100% derived from other files, so it's gitignored automatically at wherever it's actually written.
 
 ```bash
@@ -661,10 +668,10 @@ actually reporting on rather than in a new top-level directory. `--outputPath` o
 Unlike `project-docs-lineage`, this never throws on a broken reference — surfacing exactly that kind
 of bad news is the point of a status report, not something to gate on.
 
-Graph nodes and table rows are colored by status — resolved, open, orphaned, or (a distinct style,
+Graph nodes and table rows are colored by status — resolved, open, unreferenced, or (a distinct style,
 with a "Closed out" badge and a `✓` in the graph) a `terminal`-typed artifact like an
 `iteration-retrospective`, so a permanently-zero-descendant close-out reads as done rather than
-looking like an ordinary orphan.
+looking like ordinarily unreferenced.
 
 Each artifact's own markdown body — rendered to real HTML via [marked](https://marked.js.org/), not
 shown as raw source — is one click away: both its table row and its graph node link to an in-page
@@ -674,7 +681,7 @@ part of the same single file.
 ### `--project` scoping
 
 `registry`/`index`/`violations` are always computed over the full workspace first, unconditionally —
-an artifact's orphan/resolved status is a workspace-wide fact, and building the index from only one
+an artifact's unreferenced/resolved status is a workspace-wide fact, and building the index from only one
 project's files would misclassify anything referenced across a project boundary (a cross-project
 reference is real, not a mistake). `--project` filters what's _rendered_, not what's computed: the
 summary/counts/table include only that project's own artifacts; the graph additionally shows each

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -608,9 +608,30 @@ whether its kind has a resolution lifecycle at all:
   "domain-models": { "expectedAncestorTypes": ["bounded-contexts", "domain-terms"] },
   "open-questions": { "expectedAncestorTypes": [], "tracksResolution": true },
   "blockers": { "expectedAncestorTypes": [], "tracksResolution": true },
-  "iteration-retrospectives": { "expectedAncestorTypes": [], "terminal": true }
+  "iteration-retrospectives": { "expectedAncestorTypes": [], "terminal": true },
+  "requirements": {
+    "expectedAncestorTypes": ["product-briefs"],
+    "digestFields": ["rules"]
+  }
 }
 ```
+
+`digestFields` names the frontmatter fields that carry a type's **content** rather than its
+bookkeeping, so they count toward its digest alongside the body (see `stale` above). It's a
+structural fact about where a type keeps its meaning, not a switch for whether the check runs.
+
+`requirements` is the only type that needs it, and measurably so: every other artifact kind has a
+639–6857 character body, while requirements have **none** — their `rules` _are_ the artifact, and
+they live in frontmatter deliberately so a real YAML parser can read them. So a change to `rules`
+marks descendants stale, while a `title` fix or an answered `question` does not. Absent or empty
+means body-only, which is right for every type that explains itself in prose, and a type with no
+`digestFields` keeps exactly the digest it had before this existed.
+
+One consequence worth knowing: because declared fields are hashed _alongside_ the body rather than
+instead of it, editing a requirement's rationale prose also marks its descendants stale. That
+over-fires slightly — rationale is explanatory, not contractual — but rationale is written once at
+creation, a requirement has few descendants, and the alternative (declared fields _replacing_ the
+body) would silently drop body coverage for any type that has meaningful content in both.
 
 `project-docs-lineage` reads this generically — it has no knowledge of any specific type baked in, so
 a hand-added entry for a custom artifact kind gets the same checks for free. `expectedAncestorTypes` is

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -463,7 +463,7 @@ preference.
 | `unparseableRefs` | a token that doesn't fit the `<type>[:<id>]` grammar at all            |
 | `yamlErrors`      | a node whose frontmatter couldn't be read, so its edges are unknown    |
 | `cycles`          | artifacts deriving from each other, so the ancestry is not a hierarchy |
-| `schemaErrors`    | an `expectedAncestorTypes` value misspelled from a real type           |
+| `schemaErrors`    | an `artifact-schema.json` entry that can never do what it says         |
 
 `status` means the graph is sound and is telling you where the work stands. None of it fails
 `--strict`; gating on any of it is a project policy and belongs to you.
@@ -480,7 +480,10 @@ declaring the other is contradictory, since neither can precede the other. Trave
 terminated safely on one; what it never did was say so, so `getAncestors(…, Infinity)` returned a
 correct-looking finite set that quietly omitted the fact that the ancestry wasn't a hierarchy.
 
-`schemaErrors` is deliberately narrow. A type is a literal `project-docs/` subfolder name with no
+`schemaErrors` covers both declarations in `artifact-schema.json` that can never do what they say,
+and it is deliberately narrow about which it will claim.
+
+For `expectedAncestorTypes`: a type is a literal `project-docs/` subfolder name with no
 authoritative list of valid ones, so an _unknown_ type is ambiguous — `requirements` expecting
 `product-briefs` before the first product brief exists looks identical to a misspelling, and
 flagging it would fail `--strict` on a correct schema. What is decidable is a value differing from a
@@ -489,6 +492,17 @@ plural, so `bounded-context` is one keystroke from `bounded-contexts`). Those ar
 type they meant, and are the only ones dropped from the `unscoped` check — one bad value would
 otherwise report every artifact of its type as unscoped, forever, pointing at artifacts that are
 correct.
+
+For `digestFields`, the same two failures appear one property over, and both are otherwise silent:
+
+- a **structural field** (`project-docs-ancestors`, `resolves`) is excluded from `metadata` by
+  design, so declaring it contributes nothing and the digest quietly ignores it. Always wrong, so
+  always reported.
+- a **misspelled field** contributes `null` for every artifact, leaving the digest stable while it
+  stops tracking the field that was meant. Checked against the fields artifacts of that type
+  actually carry, and reported only on the same pluralization-or-case basis — a field nothing
+  carries yet is indistinguishable from one that will, and a substitution typo from a deliberate
+  choice.
 
 `stale` is the ancestor-digest mechanism. A reference may optionally record the ancestor's body
 digest at the time it was written — `domain-terms:case@a3f9c2e1b004` — and three states follow:
@@ -555,7 +569,7 @@ implementation detail and may change without a bump.
 | `integrity.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
 | `integrity.yamlErrors[]`      | `{ path, error }`                                                                              |
 | `integrity.cycles[]`          | arrays of ref strings — one cycle each, first node not repeated                                |
-| `integrity.schemaErrors[]`    | `{ type, expectedAncestorType, didYouMean }`                                                   |
+| `integrity.schemaErrors[]`    | `{ type, property, value, problem, didYouMean? }`                                              |
 | `status.resolution`           | `{ open[], resolved[] }`                                                                       |
 | `status.unreferenced[]`       | ref strings                                                                                    |
 | `status.unscoped[]`           | ref strings                                                                                    |

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -653,7 +653,7 @@ an all-of list, not any-of: `domain-models` above requires an ancestor of _both_
 and `domain-terms`, not either — a model with only one is still missing part of the vocabulary it
 should be built from. An artifact whose type has an entry here but is missing an ancestor of one of
 the expected types is reported (not thrown, since this is a convention nudge rather than a hard rule)
-as `unscoped` in `.nx-agent/lineage.json`'s `violations`.
+as `unscoped` in `.nx-agent/lineage.json`'s `status`.
 
 `tracksResolution: true` is what makes `open-questions`/`blockers` show up in `status.resolution`
 (below) — a custom artifact kind with the same lifecycle (something that starts undecided/blocking

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -428,11 +428,13 @@ _in_ the graph, or is it a fact the graph is correctly reporting?**
 isn't configurable — a consumer asking "was this graph even constructible" isn't expressing a
 preference.
 
-| `integrity`       | What it is                                                          |
-| ----------------- | ------------------------------------------------------------------- |
-| `brokenRefs`      | a declared edge whose endpoint doesn't exist                        |
-| `unparseableRefs` | a token that doesn't fit the `<type>[:<id>]` grammar at all         |
-| `yamlErrors`      | a node whose frontmatter couldn't be read, so its edges are unknown |
+| `integrity`       | What it is                                                             |
+| ----------------- | ---------------------------------------------------------------------- |
+| `brokenRefs`      | a declared edge whose endpoint doesn't exist                           |
+| `unparseableRefs` | a token that doesn't fit the `<type>[:<id>]` grammar at all            |
+| `yamlErrors`      | a node whose frontmatter couldn't be read, so its edges are unknown    |
+| `cycles`          | artifacts deriving from each other, so the ancestry is not a hierarchy |
+| `schemaErrors`    | an `expectedAncestorTypes` value misspelled from a real type           |
 
 `status` means the graph is sound and is telling you where the work stands. None of it fails
 `--strict`; gating on any of it is a project policy and belongs to you.
@@ -442,6 +444,21 @@ preference.
 | `resolution` | `{ open, resolved }` — which `tracksResolution` artifacts are settled |
 | `orphans`    | no inbound edges: nothing derives from it yet                         |
 | `unscoped`   | every edge resolves, but an expected ancestor type is missing         |
+
+`cycles` matters because `project-docs-ancestors` is a _derivation_ relation — two artifacts each
+declaring the other is contradictory, since neither can precede the other. Traversal always
+terminated safely on one; what it never did was say so, so `getAncestors(…, Infinity)` returned a
+correct-looking finite set that quietly omitted the fact that the ancestry wasn't a hierarchy.
+
+`schemaErrors` is deliberately narrow. A type is a literal `project-docs/` subfolder name with no
+authoritative list of valid ones, so an _unknown_ type is ambiguous — `requirements` expecting
+`product-briefs` before the first product brief exists looks identical to a misspelling, and
+flagging it would fail `--strict` on a correct schema. What is decidable is a value differing from a
+real type only by pluralization or case, which is the slip that actually happens (every type name is
+plural, so `bounded-context` is one keystroke from `bounded-contexts`). Those are reported with the
+type they meant, and are the only ones dropped from the `unscoped` check — one bad value would
+otherwise report every artifact of its type as unscoped, forever, pointing at artifacts that are
+correct.
 
 `status` is computed from **structure only** — edges and schema expectations. Status an artifact
 declares about itself in frontmatter (a `questions` list, a `status:` field) deliberately stays in
@@ -477,6 +494,8 @@ implementation detail and may change without a bump.
 | `integrity.brokenRefs[]`      | `{ ref, referencedFrom }`                                                                      |
 | `integrity.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
 | `integrity.yamlErrors[]`      | `{ path, error }`                                                                              |
+| `integrity.cycles[]`          | arrays of ref strings — one cycle each, first node not repeated                                |
+| `integrity.schemaErrors[]`    | `{ type, expectedAncestorType, didYouMean }`                                                   |
 | `status.resolution`           | `{ open[], resolved[] }`                                                                       |
 | `status.orphans[]`            | ref strings                                                                                    |
 | `status.unscoped[]`           | ref strings                                                                                    |

--- a/packages/nx-agent/README.md
+++ b/packages/nx-agent/README.md
@@ -410,6 +410,35 @@ Self-registers its own `project-docs/artifact-schema.json` entry as `terminal: t
 so it's excluded from the `unreferenced` report rather than flagged alongside a genuine dead-end. Re-adding a
 retrospective that already exists throws rather than silently overwriting or duplicating it.
 
+## `pin-ancestors`
+
+```bash
+npx nx g @abgov/nx-agent:pin-ancestors                              # whole workspace
+npx nx g @abgov/nx-agent:pin-ancestors --ancestor=domain-terms:case  # just this ancestor's descendants
+npx nx g @abgov/nx-agent:pin-ancestors --artifact=domain-models:x    # just this artifact's references
+```
+
+Records each resolved ancestor's current body digest on the `project-docs-ancestors` reference that
+names it, so `project-docs-lineage` can later report `status.stale`. Handles both YAML sequence
+styles the generators emit (block lists and flow lists) and **warns rather than skipping** on a
+form it can't rewrite — a silently unpinned reference is indistinguishable from a deliberately
+unpinned one, and would report nothing forever. A reference that doesn't resolve is left alone;
+that's a broken reference, and `project-docs-lineage` reports it as one.
+
+**Run it by hand. Never from a hook, a CI step, or a clean-run path.** A pin asserts _"I have read
+this ancestor as it stands"_ — a claim only a person can make. A blind bulk re-pin bakes in whatever
+drift already exists and then reports it as the floor. It's a separate generator rather than a
+`--repin` flag on `project-docs-lineage` for the same reason: that command reads and reports, and a
+mutation living next to `--strict` is how the check ends up silently dead in a workflow.
+
+Prefer `--ancestor`. "I revised one term, re-pin its descendants" is an act you can justify in a
+commit message; re-pinning the workspace is only ever "make the report stop." Because digests live
+in the committed artifact, either way the re-pin shows up in your own diff — which is what makes it
+reviewable, unlike a central baseline that re-seals where nobody looks.
+
+`resolves` lists are untouched: resolving an open question isn't a derivation, so the question's
+content moving doesn't invalidate the resolver.
+
 ## `project-docs-lineage`
 
 Scans the whole workspace for `project-docs/` artifacts and `project-docs-ancestors` references —
@@ -444,6 +473,7 @@ preference.
 | `resolution`   | `{ open, resolved }` — which `tracksResolution` artifacts are settled |
 | `unreferenced` | nothing derives from it yet (no inbound edges)                        |
 | `unscoped`     | every edge resolves, but an expected ancestor type is missing         |
+| `stale`        | a pinned ancestor was revised after this artifact derived from it     |
 
 `cycles` matters because `project-docs-ancestors` is a _derivation_ relation — two artifacts each
 declaring the other is contradictory, since neither can precede the other. Traversal always
@@ -459,6 +489,36 @@ plural, so `bounded-context` is one keystroke from `bounded-contexts`). Those ar
 type they meant, and are the only ones dropped from the `unscoped` check — one bad value would
 otherwise report every artifact of its type as unscoped, forever, pointing at artifacts that are
 correct.
+
+`stale` is the ancestor-digest mechanism. A reference may optionally record the ancestor's body
+digest at the time it was written — `domain-terms:case@a3f9c2e1b004` — and three states follow:
+
+| digest           | meaning                                             | report     |
+| ---------------- | --------------------------------------------------- | ---------- |
+| absent           | hand-authored, or predates adoption                 | **silent** |
+| present, matches | current                                             | silent     |
+| present, differs | the ancestor was revised after this derived from it | reported   |
+
+The silent first state is what makes it adoptable: turning this on reports nothing until something
+is deliberately pinned. Pin with `nx g @abgov/nx-agent:pin-ancestors`.
+
+**The digest covers the body only**, not frontmatter, and that isn't a shortcut. Recording a pin
+edits `project-docs-ancestors`, so a whole-file hash would make re-pinning a content change — one
+edit to a root would cascade staleness through the entire transitive descendancy in waves, each
+wave's fix triggering the next. A body digest stops at depth 1, and propagates one hop further
+exactly when a re-pin came _with_ a real revision, which is when descendants should look. It also
+keeps the hash independent of where a digest is stored, and avoids canonicalising a parsed YAML
+object to keep it stable.
+
+The cost is permanent rather than a wart to fix later: **a type that keeps its meaning in
+frontmatter is not covered at all.** `requirements` is that type — its `rules` _are_ the artifact —
+and they live there deliberately so a real YAML parser can read them (`check-example-mapping.mjs`
+had two regex-parsing bugs before the move). For those, a material change is a different artifact,
+not an edit.
+
+The body is normalised for line endings, trailing whitespace, and the blank line Prettier inserts
+after the frontmatter delimiter — that last one matters, since `formatFiles()` runs at the end of
+every generator and would otherwise invalidate a pin immediately after writing it.
 
 `status` is computed from **structure only** — edges and schema expectations. Status an artifact
 declares about itself in frontmatter (a `questions` list, a `status:` field) deliberately stays in
@@ -489,7 +549,7 @@ implementation detail and may change without a bump.
 | Path                          | Shape                                                                                          |
 | ----------------------------- | ---------------------------------------------------------------------------------------------- |
 | `schemaVersion`               | number — `1` today                                                                             |
-| `registry[<ref>]`             | `{ path, ancestorRefs[], resolves[], metadata }`                                               |
+| `registry[<ref>]`             | `{ path, bodyDigest, ancestorRefs[], resolves[], metadata }`                                   |
 | `index[<ref>][]`              | `{ file, type?, metadata? }` — `type` only when the descendant is itself a registered artifact |
 | `integrity.brokenRefs[]`      | `{ ref, referencedFrom }`                                                                      |
 | `integrity.unparseableRefs[]` | `{ ref, foundIn }`                                                                             |
@@ -499,6 +559,7 @@ implementation detail and may change without a bump.
 | `status.resolution`           | `{ open[], resolved[] }`                                                                       |
 | `status.unreferenced[]`       | ref strings                                                                                    |
 | `status.unscoped[]`           | ref strings                                                                                    |
+| `status.stale[]`              | `{ artifact, ancestor, pinnedDigest, currentDigest }`                                          |
 | `violations`                  | **deprecated** — see below                                                                     |
 
 This records what is already load-bearing rather than adding a new promise. `agent-delivery`'s

--- a/packages/nx-agent/generators.json
+++ b/packages/nx-agent/generators.json
@@ -11,7 +11,7 @@
     "feature": {
       "factory": "./src/generators/feature/feature",
       "schema": "./src/generators/feature/schema.json",
-      "description": "Adds one feature request under project-docs/features/, with a project-docs-ancestors frontmatter list and a free-text body describing the capability wanted. This is how new work enters the DDDD workflow — Discover decomposes it into a service-description/requirement."
+      "description": "Adds one feature request under project-docs/features/, with a project-docs-ancestors frontmatter list and a free-text body describing the capability wanted. This is how new work enters the DDDD workflow \u2014 Discover decomposes it into a service-description/requirement."
     },
     "bug": {
       "factory": "./src/generators/bug/bug",
@@ -31,7 +31,7 @@
     "product-brief": {
       "factory": "./src/generators/product-brief/product-brief",
       "schema": "./src/generators/product-brief/schema.json",
-      "description": "Adds one product brief under project-docs/product-briefs/, with structured frontmatter (capability, audience, known-platforms, questions) and a free-text body. Persistent positioning artifact — create once, reference and extend directly thereafter."
+      "description": "Adds one product brief under project-docs/product-briefs/, with structured frontmatter (capability, audience, known-platforms, questions) and a free-text body. Persistent positioning artifact \u2014 create once, reference and extend directly thereafter."
     },
     "bounded-context": {
       "factory": "./src/generators/bounded-context/bounded-context",
@@ -72,6 +72,11 @@
       "factory": "./src/generators/agent-delivery/agent-delivery",
       "schema": "./src/generators/agent-delivery/schema.json",
       "description": "Copies the Discover/Design/Develop/Deploy skill files into .claude/skills/ and appends AGENTS.md guidance pointing at them. Existing files are never overwritten. --githubActions additionally scaffolds a self-dispatching GitHub Actions iteration loop."
+    },
+    "pin-ancestors": {
+      "factory": "./src/generators/pin-ancestors/pin-ancestors",
+      "schema": "./src/generators/pin-ancestors/schema.json",
+      "description": "Records each resolved ancestor\u2019s current body digest on the project-docs-ancestors reference naming it, so project-docs-lineage can report when the ancestor is later revised. Human-invoked only \u2014 never from a hook or CI."
     }
   }
 }

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -222,12 +222,14 @@ describe('nx-agent agent-delivery generator', () => {
         schemaErrors: [
           {
             type: 'domain-terms',
-            expectedAncestorType: 'bounded-context',
+            property: 'expectedAncestorTypes',
+            value: 'bounded-context',
+            problem: 'misspelled',
             didYouMean: 'bounded-contexts',
           },
         ],
       },
-      'schema-error:domain-terms:bounded-context',
+      'schema-error:domain-terms:expectedAncestorTypes:bounded-context',
     ],
   ])(
     'task-identification raises a %s as a resolution signal on a fix branch',
@@ -287,6 +289,190 @@ describe('nx-agent agent-delivery generator', () => {
       }
     },
   );
+
+  // Both signal tests above use ARTIFACT_SCOPE='*', which bypasses the filter
+  // entirely — so neither would notice a signal whose artifact key can't be
+  // recovered from its key string. These run under a real scope.
+  function runTaskIdentification(
+    host: Tree,
+    lineage: object,
+    env: Record<string, string>,
+  ) {
+    const script = host.read('scripts/task-identification.mjs').toString();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'nx-agent-task-id-scope-'));
+    try {
+      writeFileSync(join(tmpDir, 'task-identification.mjs'), script);
+      symlinkSync(
+        join(process.cwd(), 'node_modules'),
+        join(tmpDir, 'node_modules'),
+      );
+      mkdirSync(join(tmpDir, '.nx-agent'));
+      writeFileSync(
+        join(tmpDir, '.nx-agent', 'lineage.json'),
+        JSON.stringify(lineage),
+      );
+      const outputFile = join(tmpDir, 'github-output');
+      writeFileSync(outputFile, '');
+      const stdout = execSync('node task-identification.mjs', {
+        cwd: tmpDir,
+        env: { ...process.env, GITHUB_OUTPUT: outputFile, ...env },
+      }).toString();
+      return JSON.parse(stdout);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  }
+
+  const emptyFindings = {
+    integrity: {
+      brokenRefs: [],
+      unparseableRefs: [],
+      yamlErrors: [],
+      cycles: [],
+      schemaErrors: [],
+    },
+    status: {
+      resolution: { open: [], resolved: [] },
+      unreferenced: [],
+      unscoped: [],
+      stale: [],
+    },
+  };
+
+  it('keeps a stale signal in scope when its own artifact is scoped', async () => {
+    await generator(host, { githubActions: true });
+
+    const out = runTaskIdentification(
+      host,
+      {
+        schemaVersion: 1,
+        registry: {
+          'domain-models:m': {
+            path: 'project-docs/domain-models/m.md',
+            bodyDigest: 'aaaaaaaaaaaa',
+            ancestorRefs: [],
+            resolves: [],
+            metadata: {},
+          },
+        },
+        index: {},
+        ...emptyFindings,
+        status: {
+          ...emptyFindings.status,
+          stale: [
+            {
+              artifact: 'domain-models:m',
+              ancestor: 'domain-terms:t',
+              pinnedDigest: 'aaaaaaaaaaaa',
+              currentDigest: 'bbbbbbbbbbbb',
+            },
+          ],
+        },
+      },
+      {
+        GITHUB_REF_NAME: 'feature/x',
+        ARTIFACT_SCOPE: 'project-docs/domain-models/m.md',
+      },
+    );
+
+    expect(out.signals.map((sig: { key: string }) => sig.key)).toContain(
+      'stale:domain-models:m:domain-terms:t',
+    );
+  });
+
+  // A schema error is about the workspace's configuration, not any artifact, so
+  // no artifact scope should be able to exclude it.
+  it('keeps a schema-error signal in scope under a narrow artifact scope', async () => {
+    await generator(host, { githubActions: true });
+
+    const out = runTaskIdentification(
+      host,
+      {
+        schemaVersion: 1,
+        registry: {
+          'domain-models:m': {
+            path: 'project-docs/domain-models/m.md',
+            bodyDigest: 'aaaaaaaaaaaa',
+            ancestorRefs: [],
+            resolves: [],
+            metadata: {},
+          },
+        },
+        index: {},
+        ...emptyFindings,
+        integrity: {
+          ...emptyFindings.integrity,
+          schemaErrors: [
+            {
+              type: 'requirements',
+              property: 'digestFields',
+              value: 'resolves',
+              problem: 'structural-field',
+            },
+          ],
+        },
+      },
+      {
+        GITHUB_REF_NAME: 'fix/repair',
+        ARTIFACT_SCOPE: 'project-docs/domain-models/m.md',
+      },
+    );
+
+    const keys = out.signals.map((sig: { key: string }) => sig.key);
+    expect(keys).toContain('schema-error:requirements:digestFields:resolves');
+    // And the reason renders the structural-field branch, not a "did you mean
+    // undefined?" built from the pre-reshape field names.
+    const reason = out.signals.find((sig: { key: string }) =>
+      sig.key.startsWith('schema-error:'),
+    ).reason;
+    expect(reason).toContain('structural field');
+    expect(reason).not.toContain('undefined');
+  });
+
+  // Ancestor-scope traversal walks raw ancestorRefs, which now may carry an
+  // @digest — looked up verbatim, the walk stopped at the first pinned edge.
+  it('walks a pinned ancestor reference when resolving artifact scope', async () => {
+    await generator(host, { githubActions: true });
+
+    const out = runTaskIdentification(
+      host,
+      {
+        schemaVersion: 1,
+        registry: {
+          'domain-terms:t': {
+            path: 'project-docs/domain-terms/t.md',
+            bodyDigest: 'bbbbbbbbbbbb',
+            ancestorRefs: [],
+            resolves: [],
+            metadata: {},
+          },
+          'domain-models:m': {
+            path: 'project-docs/domain-models/m.md',
+            bodyDigest: 'aaaaaaaaaaaa',
+            ancestorRefs: ['domain-terms:t@bbbbbbbbbbbb'],
+            resolves: [],
+            metadata: {},
+          },
+        },
+        index: {},
+        ...emptyFindings,
+        status: {
+          ...emptyFindings.status,
+          unscoped: ['domain-models:m'],
+        },
+      },
+      {
+        // Scoped on the *ancestor*; the descendant is in scope only if the walk
+        // can normalise the pinned token back to the ancestor's registry key.
+        GITHUB_REF_NAME: 'feature/x',
+        ARTIFACT_SCOPE: 'project-docs/domain-terms/t.md',
+      },
+    );
+
+    expect(out.signals.map((sig: { key: string }) => sig.key)).toContain(
+      'unscoped:domain-models:m',
+    );
+  });
 
   it('never overwrites a file a team has already edited', async () => {
     await generator(host, { githubActions: true });

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -474,6 +474,48 @@ describe('nx-agent agent-delivery generator', () => {
     );
   });
 
+  // Two more raw-token comparisons: an ancestorRef carrying an @digest never
+  // equals the bare key, so a pinned open question stopped blocking Develop.
+  it('lets a pinned open question still block its design', async () => {
+    await generator(host, { githubActions: true });
+
+    const out = runTaskIdentification(
+      host,
+      {
+        schemaVersion: 1,
+        registry: {
+          'api-designs:d': {
+            path: 'project-docs/api-designs/d.md',
+            bodyDigest: 'aaaaaaaaaaaa',
+            ancestorRefs: [],
+            resolves: [],
+            metadata: {},
+          },
+          'open-questions:q': {
+            path: 'project-docs/open-questions/q.md',
+            bodyDigest: 'bbbbbbbbbbbb',
+            // Pinned: the raw token is not equal to 'api-designs:d'.
+            ancestorRefs: ['api-designs:d@aaaaaaaaaaaa'],
+            resolves: [],
+            metadata: {},
+          },
+        },
+        index: {},
+        ...emptyFindings,
+        status: {
+          ...emptyFindings.status,
+          resolution: { open: ['open-questions:q'], resolved: [] },
+        },
+      },
+      { GITHUB_REF_NAME: 'feature/x', ARTIFACT_SCOPE: '*' },
+    );
+
+    const keys = out.signals.map((sig: { key: string }) => sig.key);
+    expect(keys).toContain('open:open-questions:q');
+    // Blocked by the unresolved question, so Develop must not be offered.
+    expect(keys).not.toContain('undeveloped:api-designs:d');
+  });
+
   it('never overwrites a file a team has already edited', async () => {
     await generator(host, { githubActions: true });
 

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -5,6 +5,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -204,6 +205,88 @@ describe('nx-agent agent-delivery generator', () => {
       rmSync(tmpDir, { recursive: true });
     }
   });
+
+  // A finding nothing acts on is half-delivered. integrity.cycles and
+  // integrity.schemaErrors fail --strict, so the loop has to be able to pick
+  // them up as work — and on a fix/** branch, which only sees resolution
+  // signals.
+  it.each([
+    [
+      'cycle',
+      { cycles: [['domain-terms:a', 'domain-terms:b']] },
+      'cycle:domain-terms:a,domain-terms:b',
+    ],
+    [
+      'schemaError',
+      {
+        schemaErrors: [
+          {
+            type: 'domain-terms',
+            expectedAncestorType: 'bounded-context',
+            didYouMean: 'bounded-contexts',
+          },
+        ],
+      },
+      'schema-error:domain-terms:bounded-context',
+    ],
+  ])(
+    'task-identification raises a %s as a resolution signal on a fix branch',
+    async (_name, integrityOverride, expectedKey) => {
+      await generator(host, { githubActions: true });
+
+      const script = host.read('scripts/task-identification.mjs').toString();
+      const tmpDir = mkdtempSync(join(tmpdir(), 'nx-agent-task-id-signal-'));
+      try {
+        writeFileSync(join(tmpDir, 'task-identification.mjs'), script);
+        symlinkSync(
+          join(process.cwd(), 'node_modules'),
+          join(tmpDir, 'node_modules'),
+        );
+        mkdirSync(join(tmpDir, '.nx-agent'));
+        writeFileSync(
+          join(tmpDir, '.nx-agent', 'lineage.json'),
+          JSON.stringify({
+            schemaVersion: 1,
+            registry: {},
+            index: {},
+            integrity: {
+              brokenRefs: [],
+              unparseableRefs: [],
+              yamlErrors: [],
+              cycles: [],
+              schemaErrors: [],
+              ...integrityOverride,
+            },
+            status: {
+              resolution: { open: [], resolved: [] },
+              unreferenced: [],
+              unscoped: [],
+              stale: [],
+            },
+          }),
+        );
+
+        const outputFile = join(tmpDir, 'github-output');
+        writeFileSync(outputFile, '');
+        const stdout = execSync('node task-identification.mjs', {
+          cwd: tmpDir,
+          env: {
+            ...process.env,
+            GITHUB_OUTPUT: outputFile,
+            GITHUB_REF_NAME: 'fix/some-repair',
+            ARTIFACT_SCOPE: '*',
+          },
+        }).toString();
+
+        expect(JSON.parse(stdout).signals.map((s) => s.key)).toContain(
+          expectedKey,
+        );
+        expect(readFileSync(outputFile, 'utf-8')).toContain('ready=true');
+      } finally {
+        rmSync(tmpDir, { recursive: true });
+      }
+    },
+  );
 
   it('never overwrites a file a team has already edited', async () => {
     await generator(host, { githubActions: true });

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -119,7 +119,7 @@ describe('nx-agent agent-delivery generator', () => {
           integrity: { brokenRefs: [], unparseableRefs: [], yamlErrors: [] },
           status: {
             resolution: { open: [], resolved: [] },
-            orphans: [],
+            unreferenced: [],
             unscoped: [],
           },
         }),

--- a/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
+++ b/packages/nx-agent/src/generators/agent-delivery/agent-delivery.spec.ts
@@ -1,7 +1,14 @@
 import { Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import generator from './agent-delivery';
@@ -97,9 +104,65 @@ describe('nx-agent agent-delivery generator', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'nx-agent-task-id-test-'));
     try {
       writeFileSync(join(tmpDir, 'task-identification.mjs'), script);
-      symlinkSync(join(process.cwd(), 'node_modules'), join(tmpDir, 'node_modules'));
+      symlinkSync(
+        join(process.cwd(), 'node_modules'),
+        join(tmpDir, 'node_modules'),
+      );
 
       mkdirSync(join(tmpDir, '.nx-agent'));
+      writeFileSync(
+        join(tmpDir, '.nx-agent', 'lineage.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          registry: {},
+          index: {},
+          integrity: { brokenRefs: [], unparseableRefs: [], yamlErrors: [] },
+          status: {
+            resolution: { open: [], resolved: [] },
+            orphans: [],
+            unscoped: [],
+          },
+        }),
+      );
+
+      const outputFile = join(tmpDir, 'github-output');
+      writeFileSync(outputFile, '');
+      execSync('node task-identification.mjs', {
+        cwd: tmpDir,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputFile,
+          GITHUB_REF_NAME: 'feature/test',
+        },
+      });
+
+      expect(
+        existsSync(
+          join(tmpDir, '.github', 'agent-delivery-iteration', 'history.json'),
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
+  });
+
+  // The reason lineage.json carries a schemaVersion. This script is generated
+  // write-if-missing, so a workspace can run a copy that disagrees with the
+  // graph shape; it must say so, not die on a container that moved.
+  it('task-identification fails with both versions named on a shape mismatch', async () => {
+    await generator(host, { githubActions: true });
+
+    const script = host.read('scripts/task-identification.mjs').toString();
+    const tmpDir = mkdtempSync(join(tmpdir(), 'nx-agent-task-id-version-'));
+    try {
+      writeFileSync(join(tmpDir, 'task-identification.mjs'), script);
+      symlinkSync(
+        join(process.cwd(), 'node_modules'),
+        join(tmpDir, 'node_modules'),
+      );
+
+      mkdirSync(join(tmpDir, '.nx-agent'));
+      // A graph written before schemaVersion existed: the pre-split shape.
       writeFileSync(
         join(tmpDir, '.nx-agent', 'lineage.json'),
         JSON.stringify({
@@ -116,14 +179,27 @@ describe('nx-agent agent-delivery generator', () => {
 
       const outputFile = join(tmpDir, 'github-output');
       writeFileSync(outputFile, '');
-      execSync('node task-identification.mjs', {
-        cwd: tmpDir,
-        env: { ...process.env, GITHUB_OUTPUT: outputFile, GITHUB_REF_NAME: 'feature/test' },
-      });
+      let stderr = '';
+      expect(() => {
+        try {
+          execSync('node task-identification.mjs', {
+            cwd: tmpDir,
+            env: {
+              ...process.env,
+              GITHUB_OUTPUT: outputFile,
+              GITHUB_REF_NAME: 'feature/test',
+            },
+            stdio: ['ignore', 'ignore', 'pipe'],
+          });
+        } catch (e) {
+          stderr = (e.stderr ?? '').toString();
+          throw e;
+        }
+      }).toThrow();
 
-      expect(
-        existsSync(join(tmpDir, '.github', 'agent-delivery-iteration', 'history.json')),
-      ).toBe(false);
+      expect(stderr).toContain('schemaVersion (absent)');
+      expect(stderr).toContain('expects 1');
+      expect(stderr).not.toContain('TypeError');
     } finally {
       rmSync(tmpDir, { recursive: true });
     }

--- a/packages/nx-agent/src/generators/agent-delivery/files/AGENTS.ci-harness.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/AGENTS.ci-harness.md
@@ -10,7 +10,7 @@ is left or the `MAX_ITERATIONS` cap is hit.
 | Branch prefix | Signal types eligible | Typical use |
 |---|---|---|
 | `feature/**` | All (discover → design → develop → deploy) | Advancing a new capability from a `features:` artifact through to Deploy |
-| `fix/**` | Resolution only (`broken:`, `unparseable:`, `yaml-error:`, `open:`) | Resolving a specific blocker, open question, broken/unparseable reference, or malformed frontmatter |
+| `fix/**` | Resolution only (`broken:`, `unparseable:`, `yaml-error:`, `cycle:`, `schema-error:`, `open:`) | Resolving a specific blocker, open question, broken/unparseable reference, reference cycle, misspelled schema expectation, or malformed frontmatter |
 
 Both branch types derive artifact scope from the first commit (see below). The `fix/**`
 restriction is enforced independently of scope — a scoped fix branch only sees resolution

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/learnings/learnings.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/learnings/learnings.md
@@ -1,7 +1,7 @@
 # DDD flow — cross-iteration learnings
 
 Not a project-docs artifact — no frontmatter, no lineage tracking, nothing here participates in
-`resolutionStatus`/`orphans`/readiness signals. This file exists for exactly one gap those
+`status.resolution`/`unreferenced`/readiness signals. This file exists for exactly one gap those
 mechanisms don't cover: something found once (a tool gotcha, an environment quirk, a skill-process
 gap) that would recur for *any* future iteration regardless of which requirement it's working on,
 so filing it in a requirement-scoped `iteration-retrospectives/*.md` entry means a differently-

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -124,6 +124,15 @@ const designArtifactsOf = (key) => (index[key] ?? []).filter((e) => DESIGN_TYPES
 
 // --- Signals, in priority order --------------------------------------------------------------
 
+// A reference token can carry an @digest and/or a #fragment, neither of which is
+// part of the target's identity, so strip both before using one as a registry
+// key. Without this, ancestor-scope traversal silently stopped at the first
+// pinned reference: registry['domain-terms:a@a3f9c2e1b004'] is undefined, so a
+// descendant of a scoped artifact stopped being recognised as in scope.
+function refKeyOf(token) {
+  return String(token).split('@')[0].split('#')[0];
+}
+
 const signals = [];
 
 for (const yamlError of integrity.yamlErrors ?? []) {
@@ -285,7 +294,11 @@ const openKeys = status.resolution?.open ?? [];
 for (const key of Object.keys(registry)) {
   if (!isDesignKey(key)) continue;
   if (hasUntypedDescendant(key)) continue; // already has implementing code
-  const blockedByOpen = openKeys.some((ok) => (registry[ok]?.ancestorRefs ?? []).includes(key));
+  // refKeyOf, not a raw includes(): an ancestorRef may carry an @digest, and the
+  // raw token never equals the bare key, so a pinned blocker stopped blocking.
+  const blockedByOpen = openKeys.some((ok) =>
+    (registry[ok]?.ancestorRefs ?? []).some((anc) => refKeyOf(anc) === key),
+  );
   if (blockedByOpen) continue;
   signals.push({
     key: `undeveloped:${key}`,
@@ -300,7 +313,9 @@ for (const path of mdFilesIn('project-docs/requirements')) {
   if ((fm.rules ?? []).length === 0) continue;
   const reqKey = `requirements:${slugOf(path)}`;
   const domainModelKeys = Object.keys(registry).filter(
-    (k) => k.startsWith('domain-models:') && (registry[k].ancestorRefs ?? []).includes(reqKey),
+    (k) =>
+      k.startsWith('domain-models:') &&
+      (registry[k].ancestorRefs ?? []).some((anc) => refKeyOf(anc) === reqKey),
   );
   if (domainModelKeys.length === 0) continue;
 
@@ -371,15 +386,6 @@ if (scopedPaths.length > 0 && scopedKeys.size === 0) {
     `these paths resolved to a registry key — running unfiltered. ` +
     `Check whether the scoped files were renamed or are not yet registered in project-docs/.`,
   );
-}
-
-// A reference token can carry an @digest and/or a #fragment, neither of which is
-// part of the target's identity, so strip both before using one as a registry
-// key. Without this, ancestor-scope traversal silently stopped at the first
-// pinned reference: registry['domain-terms:a@a3f9c2e1b004'] is undefined, so a
-// descendant of a scoped artifact stopped being recognised as in scope.
-function refKeyOf(token) {
-  return String(token).split('@')[0].split('#')[0];
 }
 
 function isInArtifactScope(signal) {

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -154,6 +154,33 @@ for (const broken of integrity.brokenRefs ?? []) {
   });
 }
 
+for (const cycle of integrity.cycles ?? []) {
+  signals.push({
+    // Keyed on the canonical cycle, which project-docs-lineage already rotates
+    // so the smallest node leads — otherwise the same loop would produce a
+    // different key each run and stall detection would never see a repeat.
+    key: `cycle:${cycle.join(',')}`,
+    stage: 'unknown',
+    reason:
+      `Reference cycle: ${[...cycle, cycle[0]].join(' -> ')}. project-docs-ancestors is a ` +
+      `derivation relation, so these artifacts each claim to be built from the other and ` +
+      `neither can precede it. Break the cycle by removing whichever reference is not a real ` +
+      `derivation — fix this before anything else.`,
+  });
+}
+
+for (const schemaError of integrity.schemaErrors ?? []) {
+  signals.push({
+    key: `schema-error:${schemaError.type}:${schemaError.expectedAncestorType}`,
+    stage: 'unknown',
+    reason:
+      `project-docs/artifact-schema.json: "${schemaError.type}" expects ancestor type ` +
+      `"${schemaError.expectedAncestorType}", which is not a known artifact type — did you mean ` +
+      `"${schemaError.didYouMean}"? Nothing can satisfy it as written, so every ` +
+      `${schemaError.type} artifact would report unscoped. Fix the schema, not the artifacts.`,
+  });
+}
+
 for (const openKey of status.resolution?.open ?? []) {
   const entry = registry[openKey];
   signals.push({
@@ -168,6 +195,21 @@ for (const unscopedKey of status.unscoped ?? []) {
     key: `unscoped:${unscopedKey}`,
     stage: stageFor(typeOf(unscopedKey)),
     reason: `${unscopedKey} is missing one of its kind's expected ancestors.`,
+  });
+}
+
+// Staleness is a status finding, not integrity: the graph is sound and reporting
+// that an ancestor moved after this artifact derived from it. So it's ordinary
+// work at the descendant's own stage, not a repair — which is also why it stays
+// out of RESOLUTION_PREFIXES below, same as 'unscoped:'.
+for (const entry of status.stale ?? []) {
+  signals.push({
+    key: `stale:${entry.artifact}:${entry.ancestor}`,
+    stage: stageFor(typeOf(entry.artifact)),
+    reason:
+      `${entry.ancestor} was revised after ${entry.artifact} derived from it, so ${entry.artifact} ` +
+      `may no longer reflect it. Read both, revise ${entry.artifact} if it needs it, then record ` +
+      `that you have by re-pinning: nx g @abgov/nx-agent:pin-ancestors --artifact=${entry.artifact}.`,
   });
 }
 
@@ -285,10 +327,16 @@ const isFixBranch = branchName.startsWith('fix/');
 // each names one specific thing to repair, not new work to start. Both only became reachable
 // once project-docs-lineage stopped aborting its write on them; without them here, a fix/**
 // branch would see the signal and then be told it isn't eligible to act on it.
+//
+// 'cycle:' and 'schema-error:' join them on the same test: both are integrity findings naming
+// one specific thing to repair. 'stale:' deliberately does not — it's a status finding, so
+// revisiting the descendant is ordinary work at its own stage, same as 'unscoped:'.
 const RESOLUTION_PREFIXES = [
   'broken:',
   'unparseable:',
   'yaml-error:',
+  'cycle:',
+  'schema-error:',
   'open:',
 ];
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -99,7 +99,24 @@ if (!existsSync(LINEAGE_PATH)) {
 }
 
 const lineage = JSON.parse(readFileSync(LINEAGE_PATH, 'utf-8'));
-const { registry, index, violations } = lineage;
+
+// What the schemaVersion in lineage.json is for. This script is generated
+// write-if-missing, so a workspace can end up running an older copy of it
+// against a newer graph (or the reverse, off a stale gitignored file) -- fail
+// here, naming both versions, rather than 40 lines down with a TypeError on a
+// container that moved.
+const EXPECTED_LINEAGE_SCHEMA_VERSION = 1;
+if (lineage.schemaVersion !== EXPECTED_LINEAGE_SCHEMA_VERSION) {
+  console.error(
+    `[task-identification] ${LINEAGE_PATH} is schemaVersion ${lineage.schemaVersion ?? '(absent)'}, ` +
+      `this script expects ${EXPECTED_LINEAGE_SCHEMA_VERSION}. Re-run ` +
+      `\`npx nx g @abgov/nx-agent:project-docs-lineage\`; if that doesn't fix it, this copy of ` +
+      `the script is older than the installed @abgov/nx-agent and needs updating.`,
+  );
+  process.exit(1);
+}
+
+const { registry, index, integrity, status } = lineage;
 
 const descendantTypes = (key) => (index[key] ?? []).map((e) => e.type).filter(Boolean);
 const hasUntypedDescendant = (key) => (index[key] ?? []).some((e) => !e.type);
@@ -109,7 +126,7 @@ const designArtifactsOf = (key) => (index[key] ?? []).filter((e) => DESIGN_TYPES
 
 const signals = [];
 
-for (const yamlError of violations.yamlErrors ?? []) {
+for (const yamlError of integrity.yamlErrors ?? []) {
   signals.push({
     key: `yaml-error:${yamlError.path}`,
     stage: 'unknown',
@@ -117,7 +134,7 @@ for (const yamlError of violations.yamlErrors ?? []) {
   });
 }
 
-for (const unparseable of violations.unparseableRefs ?? []) {
+for (const unparseable of integrity.unparseableRefs ?? []) {
   signals.push({
     key: `unparseable:${unparseable.ref}`,
     stage: 'unknown',
@@ -129,7 +146,7 @@ for (const unparseable of violations.unparseableRefs ?? []) {
   });
 }
 
-for (const broken of violations.brokenRefs ?? []) {
+for (const broken of integrity.brokenRefs ?? []) {
   signals.push({
     key: `broken:${broken.ref}`,
     stage: 'unknown',
@@ -137,7 +154,7 @@ for (const broken of violations.brokenRefs ?? []) {
   });
 }
 
-for (const openKey of violations.resolutionStatus?.open ?? []) {
+for (const openKey of status.resolution?.open ?? []) {
   const entry = registry[openKey];
   signals.push({
     key: `open:${openKey}`,
@@ -146,7 +163,7 @@ for (const openKey of violations.resolutionStatus?.open ?? []) {
   });
 }
 
-for (const unscopedKey of violations.unscoped ?? []) {
+for (const unscopedKey of status.unscoped ?? []) {
   signals.push({
     key: `unscoped:${unscopedKey}`,
     stage: stageFor(typeOf(unscopedKey)),
@@ -210,7 +227,7 @@ for (const key of Object.keys(registry)) {
 }
 
 // api-design/ux-design with no implementing code, and no unresolved blocker/open-question naming it.
-const openKeys = violations.resolutionStatus?.open ?? [];
+const openKeys = status.resolution?.open ?? [];
 for (const key of Object.keys(registry)) {
   if (!isDesignKey(key)) continue;
   if (hasUntypedDescendant(key)) continue; // already has implementing code
@@ -375,7 +392,7 @@ if (process.env.PEEK_ONLY !== 'true') {
   // nothing to stall on, and 'none' entries corrupt the stall-detection window when
   // a real signal recurs across a no-work gap.
   if (topSignal) {
-    const lineageFingerprint = JSON.stringify(violations);
+    const lineageFingerprint = JSON.stringify({ integrity, status });
     history.push({ key: topSignal.key, lineageFingerprint });
     history = history.slice(-HISTORY_KEEP);
     writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2) + '\n');

--- a/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/github-actions/scripts/task-identification.mjs
@@ -160,6 +160,8 @@ for (const cycle of integrity.cycles ?? []) {
     // so the smallest node leads — otherwise the same loop would produce a
     // different key each run and stall detection would never see a repeat.
     key: `cycle:${cycle.join(',')}`,
+    // Every node in the cycle, so the signal is in scope when any member is.
+    artifacts: cycle,
     stage: 'unknown',
     reason:
       `Reference cycle: ${[...cycle, cycle[0]].join(' -> ')}. project-docs-ancestors is a ` +
@@ -170,14 +172,23 @@ for (const cycle of integrity.cycles ?? []) {
 }
 
 for (const schemaError of integrity.schemaErrors ?? []) {
+  // Keyed on all three of type/property/value: two bad values on one type are
+  // two things to fix, and collapsing them would let stall detection read the
+  // second as a repeat of the first.
   signals.push({
-    key: `schema-error:${schemaError.type}:${schemaError.expectedAncestorType}`,
+    key: `schema-error:${schemaError.type}:${schemaError.property}:${schemaError.value}`,
+    // Explicitly no artifact: the schema is what's wrong, so no artifact scope
+    // should exclude it.
+    artifacts: null,
     stage: 'unknown',
     reason:
-      `project-docs/artifact-schema.json: "${schemaError.type}" expects ancestor type ` +
-      `"${schemaError.expectedAncestorType}", which is not a known artifact type — did you mean ` +
-      `"${schemaError.didYouMean}"? Nothing can satisfy it as written, so every ` +
-      `${schemaError.type} artifact would report unscoped. Fix the schema, not the artifacts.`,
+      schemaError.problem === 'structural-field'
+        ? `project-docs/artifact-schema.json: "${schemaError.type}".${schemaError.property} names ` +
+          `"${schemaError.value}", a structural field the graph already models as a relationship. ` +
+          `It is excluded from metadata, so the declaration does nothing — remove it.`
+        : `project-docs/artifact-schema.json: "${schemaError.type}".${schemaError.property} names ` +
+          `"${schemaError.value}" — did you mean "${schemaError.didYouMean}"? Nothing can satisfy ` +
+          `it as written. Fix the schema, not the artifacts.`,
   });
 }
 
@@ -205,6 +216,7 @@ for (const unscopedKey of status.unscoped ?? []) {
 for (const entry of status.stale ?? []) {
   signals.push({
     key: `stale:${entry.artifact}:${entry.ancestor}`,
+    artifacts: [entry.artifact],
     stage: stageFor(typeOf(entry.artifact)),
     reason:
       `${entry.ancestor} was revised after ${entry.artifact} derived from it, so ${entry.artifact} ` +
@@ -361,37 +373,63 @@ if (scopedPaths.length > 0 && scopedKeys.size === 0) {
   );
 }
 
-function isInArtifactScope(signalKey) {
+// A reference token can carry an @digest and/or a #fragment, neither of which is
+// part of the target's identity, so strip both before using one as a registry
+// key. Without this, ancestor-scope traversal silently stopped at the first
+// pinned reference: registry['domain-terms:a@a3f9c2e1b004'] is undefined, so a
+// descendant of a scoped artifact stopped being recognised as in scope.
+function refKeyOf(token) {
+  return String(token).split('@')[0].split('#')[0];
+}
+
+function isInArtifactScope(signal) {
   if (openScope) return true;             // explicit * → unfiltered
   if (noScope) return false;             // first commit touched no project-docs files → nothing in scope
   if (scopedKeys.size === 0) return true; // paths specified but unresolvable → fall back to unfiltered (warn already printed)
-  // Signal keys look like 'open:features:x', 'unrefined:requirements:x', etc. -- the artifact
-  // registry key is everything after the first colon-prefix segment.
-  const artifactKey = signalKey.includes(':') ? signalKey.replace(/^[^:]+:/, '') : signalKey;
+
   function ancestorInScope(key, visited = new Set()) {
     if (visited.has(key)) return false;
     visited.add(key);
     if (scopedKeys.has(key)) return true;
     for (const anc of registry[key]?.ancestorRefs ?? []) {
-      if (ancestorInScope(anc, visited)) return true;
+      if (ancestorInScope(refKeyOf(anc), visited)) return true;
     }
     return false;
   }
+
+  // Most signal keys are 'prefix:artifactKey', so the artifact is recoverable
+  // from the string. The keys added for cycles, staleness and schema errors are
+  // not: a cycle names every node in it, a stale edge names both ends, and a
+  // schema error names no artifact at all. Those signals therefore declare
+  // `artifacts` outright. Recovering by string would have derived
+  // 'domain-models:m:domain-terms:t' from a stale signal, matched nothing in the
+  // registry, and dropped the signal on every branch except ARTIFACT_SCOPE='*'.
+  if (signal.artifacts === null) {
+    // About the workspace's own configuration rather than any artifact, so no
+    // artifact scope can legitimately exclude it.
+    return true;
+  }
+  if (Array.isArray(signal.artifacts)) {
+    return signal.artifacts.some((key) => ancestorInScope(refKeyOf(key)));
+  }
+  const artifactKey = signal.key.includes(':')
+    ? signal.key.replace(/^[^:]+:/, '')
+    : signal.key;
   return ancestorInScope(artifactKey);
 }
 
 const eligibleSignals = isFixBranch
   ? signals.filter(
-      (s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)) && isInArtifactScope(s.key),
+      (s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)) && isInArtifactScope(s),
     )
-  : signals.filter((s) => isInArtifactScope(s.key));
+  : signals.filter((s) => isInArtifactScope(s));
 const excludedCount = signals.length - eligibleSignals.length;
 
 // Diagnostic breakdown — computed only when filtering produced nothing, so the log doesn't
 // just say "nothing to do" when the real answer is "scope and branch type disagree."
 let noEligibleNote = null;
 if (eligibleSignals.length === 0 && signals.length > 0) {
-  const inScope = scopedKeys.size > 0 ? signals.filter((s) => isInArtifactScope(s.key)) : signals;
+  const inScope = scopedKeys.size > 0 ? signals.filter((s) => isInArtifactScope(s)) : signals;
   const inBranchType = isFixBranch
     ? signals.filter((s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)))
     : signals;

--- a/packages/nx-agent/src/generators/agent-delivery/files/scripts/check-example-mapping.mjs
+++ b/packages/nx-agent/src/generators/agent-delivery/files/scripts/check-example-mapping.mjs
@@ -3,7 +3,7 @@
 // example or question, and every example must actually be Given/When/Then-shaped, not just
 // any text — a vague sentence shouldn't satisfy the same bar as a concrete, testable scenario.
 //
-// project-docs-lineage's `orphans` check does NOT cover any of this — it's a graph check on
+// project-docs-lineage's `unreferenced` check does NOT cover any of this — it's a graph check on
 // backward references between files, and rules/examples/questions are structured content
 // inside a single requirement file, not separate artifacts. This fills that specific gap.
 //

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/deploy/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/deploy/SKILL.md
@@ -138,7 +138,7 @@ pass genuinely resolved. Captures two things nothing else durably records:
 
 One file, written once this iteration's own work concludes, not a new checkpoint with its own
 gate — the generator self-registers the type (`expectedAncestorTypes: []`, `terminal: true`) so
-this type's own correctly-having-zero-descendants doesn't get reported as an orphan alongside a
+this type's own correctly-having-zero-descendants doesn't get reported as unreferenced alongside a
 genuine dead-end.
 
 ### Commit, when this pass actually generates something

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -57,7 +57,7 @@ scope here.
    `resolves` frontmatter field, also mirrored into `project-docs-ancestors`) is what makes a
    resolution structural — describe the aggregate and its invariants, resolving each named
    Question in the model's own text, with the `resolves:` reference as what a fresh reader (or
-   `project-docs-lineage`'s `resolutionStatus` field) can check without reading that prose.
+   `project-docs-lineage`'s `status.resolution` field) can check without reading that prose.
 
    If a Question needs real information nobody in this pass has, don't guess — stop and ask, or
    write an explicitly-marked placeholder decision if told to keep moving; a placeholder still

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -145,7 +145,7 @@ blocking status depends on whether this project has a CI backstop yet — see be
   already present in scaffolding before this pass touched anything is drift to flag, not a reason
   to block.
 - **`project-docs-lineage --strict`** blocks on a broken reference, as always — `--strict` is what
-  makes it fail the command rather than just record the reference in `lineage.json`. Its `status` report (orphans, unscoped)
+  makes it fail the command rather than just record the reference in `lineage.json`. Its `status` report (unreferenced, unscoped)
   should be empty by the time a resource's code exists and correctly references its api-design.
 
 ### Independent code review — every pass

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -145,7 +145,7 @@ blocking status depends on whether this project has a CI backstop yet — see be
   already present in scaffolding before this pass touched anything is drift to flag, not a reason
   to block.
 - **`project-docs-lineage --strict`** blocks on a broken reference, as always — `--strict` is what
-  makes it fail the command rather than just record the reference in `lineage.json`. Its orphan/unscoped report
+  makes it fail the command rather than just record the reference in `lineage.json`. Its `status` report (orphans, unscoped)
   should be empty by the time a resource's code exists and correctly references its api-design.
 
 ### Independent code review — every pass

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
@@ -96,7 +96,7 @@ written by a generator's own `--resolves <path>` flag (`feature`/`domain-term`/`
 `domain-model`) or by hand for a type with no generator yet (`api-design`, `ux-design`). Never a
 separate edit on the open-question/blocker file itself, and an unrelated later edit to the target
 doesn't count as resolving anything. `project-docs-lineage` reports resolution status directly
-(`violations.resolutionStatus.open`/`.resolved`) — nothing to compute or register by hand.
+(`status.resolution.open`/`.resolved`) — nothing to compute or register by hand.
 
 **`bug` also tracks open/resolved status this same generic way, but is resolved differently** — see
 `develop/SKILL.md`'s own bug-handling section; Discover never resolves one directly.

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
@@ -132,7 +132,7 @@ These check different things:
 - `project-docs-lineage`'s broken-reference check always blocks, regardless of mode — `--strict`
   is what turns a recorded broken reference into a failing command, and composes with
   `--dry-run` to check without writing anything. Its
-  `orphans` report is a graph fact (has Design picked this requirement up yet), not an
+  `unreferenced` report is a graph fact (has Design picked this requirement up yet), not an
   example-mapping check — it stays true even after perfect example-mapping, since nothing
   downstream exists yet.
 - `check-example-mapping.mjs` is the actual example-mapping gate: every `rules:` entry needs a

--- a/packages/nx-agent/src/generators/blocker/blocker.ts
+++ b/packages/nx-agent/src/generators/blocker/blocker.ts
@@ -66,7 +66,7 @@ export default async function (host: Tree, options: Schema) {
   // No fixed expected ancestor type — a blocker can relate to any artifact
   // kind. tracksResolution: true is what makes project-docs-lineage report
   // this blocker as open/resolved.
-  ensureArtifactSchemaEntry(host, 'blockers', [], true);
+  ensureArtifactSchemaEntry(host, 'blockers', [], { tracksResolution: true });
 
   const content = [
     '---',

--- a/packages/nx-agent/src/generators/bug/bug.ts
+++ b/packages/nx-agent/src/generators/bug/bug.ts
@@ -72,7 +72,7 @@ export default async function (host: Tree, options: Schema) {
   // open-question/blocker: an iteration-retrospective's --resolves once a
   // fix lands (often a pure code change, producing no new project-docs
   // artifact of its own to carry the reference instead).
-  ensureArtifactSchemaEntry(host, 'bugs', [], true);
+  ensureArtifactSchemaEntry(host, 'bugs', [], { tracksResolution: true });
 
   const content = [
     '---',

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -56,3 +56,19 @@ rather than a hard rule — an artifact of a scoped type missing one of its expe
 record (a retrospective, for instance) — nothing is ever expected to derive from it, so it's excluded
 from the `unreferenced` report (zero descendants) that would otherwise flag it identically to a
 domain-model nobody's built on yet.
+
+**Two kinds of finding, and only one of them blocks.** `project-docs-lineage` splits what it reports
+into `integrity` — a reference whose target doesn't exist, a token that isn't a reference at all,
+frontmatter that won't parse, a cycle, a schema entry naming a type that doesn't exist — and
+`status`, which is a sound graph telling you where the work stands (nothing derives from it yet, an
+expected ancestor is missing, an ancestor was revised after this derived from it). `--strict` fails
+on integrity and never on status, so use it as a gate freely: it can't be tripped by work merely
+being incomplete.
+
+**Recording that you've read an ancestor.** A reference may carry the ancestor's body digest —
+`domain-terms:case@a3f9c2e1b004` — and `project-docs-lineage` then reports it as `stale` once that
+ancestor is revised, meaning your artifact may no longer reflect what it was built from. An
+unpinned reference is never reported, so this costs nothing until you opt a reference in with
+`nx g @abgov/nx-agent:pin-ancestors`. Re-pin only after actually re-reading the ancestor — the
+digest is an assertion that you have, it lands in your own diff, and a blind bulk re-pin just
+records existing drift as the new floor.

--- a/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
+++ b/packages/nx-agent/src/generators/init/guidance/conventions-and-consistency/project-docs-lineage.md
@@ -32,7 +32,7 @@ or blocker as resolved specifically, rather than mistaking any artifact that mer
 context as having settled it. Hand-authoring a resolution for a type with no generator yet (the
 normal state before one exists) doesn't need that duplication done by hand — a `resolves:` entry
 alone is enough; lineage traversal unions it in for you, so the resolved artifact doesn't also need
-to appear in `project-docs-ancestors` to avoid being misreported as an orphan.
+to appear in `project-docs-ancestors` to avoid being misreported as unreferenced.
 
 **Where an artifact belongs**, one level below the format above: a bounded context, domain model, or
 domain term can be scoped to a specific project (`--project <p>`) instead of the workspace root, and
@@ -54,5 +54,5 @@ knowledge of any specific type baked in, and reports — never fails, since this
 rather than a hard rule — an artifact of a scoped type missing one of its expected ancestors as
 "unscoped." The same file also supports `"terminal": true` for a type meant purely as a close-out
 record (a retrospective, for instance) — nothing is ever expected to derive from it, so it's excluded
-from the "orphan" report (zero descendants) that would otherwise flag it identically to a
+from the `unreferenced` report (zero descendants) that would otherwise flag it identically to a
 domain-model nobody's built on yet.

--- a/packages/nx-agent/src/generators/iteration-retrospective/README.template.md
+++ b/packages/nx-agent/src/generators/iteration-retrospective/README.template.md
@@ -31,5 +31,5 @@ Add one with `nx g @abgov/nx-agent:iteration-retrospective "<title>" --project-d
   invocation. Always present, empty if nothing was resolved.
 
 A correctly-closed-out retrospective has zero descendants forever — nothing is ever expected to
-build on a close-out record — so it's excluded from `project-docs-lineage`'s orphan report rather
+build on a close-out record — so it's excluded from `project-docs-lineage`'s `unreferenced` report rather
 than flagged alongside a genuine dead-end.

--- a/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
+++ b/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
@@ -74,7 +74,7 @@ export default async function (host: Tree, options: Schema) {
   // coverage varies pass to pass by design, unlike domain-terms/domain-models
   // which always expect the same fixed ancestor types. terminal: true is what
   // keeps a correctly-closed-out retrospective (zero descendants by design)
-  // from being reported as an orphan alongside a genuine dead-end.
+  // from being reported as unreferenced alongside a genuine dead-end.
   ensureArtifactSchemaEntry(
     host,
     'iteration-retrospectives',

--- a/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
+++ b/packages/nx-agent/src/generators/iteration-retrospective/iteration-retrospective.ts
@@ -75,13 +75,9 @@ export default async function (host: Tree, options: Schema) {
   // which always expect the same fixed ancestor types. terminal: true is what
   // keeps a correctly-closed-out retrospective (zero descendants by design)
   // from being reported as unreferenced alongside a genuine dead-end.
-  ensureArtifactSchemaEntry(
-    host,
-    'iteration-retrospectives',
-    [],
-    undefined,
-    true,
-  );
+  ensureArtifactSchemaEntry(host, 'iteration-retrospectives', [], {
+    terminal: true,
+  });
 
   const content = [
     '---',

--- a/packages/nx-agent/src/generators/open-question/open-question.ts
+++ b/packages/nx-agent/src/generators/open-question/open-question.ts
@@ -66,7 +66,7 @@ export default async function (host: Tree, options: Schema) {
   // No fixed expected ancestor type — an open question can ground on any
   // artifact kind. tracksResolution: true is what makes project-docs-lineage
   // report this question as open/resolved.
-  ensureArtifactSchemaEntry(host, 'open-questions', [], true);
+  ensureArtifactSchemaEntry(host, 'open-questions', [], { tracksResolution: true });
 
   const content = [
     '---',

--- a/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.spec.ts
+++ b/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.spec.ts
@@ -236,4 +236,43 @@ describe('nx-agent pin-ancestors generator', () => {
       warn.mockRestore();
     });
   });
+
+  // Digests were computed from a registry built before formatFiles, and
+  // Prettier rewrites bodies (list markers, heading style, table alignment) —
+  // none of which extractBody normalises. So an artifact that is both a pin
+  // target and itself pinned got a digest against its pre-format body and
+  // reported stale seconds later with no edit in between.
+  it('records a digest that survives its own formatting pass', async () => {
+    // '*' list markers: Prettier rewrites these to '-'.
+    host.write(
+      'project-docs/domain-terms/mid.md',
+      [
+        '---',
+        'term: Mid',
+        'project-docs-ancestors:',
+        '  - domain-terms:a',
+        '---',
+        '',
+        '* one',
+        '* two',
+      ].join('\n'),
+    );
+    host.write(
+      'project-docs/domain-terms/leaf.md',
+      [
+        '---',
+        'term: Leaf',
+        'project-docs-ancestors:',
+        '  - domain-terms:mid',
+        '---',
+        'Leaf body',
+      ].join('\n'),
+    );
+
+    await generator(host);
+    await lineage(host);
+
+    const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(l.status.stale).toEqual([]);
+  });
 });

--- a/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.spec.ts
+++ b/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.spec.ts
@@ -1,0 +1,239 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { Tree, logger } from '@nx/devkit';
+import generator from './pin-ancestors';
+import lineage from '../project-docs-lineage/project-docs-lineage';
+
+describe('nx-agent pin-ancestors generator', () => {
+  let host: Tree;
+
+  beforeEach(() => {
+    host = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    host.write(
+      'project-docs/domain-terms/a.md',
+      ['---', 'term: A', '---', 'A body'].join('\n'),
+    );
+  });
+
+  function writeDescendant(
+    id: string,
+    ancestors: string[],
+    extra: string[] = [],
+  ) {
+    host.write(
+      `project-docs/domain-terms/${id}.md`,
+      [
+        '---',
+        `term: ${id}`,
+        ...extra,
+        'project-docs-ancestors:',
+        ...ancestors.map((a) => `  - ${a}`),
+        '---',
+        `${id} body`,
+      ].join('\n'),
+    );
+  }
+
+  function refsOf(id: string): string[] {
+    return host
+      .read(`project-docs/domain-terms/${id}.md`, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim().startsWith('- '))
+      .map((l) => l.trim().slice(2));
+  }
+
+  it('adds the ancestor body digest to an unpinned reference', async () => {
+    writeDescendant('b', ['domain-terms:a']);
+
+    await generator(host);
+
+    expect(refsOf('b')).toEqual([
+      expect.stringMatching(/^domain-terms:a@[0-9a-f]{12}$/),
+    ]);
+  });
+
+  it('produces a pin project-docs-lineage then reports as current', async () => {
+    writeDescendant('b', ['domain-terms:a']);
+
+    await generator(host);
+    await lineage(host);
+
+    const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+    expect(l.status.stale).toEqual([]);
+  });
+
+  it('refreshes a stale pin', async () => {
+    writeDescendant('b', ['domain-terms:a@aaaaaaaaaaaa']);
+
+    await generator(host);
+
+    expect(refsOf('b')[0]).not.toContain('aaaaaaaaaaaa');
+    await lineage(host);
+    expect(
+      JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).status.stale,
+    ).toEqual([]);
+  });
+
+  it('leaves a reference that does not resolve alone, rather than inventing provenance', async () => {
+    writeDescendant('b', ['domain-terms:nonexistent']);
+
+    await generator(host);
+
+    expect(refsOf('b')).toEqual(['domain-terms:nonexistent']);
+  });
+
+  it('preserves a fragment while pinning', async () => {
+    writeDescendant('b', ['domain-terms:a#some-section']);
+
+    await generator(host);
+
+    expect(refsOf('b')[0]).toMatch(
+      /^domain-terms:a@[0-9a-f]{12}#some-section$/,
+    );
+  });
+
+  it('scopes to one descendant with --artifact', async () => {
+    writeDescendant('b', ['domain-terms:a']);
+    writeDescendant('c', ['domain-terms:a']);
+
+    await generator(host, { artifact: 'domain-terms:b' });
+
+    expect(refsOf('b')[0]).toContain('@');
+    expect(refsOf('c')).toEqual(['domain-terms:a']);
+  });
+
+  it('scopes to one ancestor with --ancestor', async () => {
+    host.write(
+      'project-docs/domain-terms/other.md',
+      ['---', 'term: Other', '---', 'Other body'].join('\n'),
+    );
+    writeDescendant('b', ['domain-terms:a', 'domain-terms:other']);
+
+    await generator(host, { ancestor: 'domain-terms:a' });
+
+    const refs = refsOf('b');
+    expect(refs[0]).toContain('domain-terms:a@');
+    expect(refs[1]).toBe('domain-terms:other');
+  });
+
+  it('throws on a scope that is not a registered artifact', async () => {
+    writeDescendant('b', ['domain-terms:a']);
+
+    await expect(
+      generator(host, { ancestor: 'domain-terms:typo' }),
+    ).rejects.toThrow(/not a registered project-docs artifact/);
+  });
+
+  // resolves holds references too, but resolving an open question isn't a
+  // derivation — the question's content moving doesn't invalidate the resolver.
+  it('does not touch a resolves list', async () => {
+    writeDescendant(
+      'b',
+      ['domain-terms:a'],
+      ['resolves:', '  - domain-terms:a'],
+    );
+
+    await generator(host);
+
+    const content = host.read('project-docs/domain-terms/b.md', 'utf-8');
+    const resolvesBlock = content.slice(
+      content.indexOf('resolves:'),
+      content.indexOf('project-docs-ancestors:'),
+    );
+    expect(resolvesBlock).not.toContain('@');
+  });
+
+  it('is idempotent', async () => {
+    writeDescendant('b', ['domain-terms:a']);
+
+    await generator(host);
+    const once = host.read('project-docs/domain-terms/b.md', 'utf-8');
+    await generator(host);
+
+    expect(host.read('project-docs/domain-terms/b.md', 'utf-8')).toBe(once);
+  });
+
+  // The generators emit both sequence styles: requirements write a block list,
+  // domain-terms write a flow list. Handling only one silently skipped the
+  // other, which reads exactly like a deliberately unpinned reference.
+  describe('flow-style sequences', () => {
+    function writeFlowDescendant(id: string, inner: string) {
+      host.write(
+        `project-docs/domain-terms/${id}.md`,
+        [
+          '---',
+          `term: ${id}`,
+          `project-docs-ancestors: [${inner}]`,
+          'resolves: []',
+          '---',
+          `${id} body`,
+        ].join('\n'),
+      );
+    }
+
+    it('pins a single-item flow list', async () => {
+      writeFlowDescendant('b', 'domain-terms:a');
+
+      await generator(host);
+
+      expect(host.read('project-docs/domain-terms/b.md', 'utf-8')).toMatch(
+        /project-docs-ancestors: \[domain-terms:a@[0-9a-f]{12}\]/,
+      );
+    });
+
+    it('pins every item in a multi-item flow list', async () => {
+      host.write(
+        'project-docs/domain-terms/other.md',
+        ['---', 'term: Other', '---', 'Other body'].join('\n'),
+      );
+      writeFlowDescendant('b', 'domain-terms:a, domain-terms:other');
+
+      await generator(host);
+
+      // formatFiles reflows a multi-item flow list into block style, so assert
+      // on the file rather than on the original single line.
+      const content = host.read('project-docs/domain-terms/b.md', 'utf-8');
+      expect(content).toMatch(/domain-terms:a@[0-9a-f]{12}/);
+      expect(content).toMatch(/domain-terms:other@[0-9a-f]{12}/);
+    });
+
+    it('leaves an empty flow list alone', async () => {
+      writeFlowDescendant('b', '');
+
+      await generator(host);
+
+      expect(host.read('project-docs/domain-terms/b.md', 'utf-8')).toContain(
+        'project-docs-ancestors: []',
+      );
+    });
+
+    it('does not treat a following resolves list as part of the ancestors list', async () => {
+      writeFlowDescendant('b', 'domain-terms:a');
+
+      await generator(host);
+
+      expect(host.read('project-docs/domain-terms/b.md', 'utf-8')).toContain(
+        'resolves: []',
+      );
+    });
+
+    it('warns rather than silently skipping a form it cannot rewrite', async () => {
+      const warn = jest.spyOn(logger, 'warn').mockImplementation();
+      host.write(
+        'project-docs/domain-terms/b.md',
+        [
+          '---',
+          'term: b',
+          'project-docs-ancestors:',
+          '  - { weird: mapping }',
+          '---',
+          'b body',
+        ].join('\n'),
+      );
+
+      await generator(host);
+
+      expect(warn.mock.calls.flat().join('\n')).toContain('could not pin');
+      warn.mockRestore();
+    });
+  });
+});

--- a/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.ts
+++ b/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.ts
@@ -137,6 +137,15 @@ function pinFile(
 }
 
 export default async function (host: Tree, options: Schema = {}) {
+  // formatFiles() before anything is read, not only at the end. Digests cover
+  // the body, and Prettier rewrites bodies — list markers, heading style, table
+  // alignment, emphasis characters — none of which extractBody normalises. So a
+  // pin computed against an unformatted body was invalidated by the format pass
+  // that followed it: for any artifact that is both a pin target and itself
+  // pinned (a chain, i.e. the normal shape), project-docs-lineage reported it
+  // stale seconds after pinning, with no edit in between.
+  await formatFiles(host);
+
   const registry = buildRegistry(host);
   const artifactSchema = readArtifactSchema(host);
 
@@ -167,6 +176,8 @@ export default async function (host: Tree, options: Schema = {}) {
     );
     return;
   }
+  // Again, so the frontmatter just rewritten is itself formatted. Safe for the
+  // digests recorded above: they cover bodies, and nothing here touched one.
   await formatFiles(host);
   logger.info(
     `[nx-agent] pinned ${updated} reference(s). Each records that you have read the ` +

--- a/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.ts
+++ b/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.ts
@@ -1,0 +1,162 @@
+import { Tree, formatFiles, logger } from '@nx/devkit';
+import {
+  buildRegistry,
+  parseAncestorRef,
+  refKey,
+  Registry,
+} from '../../utils/project-docs-refs';
+import { Schema } from './schema';
+
+// Records each resolved ancestor's current body digest on the reference that
+// names it, so project-docs-lineage can later report that the ancestor moved
+// and downstream review is pending.
+//
+// Its own generator rather than a --repin flag on project-docs-lineage, for two
+// reasons. project-docs-lineage reads the graph and reports; this writes to
+// artifacts, and mixing a mutation into the reporting tool is how it ends up
+// next to --strict in a workflow with the check silently dead. And re-pinning
+// asserts "I reviewed this and my artifact still holds" — a claim only a human
+// can make. So: never call this from a hook, a CI step, or a clean-run path. A
+// blind bulk re-pin bakes in whatever drift already exists and then reports it
+// as the floor.
+//
+// Scoping is the point of --artifact/--ancestor. "I fixed a typo in this one
+// term, re-pin its descendants" is an act you can justify in a commit message;
+// re-pinning the whole workspace is only ever "make the report stop."
+const ANCESTORS_KEY = 'project-docs-ancestors';
+const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/;
+// Both YAML sequence styles, because the generators emit both: `requirements`
+// write a block list, `domain-terms` write a flow list on one line. Matched by
+// line rather than round-tripped through a YAML parser, which would reformat
+// the whole block and lose comments and quoting with it — at the cost of having
+// to know each style, hence the warning below for anything neither matches.
+const BLOCK_ITEM = /^(\s*-\s*)(\S+)\s*$/;
+const FLOW_LIST = /^(project-docs-ancestors:\s*\[)([^\]]*)(\]\s*)$/;
+
+function pinFile(
+  host: Tree,
+  registry: Registry,
+  path: string,
+  options: Schema,
+): string[] {
+  const content = host.read(path, 'utf-8') ?? '';
+  const block = FRONTMATTER_BLOCK.exec(content);
+  if (!block) {
+    return [];
+  }
+
+  const pinned: string[] = [];
+
+  // Returns the token re-pinned, or the token unchanged when it shouldn't be.
+  const pin = (token: string): string => {
+    const parsed = parseAncestorRef(token);
+    if (!parsed) {
+      return token;
+    }
+    const key = refKey(parsed);
+    // A reference that doesn't resolve is a broken reference, and
+    // project-docs-lineage reports it as one. Pinning it would invent
+    // provenance for something that was never read.
+    const ancestor = registry.get(key);
+    if (!ancestor) {
+      return token;
+    }
+    if (options.ancestor && options.ancestor !== key) {
+      return token;
+    }
+    if (parsed.digest === ancestor.bodyDigest) {
+      return token;
+    }
+    pinned.push(key);
+    const fragment = parsed.fragment ? `#${parsed.fragment}` : '';
+    return `${key}@${ancestor.bodyDigest}${fragment}`;
+  };
+
+  let inAncestors = false;
+  const rewritten = block[1]
+    .split('\n')
+    .map((line) => {
+      if (/^\S/.test(line)) {
+        const flow = FLOW_LIST.exec(line);
+        if (flow) {
+          // Self-contained on this line, so the block-item branch below never
+          // applies to it.
+          inAncestors = false;
+          const items = flow[2].trim();
+          if (!items) {
+            return line;
+          }
+          const rewrittenItems = items
+            .split(',')
+            .map((token) => pin(token.trim()))
+            .join(', ');
+          return `${flow[1]}${rewrittenItems}${flow[3]}`;
+        }
+        inAncestors = line.startsWith(`${ANCESTORS_KEY}:`);
+        return line;
+      }
+      if (!inAncestors) {
+        return line;
+      }
+      const item = BLOCK_ITEM.exec(line);
+      if (!item) {
+        // Inside the ancestors list but in neither style this knows how to
+        // rewrite. Warned rather than skipped: a silently unpinned reference
+        // looks identical to a deliberately unpinned one, and reports nothing
+        // forever.
+        if (line.trim()) {
+          logger.warn(
+            `[nx-agent] ${path}: could not pin "${line.trim()}" — not a form this ` +
+              `generator rewrites. Pin it by hand as <type>:<id>@<digest>.`,
+          );
+        }
+        return line;
+      }
+      return `${item[1]}${pin(item[2])}`;
+    })
+    .join('\n');
+
+  if (pinned.length === 0) {
+    return [];
+  }
+  host.write(path, `---\n${rewritten}\n---${content.slice(block[0].length)}`);
+  return pinned;
+}
+
+export default async function (host: Tree, options: Schema = {}) {
+  const registry = buildRegistry(host);
+
+  for (const scoped of [options.artifact, options.ancestor]) {
+    if (scoped && !registry.has(scoped)) {
+      throw new Error(
+        `[nx-agent] "${scoped}" is not a registered project-docs artifact. ` +
+          `Reference it as <type>:<id> (e.g. domain-terms:collision-report).`,
+      );
+    }
+  }
+
+  let updated = 0;
+  for (const [key, entry] of registry) {
+    if (options.artifact && options.artifact !== key) {
+      continue;
+    }
+    const pinned = pinFile(host, registry, entry.path, options);
+    if (pinned.length > 0) {
+      updated += pinned.length;
+      logger.info(`[nx-agent] ${key}: pinned ${pinned.join(', ')}`);
+    }
+  }
+
+  if (updated === 0) {
+    logger.info(
+      '[nx-agent] every in-scope reference is already pinned to its ancestor.',
+    );
+    return;
+  }
+  await formatFiles(host);
+  logger.info(
+    `[nx-agent] pinned ${updated} reference(s). Each records that you have read the ` +
+      `ancestor as it stands now — the digests appear in your own diff, so review them ` +
+      `as the assertion they are.`,
+  );
+}

--- a/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.ts
+++ b/packages/nx-agent/src/generators/pin-ancestors/pin-ancestors.ts
@@ -1,10 +1,15 @@
 import { Tree, formatFiles, logger } from '@nx/devkit';
 import {
+  artifactDigest,
   buildRegistry,
   parseAncestorRef,
   refKey,
   Registry,
 } from '../../utils/project-docs-refs';
+import {
+  ArtifactSchema,
+  readArtifactSchema,
+} from '../../utils/artifact-schema';
 import { Schema } from './schema';
 
 // Records each resolved ancestor's current body digest on the reference that
@@ -36,6 +41,7 @@ const FLOW_LIST = /^(project-docs-ancestors:\s*\[)([^\]]*)(\]\s*)$/;
 function pinFile(
   host: Tree,
   registry: Registry,
+  artifactSchema: ArtifactSchema,
   path: string,
   options: Schema,
 ): string[] {
@@ -64,12 +70,19 @@ function pinFile(
     if (options.ancestor && options.ancestor !== key) {
       return token;
     }
-    if (parsed.digest === ancestor.bodyDigest) {
+    // Through artifactDigest, never bodyDigest directly: the type may declare
+    // digestFields, and a pin computed any other way would read as stale the
+    // moment project-docs-lineage looked at it.
+    const digest = artifactDigest(
+      ancestor,
+      artifactSchema[parsed.type]?.digestFields,
+    );
+    if (parsed.digest === digest) {
       return token;
     }
     pinned.push(key);
     const fragment = parsed.fragment ? `#${parsed.fragment}` : '';
-    return `${key}@${ancestor.bodyDigest}${fragment}`;
+    return `${key}@${digest}${fragment}`;
   };
 
   let inAncestors = false;
@@ -125,6 +138,7 @@ function pinFile(
 
 export default async function (host: Tree, options: Schema = {}) {
   const registry = buildRegistry(host);
+  const artifactSchema = readArtifactSchema(host);
 
   for (const scoped of [options.artifact, options.ancestor]) {
     if (scoped && !registry.has(scoped)) {
@@ -140,7 +154,7 @@ export default async function (host: Tree, options: Schema = {}) {
     if (options.artifact && options.artifact !== key) {
       continue;
     }
-    const pinned = pinFile(host, registry, entry.path, options);
+    const pinned = pinFile(host, registry, artifactSchema, entry.path, options);
     if (pinned.length > 0) {
       updated += pinned.length;
       logger.info(`[nx-agent] ${key}: pinned ${pinned.join(', ')}`);

--- a/packages/nx-agent/src/generators/pin-ancestors/schema.d.ts
+++ b/packages/nx-agent/src/generators/pin-ancestors/schema.d.ts
@@ -1,0 +1,4 @@
+export interface Schema {
+  artifact?: string;
+  ancestor?: string;
+}

--- a/packages/nx-agent/src/generators/pin-ancestors/schema.json
+++ b/packages/nx-agent/src/generators/pin-ancestors/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "NxAgentPinAncestors",
+  "title": "Pin project-docs-ancestors references to their ancestors current body digest",
+  "description": "Records each resolved ancestor's current body digest on the project-docs-ancestors reference that names it, so project-docs-lineage can later report that the ancestor was revised and downstream review is pending. Run it by hand, never from a hook, a CI step, or a clean-run path: a pin asserts that you have read the ancestor as it stands, and a blind bulk re-pin bakes in whatever drift already exists and then reports it as the floor. Scope it with --artifact or --ancestor rather than re-pinning the whole workspace. References that don't resolve are left alone (project-docs-lineage reports those as broken).",
+  "type": "object",
+  "properties": {
+    "artifact": {
+      "type": "string",
+      "description": "Only pin references *in* this artifact, as <type>:<id> (e.g. domain-models:collision-reporting)."
+    },
+    "ancestor": {
+      "type": "string",
+      "description": "Only pin references *to* this ancestor, as <type>:<id>. The scoped case worth doing: you revised one artifact and want its direct descendants to record that they have seen it."
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -242,4 +242,86 @@ describe('nx-agent project-docs-lineage generator', () => {
     );
     logSpy.mockRestore();
   });
+  describe('schemaVersion and --json', () => {
+    // A minimal graph with one resolving reference and one broken one, so both
+    // halves of the payload are non-empty in the assertions below.
+    function seedGraph(host: Tree) {
+      host.write(
+        'project-docs/domain-terms/collision-report.md',
+        ['---', 'term: Collision Report', '---'].join('\n'),
+      );
+      host.write(
+        'apps/test/src/routes/collision-reports.ts',
+        '// project-docs-ancestors: domain-terms:collision-report\nexport {};',
+      );
+    }
+
+    it('declares a schemaVersion in the written graph', async () => {
+      seedGraph(host);
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.schemaVersion).toBe(1);
+    });
+
+    it('prints the graph to stdout as one parseable document with --json', async () => {
+      seedGraph(host);
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await generator(host, { json: true });
+
+      const printed = logSpy.mock.calls.map((c) => c[0]);
+      expect(printed).toHaveLength(1);
+      const streamed = JSON.parse(printed[0]);
+      expect(streamed.schemaVersion).toBe(1);
+      expect(streamed.registry['domain-terms:collision-report']).toBeDefined();
+      logSpy.mockRestore();
+    });
+
+    it('streams exactly what it writes, so the two surfaces cannot diverge', async () => {
+      seedGraph(host);
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await generator(host, { json: true });
+
+      const streamed = JSON.parse(logSpy.mock.calls[0][0]);
+      const written = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(streamed).toEqual(written);
+      logSpy.mockRestore();
+    });
+
+    it('suppresses the human-readable summary under --json', async () => {
+      host.write(
+        'apps/test/src/routes/collision-reports.ts',
+        '// project-docs-ancestors: domain-terms:typo-id\nexport {};',
+      );
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await generator(host, { json: true });
+
+      const printed = logSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(printed).not.toContain('[nx-agent]');
+      expect(JSON.parse(printed).violations.brokenRefs).toHaveLength(1);
+      logSpy.mockRestore();
+    });
+
+    // The reason --json exists: --strict alone rolls its own write back, so a
+    // gate could have the exit code or the graph but never both in one run.
+    it('prints the graph before --strict throws, so a gate gets both', async () => {
+      host.write(
+        'apps/test/src/routes/collision-reports.ts',
+        '// project-docs-ancestors: domain-terms:typo-id\nexport {};',
+      );
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await expect(
+        generator(host, { json: true, strict: true }),
+      ).rejects.toThrow(/broken project-docs-ancestors reference/);
+
+      const streamed = JSON.parse(logSpy.mock.calls[0][0]);
+      expect(streamed.violations.brokenRefs).toHaveLength(1);
+      logSpy.mockRestore();
+    });
+  });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -757,4 +757,161 @@ describe('nx-agent project-docs-lineage generator', () => {
       logSpy.mockRestore();
     });
   });
+
+  // requirements are the one type whose meaning lives in frontmatter (`rules`),
+  // so the schema declares digestFields for them and the digest covers those
+  // fields alongside the body.
+  describe('declared digest fields', () => {
+    function writeSchema(host: Tree, digestFields?: string[]) {
+      host.write(
+        'project-docs/artifact-schema.json',
+        JSON.stringify({
+          'product-briefs': { expectedAncestorTypes: [] },
+          requirements: {
+            expectedAncestorTypes: [],
+            ...(digestFields ? { digestFields } : {}),
+          },
+          'domain-models': { expectedAncestorTypes: [] },
+        }),
+      );
+    }
+    function writeRequirement(
+      host: Tree,
+      frontmatter: string[],
+      body = 'Rationale.',
+    ) {
+      host.write(
+        'project-docs/requirements/r.md',
+        [
+          '---',
+          'title: R',
+          'id: req-001',
+          ...frontmatter,
+          '---',
+          '',
+          body,
+        ].join('\n'),
+      );
+    }
+    function pinDescendant(host: Tree, digest: string) {
+      host.write(
+        'project-docs/domain-models/m.md',
+        [
+          '---',
+          'name: M',
+          'project-docs-ancestors:',
+          `  - requirements:r@${digest}`,
+          '---',
+          'M body',
+        ].join('\n'),
+      );
+    }
+    async function currentDigest(host: Tree) {
+      await generator(host);
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      return l.status.stale[0]?.currentDigest;
+    }
+
+    it('marks descendants stale when a declared field changes', async () => {
+      writeSchema(host, ['rules']);
+      writeRequirement(host, ['rules:', '  - rule: original']);
+      pinDescendant(host, 'aaaaaaaaaaaa');
+      const before = await currentDigest(host);
+
+      writeRequirement(host, ['rules:', '  - rule: substantively different']);
+      pinDescendant(host, before);
+      await generator(host);
+
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(l.status.stale).toHaveLength(1);
+      expect(l.status.stale[0].ancestor).toBe('requirements:r');
+    });
+
+    it('does not mark descendants stale for bookkeeping frontmatter', async () => {
+      writeSchema(host, ['rules']);
+      writeRequirement(host, ['rules:', '  - rule: original', 'questions: []']);
+      pinDescendant(host, 'aaaaaaaaaaaa');
+      const pinned = await currentDigest(host);
+      pinDescendant(host, pinned);
+
+      // title changed, an open question answered — neither is of any interest
+      // to something derived from the rules.
+      host.write(
+        'project-docs/requirements/r.md',
+        [
+          '---',
+          'title: R, retitled',
+          'id: req-001',
+          'rules:',
+          '  - rule: original',
+          'questions: []',
+          '---',
+          '',
+          'Rationale.',
+        ].join('\n'),
+      );
+      await generator(host);
+
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(l.status.stale).toEqual([]);
+    });
+
+    it('ignores a frontmatter key reorder', async () => {
+      writeSchema(host, ['rules']);
+      writeRequirement(host, ['rules:', '  - rule: a', '  - rule: b']);
+      pinDescendant(host, 'aaaaaaaaaaaa');
+      const pinned = await currentDigest(host);
+      pinDescendant(host, pinned);
+
+      host.write(
+        'project-docs/requirements/r.md',
+        [
+          '---',
+          'id: req-001',
+          'rules:',
+          '  - rule: a',
+          '  - rule: b',
+          'title: R',
+          '---',
+          '',
+          'Rationale.',
+        ].join('\n'),
+      );
+      await generator(host);
+
+      expect(
+        JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).status.stale,
+      ).toEqual([]);
+    });
+
+    it('sees a declared field being removed entirely', async () => {
+      writeSchema(host, ['rules']);
+      writeRequirement(host, ['rules:', '  - rule: original']);
+      pinDescendant(host, 'aaaaaaaaaaaa');
+      const pinned = await currentDigest(host);
+      pinDescendant(host, pinned);
+
+      writeRequirement(host, []);
+      await generator(host);
+
+      expect(
+        JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).status.stale,
+      ).toHaveLength(1);
+    });
+
+    // Guarantee that adding digestFields to the schema didn't invalidate pins
+    // recorded before it existed.
+    it('leaves the digest equal to bodyDigest when no fields are declared', async () => {
+      writeSchema(host);
+      writeRequirement(host, ['rules:', '  - rule: original']);
+      pinDescendant(host, 'aaaaaaaaaaaa');
+
+      await generator(host);
+
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(l.status.stale[0].currentDigest).toBe(
+        l.registry['requirements:r'].bodyDigest,
+      );
+    });
+  });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -324,4 +324,67 @@ describe('nx-agent project-docs-lineage generator', () => {
       logSpy.mockRestore();
     });
   });
+
+  describe('integrity and status containers', () => {
+    it('splits findings into integrity and status', async () => {
+      host.write(
+        'apps/test/src/routes/collision-reports.ts',
+        '// project-docs-ancestors: domain-terms:typo-id\nexport {};',
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(Object.keys(lineage.integrity).sort()).toEqual([
+        'brokenRefs',
+        'unparseableRefs',
+        'yamlErrors',
+      ]);
+      expect(Object.keys(lineage.status).sort()).toEqual([
+        'orphans',
+        'resolution',
+        'unscoped',
+      ]);
+      expect(lineage.integrity.brokenRefs).toHaveLength(1);
+    });
+
+    // The deprecated alias exists only so an existing workspace's
+    // write-if-missing script keeps working; it must never be a second source
+    // of truth, so it's built from the same arrays rather than recomputed.
+    it('keeps a deprecated violations alias carrying identical data', async () => {
+      host.write(
+        'project-docs/domain-terms/unused.md',
+        ['---', 'term: Unused', '---'].join('\n'),
+      );
+      host.write(
+        'apps/test/src/routes/collision-reports.ts',
+        '// project-docs-ancestors: domain-terms:typo-id\nexport {};',
+      );
+
+      await generator(host);
+
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(l.violations.brokenRefs).toEqual(l.integrity.brokenRefs);
+      expect(l.violations.unparseableRefs).toEqual(l.integrity.unparseableRefs);
+      expect(l.violations.yamlErrors).toEqual(l.integrity.yamlErrors);
+      expect(l.violations.orphans).toEqual(l.status.orphans);
+      expect(l.violations.unscoped).toEqual(l.status.unscoped);
+      expect(l.violations.resolutionStatus).toEqual(l.status.resolution);
+    });
+
+    // The whole point of the split: --strict is a validity check on the graph,
+    // so a sound graph reporting incomplete work must not fail it.
+    it('does not fail --strict on a status-only finding', async () => {
+      host.write(
+        'project-docs/domain-terms/unused.md',
+        ['---', 'term: Unused', '---'].join('\n'),
+      );
+
+      await expect(generator(host, { strict: true })).resolves.toBeUndefined();
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.status.orphans).toEqual(['domain-terms:unused']);
+      expect(lineage.integrity.brokenRefs).toEqual([]);
+    });
+  });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -344,6 +344,7 @@ describe('nx-agent project-docs-lineage generator', () => {
       ]);
       expect(Object.keys(lineage.status).sort()).toEqual([
         'resolution',
+        'stale',
         'unreferenced',
         'unscoped',
       ]);
@@ -593,6 +594,167 @@ describe('nx-agent project-docs-lineage generator', () => {
       await expect(generator(host, { strict: true })).rejects.toThrow(
         /misspelled expectedAncestorTypes/,
       );
+    });
+  });
+
+  describe('ancestor digests', () => {
+    // Pins b to a's *body* digest, so the fixtures below can move a's body
+    // (stale) or only its frontmatter (not stale) independently.
+    function writeAncestorWithBody(host: Tree, body: string) {
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', '---', body].join('\n'),
+      );
+    }
+    function pin(host: Tree, digest: string) {
+      host.write(
+        'project-docs/domain-terms/b.md',
+        [
+          '---',
+          'term: B',
+          'project-docs-ancestors:',
+          `  - domain-terms:a@${digest}`,
+          '---',
+          'B body',
+        ].join('\n'),
+      );
+    }
+    async function digestOfA(host: Tree) {
+      await generator(host);
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      return lineage.registry['domain-terms:a'].bodyDigest;
+    }
+
+    it('leaves an unpinned reference silent', async () => {
+      writeAncestorWithBody(host, 'original');
+      host.write(
+        'project-docs/domain-terms/b.md',
+        [
+          '---',
+          'term: B',
+          'project-docs-ancestors:',
+          '  - domain-terms:a',
+          '---',
+        ].join('\n'),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.status.stale).toEqual([]);
+    });
+
+    it('stays silent while the pin matches', async () => {
+      writeAncestorWithBody(host, 'original');
+      pin(host, await digestOfA(host));
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.status.stale).toEqual([]);
+    });
+
+    it('reports stale once the ancestor body moves', async () => {
+      writeAncestorWithBody(host, 'original');
+      const pinned = await digestOfA(host);
+      pin(host, pinned);
+      writeAncestorWithBody(host, 'revised substantively');
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.status.stale).toHaveLength(1);
+      expect(lineage.status.stale[0]).toMatchObject({
+        artifact: 'domain-terms:b',
+        ancestor: 'domain-terms:a',
+        pinnedDigest: pinned,
+      });
+      expect(lineage.status.stale[0].currentDigest).not.toBe(pinned);
+    });
+
+    // The property the body-only cut buys: re-pinning edits frontmatter, so it
+    // must not itself count as a content change, or one edit to a root would
+    // cascade through the whole descendancy in waves.
+    it('does not change an artifact digest when only its pins change', async () => {
+      writeAncestorWithBody(host, 'original');
+      pin(host, 'aaaaaaaaaaaa');
+      const before = JSON.parse(
+        (await generator(host), host.read('.nx-agent/lineage.json', 'utf-8')),
+      ).registry['domain-terms:b'].bodyDigest;
+
+      pin(host, 'bbbbbbbbbbbb');
+      await generator(host);
+
+      const after = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'))
+        .registry['domain-terms:b'].bodyDigest;
+      expect(after).toBe(before);
+    });
+
+    it('is not stale when only the ancestor frontmatter changes', async () => {
+      writeAncestorWithBody(host, 'original');
+      const pinned = await digestOfA(host);
+      pin(host, pinned);
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', 'aliases:', '  - Ay', '---', 'original'].join('\n'),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.status.stale).toEqual([]);
+    });
+
+    it('does not fail --strict, since a sound graph is reporting pending review', async () => {
+      writeAncestorWithBody(host, 'original');
+      pin(host, await digestOfA(host));
+      writeAncestorWithBody(host, 'revised');
+
+      await expect(generator(host, { strict: true })).resolves.toBeUndefined();
+    });
+
+    // A digest is provenance, not identity: including it in the key would
+    // fragment the registry and index on every edit.
+    it('resolves a pinned reference to the same target as an unpinned one', async () => {
+      writeAncestorWithBody(host, 'original');
+      pin(host, 'aaaaaaaaaaaa');
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.brokenRefs).toEqual([]);
+      expect(lineage.index['domain-terms:a']).toHaveLength(1);
+      // a counts as referenced despite the pin; b is genuinely a leaf.
+      expect(lineage.status.unreferenced).toEqual(['domain-terms:b']);
+    });
+
+    it('groups the console report by ancestor rather than per stale edge', async () => {
+      writeAncestorWithBody(host, 'original');
+      const pinned = await digestOfA(host);
+      for (const id of ['b', 'c']) {
+        host.write(
+          `project-docs/domain-terms/${id}.md`,
+          [
+            '---',
+            `term: ${id}`,
+            'project-docs-ancestors:',
+            `  - domain-terms:a@${pinned}`,
+            '---',
+            `${id} body`,
+          ].join('\n'),
+        );
+      }
+      writeAncestorWithBody(host, 'revised');
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await generator(host);
+
+      const grouped = logSpy.mock.calls
+        .map((c) => String(c[0]))
+        .filter((line) => line.includes('review pending'));
+      expect(grouped).toHaveLength(1);
+      expect(grouped[0]).toContain('2 artifact(s)');
+      logSpy.mockRestore();
     });
   });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -337,6 +337,8 @@ describe('nx-agent project-docs-lineage generator', () => {
       const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
       expect(Object.keys(lineage.integrity).sort()).toEqual([
         'brokenRefs',
+        'cycles',
+        'schemaErrors',
         'unparseableRefs',
         'yamlErrors',
       ]);
@@ -385,6 +387,212 @@ describe('nx-agent project-docs-lineage generator', () => {
       const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
       expect(lineage.status.orphans).toEqual(['domain-terms:unused']);
       expect(lineage.integrity.brokenRefs).toEqual([]);
+    });
+  });
+
+  describe('cycles', () => {
+    function writeMutualPair(host: Tree) {
+      host.write(
+        'project-docs/domain-terms/a.md',
+        [
+          '---',
+          'term: A',
+          'project-docs-ancestors:',
+          '  - domain-terms:b',
+          '---',
+        ].join('\n'),
+      );
+      host.write(
+        'project-docs/domain-terms/b.md',
+        [
+          '---',
+          'term: B',
+          'project-docs-ancestors:',
+          '  - domain-terms:a',
+          '---',
+        ].join('\n'),
+      );
+    }
+
+    it('reports two artifacts deriving from each other', async () => {
+      writeMutualPair(host);
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.cycles).toEqual([
+        ['domain-terms:a', 'domain-terms:b'],
+      ]);
+    });
+
+    // Reachable from either member, so without canonicalisation the same loop
+    // would be reported once per node in it.
+    it('reports a cycle once, not once per member', async () => {
+      writeMutualPair(host);
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.cycles).toHaveLength(1);
+    });
+
+    it('reports an artifact naming itself as its own ancestor', async () => {
+      host.write(
+        'project-docs/domain-terms/self.md',
+        [
+          '---',
+          'term: Self',
+          'project-docs-ancestors:',
+          '  - domain-terms:self',
+          '---',
+        ].join('\n'),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.cycles).toEqual([['domain-terms:self']]);
+    });
+
+    it('fails --strict on a cycle, since the graph is contradictory', async () => {
+      writeMutualPair(host);
+
+      await expect(generator(host, { strict: true })).rejects.toThrow(
+        /reference cycle/,
+      );
+    });
+
+    it('does not mistake a diamond for a cycle', async () => {
+      host.write(
+        'project-docs/domain-terms/root.md',
+        ['---', 'term: Root', '---'].join('\n'),
+      );
+      for (const side of ['left', 'right']) {
+        host.write(
+          `project-docs/domain-terms/${side}.md`,
+          [
+            '---',
+            `term: ${side}`,
+            'project-docs-ancestors:',
+            '  - domain-terms:root',
+            '---',
+          ].join('\n'),
+        );
+      }
+      host.write(
+        'project-docs/domain-terms/join.md',
+        [
+          '---',
+          'term: Join',
+          'project-docs-ancestors:',
+          '  - domain-terms:left',
+          '  - domain-terms:right',
+          '---',
+        ].join('\n'),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.cycles).toEqual([]);
+    });
+  });
+
+  describe('schemaErrors', () => {
+    it('catches a singular expectedAncestorTypes value and names the fix', async () => {
+      host.write(
+        'project-docs/bounded-contexts/bc.md',
+        ['---', 'name: BC', '---'].join('\n'),
+      );
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', '---'].join('\n'),
+      );
+      host.write(
+        'project-docs/artifact-schema.json',
+        JSON.stringify({
+          'bounded-contexts': { expectedAncestorTypes: [] },
+          // The slip: singular, where every real type name is plural.
+          'domain-terms': { expectedAncestorTypes: ['bounded-context'] },
+        }),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.schemaErrors).toEqual([
+        {
+          type: 'domain-terms',
+          expectedAncestorType: 'bounded-context',
+          didYouMean: 'bounded-contexts',
+        },
+      ]);
+    });
+
+    // The defect this fixes: one bad schema value made every artifact of its
+    // type report unscoped, pointing at artifacts that are correct.
+    it('does not also report every artifact of that type as unscoped', async () => {
+      host.write(
+        'project-docs/bounded-contexts/bc.md',
+        ['---', 'name: BC', '---'].join('\n'),
+      );
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', '---'].join('\n'),
+      );
+      host.write(
+        'project-docs/artifact-schema.json',
+        JSON.stringify({
+          'bounded-contexts': { expectedAncestorTypes: [] },
+          'domain-terms': { expectedAncestorTypes: ['bounded-context'] },
+        }),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.status.unscoped).toEqual([]);
+    });
+
+    // A type nothing has been written for yet is indistinguishable from a
+    // misspelling, so it must not be flagged — that would fail --strict on a
+    // correct schema, and in a fresh workspace on most of it.
+    it('stays silent on an unknown type that is not a near-miss', async () => {
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', '---'].join('\n'),
+      );
+      host.write(
+        'project-docs/artifact-schema.json',
+        JSON.stringify({
+          'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+        }),
+      );
+
+      await generator(host);
+
+      const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(lineage.integrity.schemaErrors).toEqual([]);
+      // Still checked, because the expectation may yet be satisfiable.
+      expect(lineage.status.unscoped).toEqual(['domain-terms:a']);
+    });
+
+    it('fails --strict on a misspelled expectation', async () => {
+      host.write(
+        'project-docs/bounded-contexts/bc.md',
+        ['---', 'name: BC', '---'].join('\n'),
+      );
+      host.write(
+        'project-docs/artifact-schema.json',
+        JSON.stringify({
+          'bounded-contexts': { expectedAncestorTypes: [] },
+          'domain-terms': { expectedAncestorTypes: ['bounded-context'] },
+        }),
+      );
+
+      await expect(generator(host, { strict: true })).rejects.toThrow(
+        /misspelled expectedAncestorTypes/,
+      );
     });
   });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -198,7 +198,7 @@ describe('nx-agent project-docs-lineage generator', () => {
     expect(lineage.violations.unscoped).toEqual([]);
   });
 
-  it('reports resolutionStatus without throwing, console-logging open and resolved keys', async () => {
+  it('reports status.resolution without throwing, console-logging open and resolved keys', async () => {
     host.write(
       'project-docs/artifact-schema.json',
       JSON.stringify({

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -127,7 +127,7 @@ describe('nx-agent project-docs-lineage generator', () => {
     );
   });
 
-  it('reports an orphan without throwing', async () => {
+  it('reports an unreferenced artifact without throwing', async () => {
     host.write(
       'project-docs/domain-terms/unused.md',
       ['---', 'term: Unused', '---'].join('\n'),
@@ -343,8 +343,8 @@ describe('nx-agent project-docs-lineage generator', () => {
         'yamlErrors',
       ]);
       expect(Object.keys(lineage.status).sort()).toEqual([
-        'orphans',
         'resolution',
+        'unreferenced',
         'unscoped',
       ]);
       expect(lineage.integrity.brokenRefs).toHaveLength(1);
@@ -369,7 +369,7 @@ describe('nx-agent project-docs-lineage generator', () => {
       expect(l.violations.brokenRefs).toEqual(l.integrity.brokenRefs);
       expect(l.violations.unparseableRefs).toEqual(l.integrity.unparseableRefs);
       expect(l.violations.yamlErrors).toEqual(l.integrity.yamlErrors);
-      expect(l.violations.orphans).toEqual(l.status.orphans);
+      expect(l.violations.orphans).toEqual(l.status.unreferenced);
       expect(l.violations.unscoped).toEqual(l.status.unscoped);
       expect(l.violations.resolutionStatus).toEqual(l.status.resolution);
     });
@@ -385,7 +385,7 @@ describe('nx-agent project-docs-lineage generator', () => {
       await expect(generator(host, { strict: true })).resolves.toBeUndefined();
 
       const lineage = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
-      expect(lineage.status.orphans).toEqual(['domain-terms:unused']);
+      expect(lineage.status.unreferenced).toEqual(['domain-terms:unused']);
       expect(lineage.integrity.brokenRefs).toEqual([]);
     });
   });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -1034,4 +1034,128 @@ describe('nx-agent project-docs-lineage generator', () => {
       );
     });
   });
+
+  describe('regressions found in review', () => {
+    // A malformed digest failed parseAncestorRef *and* the plausibility gate,
+    // so it was dropped in silence and its target read as unreferenced —
+    // verbatim the outcome recordUnparseable exists to prevent. Uppercase hex,
+    // straight off a SHA, is enough to trigger it.
+    it('reports a malformed digest instead of dropping the reference silently', async () => {
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', '---', 'A body'].join('\n'),
+      );
+      host.write(
+        'project-docs/domain-terms/b.md',
+        [
+          '---',
+          'term: B',
+          'project-docs-ancestors:',
+          '  - domain-terms:a@A3F9C2E1B004',
+          '---',
+          'B body',
+        ].join('\n'),
+      );
+
+      await generator(host);
+
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(l.integrity.unparseableRefs).toEqual([
+        {
+          ref: 'domain-terms:a@A3F9C2E1B004',
+          foundIn: 'project-docs/domain-terms/b.md',
+        },
+      ]);
+      // The target still reads as unreferenced — an unparseable token can't be
+      // indexed as pointing anywhere, and that's the designed trade: record the
+      // bad token loudly rather than suppress the secondary report. What
+      // changed is that it's now recorded at all, and fails --strict, so the
+      // unreferenced entry has a stated cause instead of being a dead end.
+      expect(l.status.unreferenced).toContain('domain-terms:a');
+    });
+
+    it('fails --strict on a malformed digest', async () => {
+      host.write(
+        'project-docs/domain-terms/a.md',
+        ['---', 'term: A', '---', 'A body'].join('\n'),
+      );
+      host.write(
+        'project-docs/domain-terms/b.md',
+        [
+          '---',
+          'term: B',
+          'project-docs-ancestors:',
+          '  - domain-terms:a@NOTHEX',
+          '---',
+          'B body',
+        ].join('\n'),
+      );
+
+      await expect(generator(host, { strict: true })).rejects.toThrow(
+        /unparseable project-docs reference/,
+      );
+    });
+
+    // The YAML parse error went to stdout, so --json emitted two lines and the
+    // stream stopped being parseable in exactly the case a machine consumer
+    // wants it: when integrity.yamlErrors is non-empty.
+    it('keeps stdout parseable under --json when frontmatter will not parse', async () => {
+      host.write(
+        'project-docs/domain-terms/broken.md',
+        ['---', 'term: [unclosed', '---', 'body'].join('\n'),
+      );
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      await generator(host, { json: true });
+
+      const printed = logSpy.mock.calls.map((c) => c[0]);
+      expect(printed).toHaveLength(1);
+      expect(JSON.parse(printed[0]).integrity.yamlErrors).toHaveLength(1);
+      expect(warnSpy.mock.calls.flat().join('\n')).toContain(
+        'YAML parse error',
+      );
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    // resolves entries were collected verbatim, so a pinned resolution never
+    // matched its registry key and the question silently reverted to open —
+    // which the delivery loop treats as a top-priority resolution signal.
+    it('counts a pinned resolves entry as resolving its target', async () => {
+      host.write(
+        'project-docs/artifact-schema.json',
+        JSON.stringify({
+          'open-questions': {
+            expectedAncestorTypes: [],
+            tracksResolution: true,
+          },
+          'domain-terms': { expectedAncestorTypes: [] },
+        }),
+      );
+      host.write(
+        'project-docs/open-questions/q.md',
+        ['---', 'title: Q', '---', 'Q body'].join('\n'),
+      );
+      host.write(
+        'project-docs/domain-terms/answer.md',
+        [
+          '---',
+          'term: Answer',
+          'project-docs-ancestors:',
+          '  - open-questions:q',
+          'resolves:',
+          '  - open-questions:q@aaaaaaaaaaaa',
+          '---',
+          'Answer body',
+        ].join('\n'),
+      );
+
+      await generator(host);
+
+      const l = JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8'));
+      expect(l.status.resolution.resolved).toContain('open-questions:q');
+      expect(l.status.resolution.open).not.toContain('open-questions:q');
+    });
+  });
 });

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.spec.ts
@@ -524,7 +524,9 @@ describe('nx-agent project-docs-lineage generator', () => {
       expect(lineage.integrity.schemaErrors).toEqual([
         {
           type: 'domain-terms',
-          expectedAncestorType: 'bounded-context',
+          property: 'expectedAncestorTypes',
+          value: 'bounded-context',
+          problem: 'misspelled',
           didYouMean: 'bounded-contexts',
         },
       ]);
@@ -592,8 +594,126 @@ describe('nx-agent project-docs-lineage generator', () => {
       );
 
       await expect(generator(host, { strict: true })).rejects.toThrow(
-        /misspelled expectedAncestorTypes/,
+        /unsatisfiable entry/,
       );
+    });
+    describe('digestFields', () => {
+      function writeWithDigestFields(host: Tree, digestFields: string[]) {
+        host.write(
+          'project-docs/requirements/r.md',
+          [
+            '---',
+            'title: R',
+            'id: req-001',
+            'rules:',
+            '  - rule: a',
+            '---',
+            '',
+            'Rationale.',
+          ].join('\n'),
+        );
+        host.write(
+          'project-docs/artifact-schema.json',
+          JSON.stringify({
+            requirements: { expectedAncestorTypes: [], digestFields },
+          }),
+        );
+      }
+
+      it('flags a structural field, which is excluded from metadata and so does nothing', async () => {
+        writeWithDigestFields(host, ['project-docs-ancestors']);
+
+        await generator(host);
+
+        expect(
+          JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).integrity
+            .schemaErrors,
+        ).toEqual([
+          {
+            type: 'requirements',
+            property: 'digestFields',
+            value: 'project-docs-ancestors',
+            problem: 'structural-field',
+          },
+        ]);
+      });
+
+      it('flags a singular field against the fields those artifacts carry', async () => {
+        writeWithDigestFields(host, ['rule']);
+
+        await generator(host);
+
+        expect(
+          JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).integrity
+            .schemaErrors,
+        ).toEqual([
+          {
+            type: 'requirements',
+            property: 'digestFields',
+            value: 'rule',
+            problem: 'misspelled',
+            didYouMean: 'rules',
+          },
+        ]);
+      });
+
+      it('flags a case mismatch', async () => {
+        writeWithDigestFields(host, ['Rules']);
+
+        await generator(host);
+
+        expect(
+          JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).integrity
+            .schemaErrors[0],
+        ).toMatchObject({ value: 'Rules', didYouMean: 'rules' });
+      });
+
+      // The same limit the type check has, stated so it isn't mistaken for a
+      // bug: only pluralization and case are decidable. A substitution typo is
+      // indistinguishable from a field that will exist later, so it stays
+      // silent rather than failing --strict on a legitimate declaration.
+      it('does not flag a substitution typo', async () => {
+        writeWithDigestFields(host, ['rulez']);
+
+        await generator(host);
+
+        expect(
+          JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).integrity
+            .schemaErrors,
+        ).toEqual([]);
+      });
+
+      it('accepts a field those artifacts actually carry', async () => {
+        writeWithDigestFields(host, ['rules']);
+
+        await generator(host);
+
+        expect(
+          JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).integrity
+            .schemaErrors,
+        ).toEqual([]);
+      });
+
+      // Same discipline as the type check: a field nothing carries yet is
+      // indistinguishable from one that will, so it must not fail --strict.
+      it('stays silent on a field that is not a near-miss of an observed one', async () => {
+        writeWithDigestFields(host, ['acceptance-criteria']);
+
+        await generator(host);
+
+        expect(
+          JSON.parse(host.read('.nx-agent/lineage.json', 'utf-8')).integrity
+            .schemaErrors,
+        ).toEqual([]);
+      });
+
+      it('fails --strict on a structural field', async () => {
+        writeWithDigestFields(host, ['resolves']);
+
+        await expect(generator(host, { strict: true })).rejects.toThrow(
+          /unsatisfiable entry/,
+        );
+      });
     });
   });
 

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -69,7 +69,7 @@ export default async function (host: Tree, options: Schema = {}) {
       yamlErrors: integrity.yamlErrors,
       cycles: integrity.cycles,
       schemaErrors: integrity.schemaErrors,
-      orphans: status.orphans,
+      orphans: status.unreferenced,
       unscoped: status.unscoped,
       resolutionStatus: status.resolution,
     },
@@ -79,9 +79,9 @@ export default async function (host: Tree, options: Schema = {}) {
   // of the document. Nx prints its own "NX Generating ..." banner to stdout too;
   // pair --json with --quiet to suppress it and get a parseable stream.
   if (!options.json) {
-    for (const orphan of status.orphans) {
+    for (const key of status.unreferenced) {
       // eslint-disable-next-line no-console
-      console.log(`[nx-agent] orphan (nothing derives from it yet): ${orphan}`);
+      console.log(`[nx-agent] unreferenced (nothing derives from it yet): ${key}`);
     }
     for (const unscoped of status.unscoped) {
       // eslint-disable-next-line no-console

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -25,6 +25,9 @@ const INTEGRITY_FAILURES: Record<keyof Integrity, (count: number) => string> = {
   brokenRefs: (n) => `${n} broken project-docs-ancestors reference(s)`,
   unparseableRefs: (n) => `${n} unparseable project-docs reference(s)`,
   yamlErrors: (n) => `${n} YAML parse error(s) in project-docs frontmatter`,
+  cycles: (n) => `${n} project-docs-ancestors reference cycle(s)`,
+  schemaErrors: (n) =>
+    `${n} misspelled expectedAncestorTypes entry/entries in artifact-schema.json`,
 };
 
 export default async function (host: Tree, options: Schema = {}) {
@@ -64,6 +67,8 @@ export default async function (host: Tree, options: Schema = {}) {
       brokenRefs: integrity.brokenRefs,
       unparseableRefs: integrity.unparseableRefs,
       yamlErrors: integrity.yamlErrors,
+      cycles: integrity.cycles,
+      schemaErrors: integrity.schemaErrors,
       orphans: status.orphans,
       unscoped: status.unscoped,
       resolutionStatus: status.resolution,
@@ -88,6 +93,26 @@ export default async function (host: Tree, options: Schema = {}) {
       // eslint-disable-next-line no-console
       console.log(
         `[nx-agent] broken reference "${broken.ref}" in ${broken.referencedFrom}`,
+      );
+    }
+    for (const schemaError of integrity.schemaErrors) {
+      // Names the schema key as well as the value: the value alone doesn't say
+      // which entry to go fix, and one bad value affects every artifact of its
+      // type at once.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[nx-agent] artifact-schema.json: "${schemaError.type}" expects ancestor type ` +
+          `"${schemaError.expectedAncestorType}" — did you mean "${schemaError.didYouMean}"? ` +
+          `Nothing can satisfy it as written, so every ${schemaError.type} artifact would ` +
+          `report unscoped.`,
+      );
+    }
+    for (const cycle of integrity.cycles) {
+      // Closed back to the first node when printing, so the loop reads as one
+      // — the stored form leaves that implicit.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[nx-agent] reference cycle: ${[...cycle, cycle[0]].join(' -> ')}`,
       );
     }
     for (const unparseable of integrity.unparseableRefs) {

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -4,7 +4,8 @@ import { ensureGitignoreEntries } from '../../utils/gitignore';
 import {
   buildIndex,
   buildRegistry,
-  computeViolations,
+  computeFindings,
+  Integrity,
   UnparseableRef,
   YamlError,
 } from '../../utils/project-docs-refs';
@@ -20,6 +21,12 @@ const LINEAGE_PATH = '.nx-agent/lineage.json';
 // write-if-missing, so a workspace keeps its copy and no re-run can repair it.
 const LINEAGE_SCHEMA_VERSION = 1;
 
+const INTEGRITY_FAILURES: Record<keyof Integrity, (count: number) => string> = {
+  brokenRefs: (n) => `${n} broken project-docs-ancestors reference(s)`,
+  unparseableRefs: (n) => `${n} unparseable project-docs reference(s)`,
+  yamlErrors: (n) => `${n} YAML parse error(s) in project-docs frontmatter`,
+};
+
 export default async function (host: Tree, options: Schema = {}) {
   // 100% mechanically derived from other files — committing it would create
   // a second, driftable source of truth the moment anyone adds a reference
@@ -32,7 +39,7 @@ export default async function (host: Tree, options: Schema = {}) {
   const registry = buildRegistry(host, yamlErrors, unparseableRefs);
   const index = buildIndex(host, registry, unparseableRefs);
   const artifactSchema = readArtifactSchema(host);
-  const violations = computeViolations(
+  const { integrity, status } = computeFindings(
     registry,
     index,
     artifactSchema,
@@ -44,41 +51,57 @@ export default async function (host: Tree, options: Schema = {}) {
     schemaVersion: LINEAGE_SCHEMA_VERSION,
     registry: Object.fromEntries(registry),
     index: Object.fromEntries(index),
-    violations,
+    integrity,
+    status,
+    // DEPRECATED, removed at schemaVersion 2. Kept because agent-delivery's
+    // scripts and skills are generated write-if-missing: an existing workspace
+    // keeps the copy that reads these paths, and no generator re-run can
+    // repair it — only a migration, which isn't worth ~1000 lines of verbatim
+    // fixtures for a field rename while the old paths can simply keep working.
+    // Assembled from the very same arrays as integrity/status above, so the
+    // two views cannot drift apart.
+    violations: {
+      brokenRefs: integrity.brokenRefs,
+      unparseableRefs: integrity.unparseableRefs,
+      yamlErrors: integrity.yamlErrors,
+      orphans: status.orphans,
+      unscoped: status.unscoped,
+      resolutionStatus: status.resolution,
+    },
   };
 
   // --json is a machine surface, so the human lines would be noise in the middle
   // of the document. Nx prints its own "NX Generating ..." banner to stdout too;
   // pair --json with --quiet to suppress it and get a parseable stream.
   if (!options.json) {
-    for (const orphan of violations.orphans) {
+    for (const orphan of status.orphans) {
       // eslint-disable-next-line no-console
       console.log(`[nx-agent] orphan (nothing derives from it yet): ${orphan}`);
     }
-    for (const unscoped of violations.unscoped) {
+    for (const unscoped of status.unscoped) {
       // eslint-disable-next-line no-console
       console.log(
         `[nx-agent] unscoped (missing an expected ancestor type): ${unscoped}`,
       );
     }
-    for (const broken of violations.brokenRefs) {
+    for (const broken of integrity.brokenRefs) {
       // eslint-disable-next-line no-console
       console.log(
         `[nx-agent] broken reference "${broken.ref}" in ${broken.referencedFrom}`,
       );
     }
-    for (const unparseable of violations.unparseableRefs) {
+    for (const unparseable of integrity.unparseableRefs) {
       // eslint-disable-next-line no-console
       console.log(
         `[nx-agent] unparseable reference "${unparseable.ref}" in ${unparseable.foundIn} — ` +
           `an id may contain only letters, digits, hyphens, and underscores`,
       );
     }
-    for (const open of violations.resolutionStatus.open) {
+    for (const open of status.resolution.open) {
       // eslint-disable-next-line no-console
       console.log(`[nx-agent] open (unresolved): ${open}`);
     }
-    for (const resolved of violations.resolutionStatus.resolved) {
+    for (const resolved of status.resolution.resolved) {
       // eslint-disable-next-line no-console
       console.log(`[nx-agent] resolved: ${resolved}`);
     }
@@ -108,22 +131,15 @@ export default async function (host: Tree, options: Schema = {}) {
   // gitignored, so locally the previous run's file survives the rollback and
   // the next reader silently consumes a stale graph. Neither is a graph that
   // can't be trusted — it's a complete graph with a known, enumerated gap.
-  const failures: string[] = [];
-  if (violations.brokenRefs.length > 0) {
-    failures.push(
-      `${violations.brokenRefs.length} broken project-docs-ancestors reference(s)`,
+  // Keyed on `keyof Integrity`, so a category added to that interface won't
+  // compile until it also has a --strict message here. That's the invariant
+  // worth enforcing rather than restating in prose: everything in `integrity`
+  // fails --strict, and nothing in `status` does.
+  const failures = (Object.keys(INTEGRITY_FAILURES) as (keyof Integrity)[])
+    .filter((category) => integrity[category].length > 0)
+    .map((category) =>
+      INTEGRITY_FAILURES[category](integrity[category].length),
     );
-  }
-  if (violations.unparseableRefs.length > 0) {
-    failures.push(
-      `${violations.unparseableRefs.length} unparseable project-docs reference(s)`,
-    );
-  }
-  if (violations.yamlErrors.length > 0) {
-    failures.push(
-      `${violations.yamlErrors.length} YAML parse error(s) in project-docs frontmatter`,
-    );
-  }
   if (failures.length === 0) {
     return;
   }

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -12,6 +12,14 @@ import { Schema } from './schema';
 
 const LINEAGE_PATH = '.nx-agent/lineage.json';
 
+// Bump when a declared field changes shape or leaves; additive fields don't need
+// it. The README's "Consumed shape" table is the declaration this number
+// versions — a consumer that pins a version and reads an unexpected one fails
+// loudly instead of silently misreading a renamed field, which is the failure
+// mode that matters here: agent-delivery's scripts and skills are generated
+// write-if-missing, so a workspace keeps its copy and no re-run can repair it.
+const LINEAGE_SCHEMA_VERSION = 1;
+
 export default async function (host: Tree, options: Schema = {}) {
   // 100% mechanically derived from other files — committing it would create
   // a second, driftable source of truth the moment anyone adds a reference
@@ -19,8 +27,8 @@ export default async function (host: Tree, options: Schema = {}) {
   // references were chosen over a forward-ownership model to avoid.
   ensureGitignoreEntries(host, ['.nx-agent/']);
 
-  const yamlErrors: YamlError[] = []
-  const unparseableRefs: UnparseableRef[] = []
+  const yamlErrors: YamlError[] = [];
+  const unparseableRefs: UnparseableRef[] = [];
   const registry = buildRegistry(host, yamlErrors, unparseableRefs);
   const index = buildIndex(host, registry, unparseableRefs);
   const artifactSchema = readArtifactSchema(host);
@@ -32,50 +40,61 @@ export default async function (host: Tree, options: Schema = {}) {
     unparseableRefs,
   );
 
-  for (const orphan of violations.orphans) {
-    // eslint-disable-next-line no-console
-    console.log(`[nx-agent] orphan (nothing derives from it yet): ${orphan}`);
-  }
-  for (const unscoped of violations.unscoped) {
-    // eslint-disable-next-line no-console
-    console.log(
-      `[nx-agent] unscoped (missing an expected ancestor type): ${unscoped}`,
-    );
-  }
-  for (const broken of violations.brokenRefs) {
-    // eslint-disable-next-line no-console
-    console.log(
-      `[nx-agent] broken reference "${broken.ref}" in ${broken.referencedFrom}`,
-    );
-  }
-  for (const unparseable of violations.unparseableRefs) {
-    // eslint-disable-next-line no-console
-    console.log(
-      `[nx-agent] unparseable reference "${unparseable.ref}" in ${unparseable.foundIn} — ` +
-        `an id may contain only letters, digits, hyphens, and underscores`,
-    );
-  }
-  for (const open of violations.resolutionStatus.open) {
-    // eslint-disable-next-line no-console
-    console.log(`[nx-agent] open (unresolved): ${open}`);
-  }
-  for (const resolved of violations.resolutionStatus.resolved) {
-    // eslint-disable-next-line no-console
-    console.log(`[nx-agent] resolved: ${resolved}`);
+  const payload = {
+    schemaVersion: LINEAGE_SCHEMA_VERSION,
+    registry: Object.fromEntries(registry),
+    index: Object.fromEntries(index),
+    violations,
+  };
+
+  // --json is a machine surface, so the human lines would be noise in the middle
+  // of the document. Nx prints its own "NX Generating ..." banner to stdout too;
+  // pair --json with --quiet to suppress it and get a parseable stream.
+  if (!options.json) {
+    for (const orphan of violations.orphans) {
+      // eslint-disable-next-line no-console
+      console.log(`[nx-agent] orphan (nothing derives from it yet): ${orphan}`);
+    }
+    for (const unscoped of violations.unscoped) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[nx-agent] unscoped (missing an expected ancestor type): ${unscoped}`,
+      );
+    }
+    for (const broken of violations.brokenRefs) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[nx-agent] broken reference "${broken.ref}" in ${broken.referencedFrom}`,
+      );
+    }
+    for (const unparseable of violations.unparseableRefs) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[nx-agent] unparseable reference "${unparseable.ref}" in ${unparseable.foundIn} — ` +
+          `an id may contain only letters, digits, hyphens, and underscores`,
+      );
+    }
+    for (const open of violations.resolutionStatus.open) {
+      // eslint-disable-next-line no-console
+      console.log(`[nx-agent] open (unresolved): ${open}`);
+    }
+    for (const resolved of violations.resolutionStatus.resolved) {
+      // eslint-disable-next-line no-console
+      console.log(`[nx-agent] resolved: ${resolved}`);
+    }
   }
 
-  host.write(
-    LINEAGE_PATH,
-    JSON.stringify(
-      {
-        registry: Object.fromEntries(registry),
-        index: Object.fromEntries(index),
-        violations,
-      },
-      null,
-      2,
-    ),
-  );
+  host.write(LINEAGE_PATH, JSON.stringify(payload, null, 2));
+
+  // Printed from the same object the file is written from, so the stream and the
+  // file can't describe different graphs. Emitted before the --strict throw
+  // below on purpose: stdout isn't subject to Nx's write rollback, so --json
+  // --strict is the one invocation that yields the graph *and* a failing exit
+  // code in a single run.
+  if (options.json) {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(payload));
+  }
 
   // A broken reference and a YAML parse error are both recorded in the output
   // above rather than aborting the write, because the consumer that acts on
@@ -89,39 +108,39 @@ export default async function (host: Tree, options: Schema = {}) {
   // gitignored, so locally the previous run's file survives the rollback and
   // the next reader silently consumes a stale graph. Neither is a graph that
   // can't be trusted — it's a complete graph with a known, enumerated gap.
-  const failures: string[] = []
+  const failures: string[] = [];
   if (violations.brokenRefs.length > 0) {
     failures.push(
       `${violations.brokenRefs.length} broken project-docs-ancestors reference(s)`,
-    )
+    );
   }
   if (violations.unparseableRefs.length > 0) {
     failures.push(
       `${violations.unparseableRefs.length} unparseable project-docs reference(s)`,
-    )
+    );
   }
   if (violations.yamlErrors.length > 0) {
     failures.push(
       `${violations.yamlErrors.length} YAML parse error(s) in project-docs frontmatter`,
-    )
+    );
   }
   if (failures.length === 0) {
-    return
+    return;
   }
 
-  // --strict is for gate use, where the exit code is the point and the
-  // artifact isn't: Nx's all-or-nothing generator semantics mean a throw
-  // rolls the staged write back, so failing and producing the graph genuinely
-  // can't both happen in one run. Orphans and unscoped artifacts never reach
-  // here either way — an artifact nothing implements yet is a normal,
-  // temporary state, not a mistake.
+  // --strict is for gate use, where the exit code is the point: Nx's
+  // all-or-nothing generator semantics mean a throw rolls the staged write
+  // back, so --strict alone can't both fail and leave a lineage.json behind.
+  // --json escapes that, since stdout is already flushed by here. Orphans and
+  // unscoped artifacts never reach this point either way — an artifact nothing
+  // implements yet is a normal, temporary state, not a mistake.
   if (options.strict) {
-    throw new Error(
-      `[nx-agent] ${failures.join(', ')} found — see above.`,
-    )
+    throw new Error(`[nx-agent] ${failures.join(', ')} found — see above.`);
   }
-  // eslint-disable-next-line no-console
-  console.log(
-    `[nx-agent] wrote ${LINEAGE_PATH} with ${failures.join(', ')} recorded — re-run with --strict to fail on them.`,
-  )
+  if (!options.json) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[nx-agent] wrote ${LINEAGE_PATH} with ${failures.join(', ')} recorded — re-run with --strict to fail on them.`,
+    );
+  }
 }

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -71,6 +71,7 @@ export default async function (host: Tree, options: Schema = {}) {
       schemaErrors: integrity.schemaErrors,
       orphans: status.unreferenced,
       unscoped: status.unscoped,
+      stale: status.stale,
       resolutionStatus: status.resolution,
     },
   };
@@ -81,7 +82,26 @@ export default async function (host: Tree, options: Schema = {}) {
   if (!options.json) {
     for (const key of status.unreferenced) {
       // eslint-disable-next-line no-console
-      console.log(`[nx-agent] unreferenced (nothing derives from it yet): ${key}`);
+      console.log(
+        `[nx-agent] unreferenced (nothing derives from it yet): ${key}`,
+      );
+    }
+    // Grouped by ancestor, not one line per stale edge: editing one widely-cited
+    // artifact is a single act, and a flat list of N entries reads as a mess
+    // someone learns to skip rather than as the one thing that happened.
+    const staleByAncestor = new Map<string, string[]>();
+    for (const entry of status.stale) {
+      staleByAncestor.set(entry.ancestor, [
+        ...(staleByAncestor.get(entry.ancestor) ?? []),
+        entry.artifact,
+      ]);
+    }
+    for (const [ancestor, artifacts] of staleByAncestor) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `[nx-agent] ${ancestor} was revised after ${artifacts.length} artifact(s) ` +
+          `derived from it — review pending: ${artifacts.join(', ')}`,
+      );
     }
     for (const unscoped of status.unscoped) {
       // eslint-disable-next-line no-console

--- a/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/project-docs-lineage.ts
@@ -27,7 +27,7 @@ const INTEGRITY_FAILURES: Record<keyof Integrity, (count: number) => string> = {
   yamlErrors: (n) => `${n} YAML parse error(s) in project-docs frontmatter`,
   cycles: (n) => `${n} project-docs-ancestors reference cycle(s)`,
   schemaErrors: (n) =>
-    `${n} misspelled expectedAncestorTypes entry/entries in artifact-schema.json`,
+    `${n} unsatisfiable entry/entries in artifact-schema.json`,
 };
 
 export default async function (host: Tree, options: Schema = {}) {
@@ -116,16 +116,19 @@ export default async function (host: Tree, options: Schema = {}) {
       );
     }
     for (const schemaError of integrity.schemaErrors) {
-      // Names the schema key as well as the value: the value alone doesn't say
-      // which entry to go fix, and one bad value affects every artifact of its
-      // type at once.
+      // Names the schema key and property as well as the value: the value alone
+      // doesn't say which entry to go fix, and one bad value affects every
+      // artifact of its type at once.
+      const where = `artifact-schema.json: "${schemaError.type}".${schemaError.property}`;
+      const detail =
+        schemaError.problem === 'structural-field'
+          ? `"${schemaError.value}" is a structural field the graph already models as a ` +
+            `relationship, so it is excluded from metadata and this declaration does nothing. ` +
+            `Remove it.`
+          : `"${schemaError.value}" — did you mean "${schemaError.didYouMean}"? Nothing can ` +
+            `satisfy it as written.`;
       // eslint-disable-next-line no-console
-      console.log(
-        `[nx-agent] artifact-schema.json: "${schemaError.type}" expects ancestor type ` +
-          `"${schemaError.expectedAncestorType}" — did you mean "${schemaError.didYouMean}"? ` +
-          `Nothing can satisfy it as written, so every ${schemaError.type} artifact would ` +
-          `report unscoped.`,
-      );
+      console.log(`[nx-agent] ${where}: ${detail}`);
     }
     for (const cycle of integrity.cycles) {
       // Closed back to the first node when printing, so the loop reads as one

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.d.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.d.ts
@@ -1,3 +1,4 @@
 export interface Schema {
   strict?: boolean
+  json?: boolean
 }

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.d.ts
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.d.ts
@@ -1,4 +1,4 @@
 export interface Schema {
-  strict?: boolean
-  json?: boolean
+  strict?: boolean;
+  json?: boolean;
 }

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.json
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.json
@@ -8,7 +8,7 @@
     "strict": {
       "type": "boolean",
       "default": false,
-      "description": "Fail the command on any integrity finding (a broken reference, an unparseable reference, or frontmatter that won't parse) instead of only recording it in the output. Never fails on a status finding (orphans, unscoped, resolution) -- those mean the graph is sound and reporting incomplete work. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json; pair it with --json to get the graph anyway."
+      "description": "Fail the command on any integrity finding (a broken reference, an unparseable reference, or frontmatter that won't parse) instead of only recording it in the output. Never fails on a status finding (unreferenced, unscoped, resolution) -- those mean the graph is sound and reporting incomplete work. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json; pair it with --json to get the graph anyway."
     },
     "json": {
       "type": "boolean",

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.json
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.json
@@ -2,13 +2,18 @@
   "$schema": "http://json-schema.org/schema",
   "id": "NxAgentProjectDocsLineage",
   "title": "Build the project-docs lineage graph",
-  "description": "Scans the workspace for project-docs/ artifacts and project-docs-ancestors references across code and docs, and writes the resulting graph to .nx-agent/lineage.json (gitignored). Broken references and YAML parse errors are recorded in the output rather than aborting the write. Run with --dry-run to check without writing, or --strict to fail the command on a violation.",
+  "description": "Scans the workspace for project-docs/ artifacts and project-docs-ancestors references across code and docs, and writes the resulting graph to .nx-agent/lineage.json (gitignored). Broken references and YAML parse errors are recorded in the output rather than aborting the write. Run with --dry-run to check without writing, --strict to fail the command on a violation, or --json to print the graph to stdout for a machine consumer.",
   "type": "object",
   "properties": {
     "strict": {
       "type": "boolean",
       "default": false,
-      "description": "Fail the command when a reference is broken or frontmatter is unparseable, instead of only recording it in the output. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json — use it as a gate, not to build the graph."
+      "description": "Fail the command when a reference is broken or frontmatter is unparseable, instead of only recording it in the output. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json \u2014 use it as a gate, not to build the graph."
+    },
+    "json": {
+      "type": "boolean",
+      "default": false,
+      "description": "Print the graph to stdout as one JSON document instead of the human-readable summary, for a machine consumer. Pair it with --quiet, or Nx's own \"NX Generating ...\" banner lands on stdout ahead of the document. Same object that's written to the file, and printed before --strict throws, so --json --strict is the one invocation that yields both the graph and a failing exit code in a single run."
     }
   },
   "additionalProperties": false

--- a/packages/nx-agent/src/generators/project-docs-lineage/schema.json
+++ b/packages/nx-agent/src/generators/project-docs-lineage/schema.json
@@ -8,7 +8,7 @@
     "strict": {
       "type": "boolean",
       "default": false,
-      "description": "Fail the command when a reference is broken or frontmatter is unparseable, instead of only recording it in the output. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json \u2014 use it as a gate, not to build the graph."
+      "description": "Fail the command on any integrity finding (a broken reference, an unparseable reference, or frontmatter that won't parse) instead of only recording it in the output. Never fails on a status finding (orphans, unscoped, resolution) -- those mean the graph is sound and reporting incomplete work. Nx rolls a generator's staged write back when it throws, so a failing --strict run deliberately produces no lineage.json; pair it with --json to get the graph anyway."
     },
     "json": {
       "type": "boolean",

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.spec.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.spec.ts
@@ -74,8 +74,8 @@ describe('nx-agent project-docs-report generator', () => {
       'project-docs/domain-terms/unused.md',
       ['---', 'term: Unused', '---'].join('\n'),
     );
-    // References both m and still-open, so neither is left as an orphan —
-    // isolates domain-terms:unused as the one deliberate orphan.
+    // References both m and still-open, so neither is left unreferenced —
+    // isolates domain-terms:unused as the one deliberate case.
     host.write(
       'src/feature.ts',
       '// project-docs-ancestors: domain-models:m, open-questions:still-open\nexport {};',
@@ -99,11 +99,11 @@ describe('nx-agent project-docs-report generator', () => {
     expect(html).toContain(
       '<div class="count">1</div><div class="label">Open</div>',
     );
-    // domain-terms:unused is the only real orphan — iteration-retrospectives:
+    // domain-terms:unused is the only genuinely unreferenced one — iteration-retrospectives:
     // closed-out has zero descendants too, but is terminal, so it must not
     // inflate this count.
     expect(html).toContain(
-      '<div class="count">1</div><div class="label">Orphaned</div>',
+      '<div class="count">1</div><div class="label">Unreferenced</div>',
     );
     expect(html).toContain(
       '<div class="count">1</div><div class="label">Broken references</div>',
@@ -125,7 +125,7 @@ describe('nx-agent project-docs-report generator', () => {
     expect(html).toContain('mermaid.initialize');
 
     // a terminal artifact (zero descendants by design) gets its own distinct
-    // graph style and table badge, rather than looking like a plain orphan
+    // graph style and table badge, rather than looking like plainly unreferenced
     expect(html).toContain(
       '✓ iteration-retrospectives:closed-out&quot;]:::terminal',
     );
@@ -236,16 +236,16 @@ describe('nx-agent project-docs-report generator', () => {
       expect(html).not.toContain('shipping/domain-terms:shipment');
     });
 
-    it('does not misclassify a cross-project reference as an orphan', async () => {
+    it('does not misclassify a cross-project reference as unreferenced', async () => {
       await generator(host, { project: 'billing', noSynthesis: true });
       const html = host.read('apps/billing/project-docs/report.html', 'utf-8');
 
       // billing/bounded-contexts:invoicing IS referenced — from shipping,
       // outside the billing scope — so a report that (incorrectly) built
       // its violations only from billing's own files would flag it as an
-      // orphan. Computing violations workspace-wide first prevents that.
+      // unreferenced. Computing findings workspace-wide first prevents that.
       expect(html).toContain(
-        '<div class="count">0</div><div class="label">Orphaned</div>',
+        '<div class="count">0</div><div class="label">Unreferenced</div>',
       );
     });
   });

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
@@ -815,7 +815,7 @@ function buildHomePanel(params: {
   const legendHtml = `<div class="legend">
 <span><span class="legend-swatch" style="background:${TOKENS.success.bg};border:1px solid ${TOKENS.success.border}"></span>Resolved</span>
 <span><span class="legend-swatch" style="background:${TOKENS.important.bg};border:1px solid ${TOKENS.important.border}"></span>Open</span>
-<span><span class="legend-swatch" style="background:${TOKENS.interactive.bg};border:1px solid ${TOKENS.interactive.border}"></span>Orphaned</span>
+<span><span class="legend-swatch" style="background:${TOKENS.interactive.bg};border:1px solid ${TOKENS.interactive.border}"></span>Unreferenced</span>
 <span><span class="legend-swatch" style="background:${TOKENS.background};border:1px solid ${TOKENS.textMuted}"></span>Closed out (terminal)</span>
 <span><span class="legend-swatch" style="background:${TOKENS.backgroundSubtle};border:1px dashed ${TOKENS.textMuted}"></span>Context (out of scope)</span>
 </div>`;

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
@@ -260,7 +260,7 @@ function buildStyles(): string {
     }
     .badge-resolved { background: ${TOKENS.success.bg}; border: 1px solid ${TOKENS.success.border}; color: ${TOKENS.success.text}; }
     .badge-open { background: ${TOKENS.important.bg}; border: 1px solid ${TOKENS.important.border}; color: ${TOKENS.important.text}; }
-    .badge-orphan { background: ${TOKENS.interactive.bg}; border: 1px solid ${TOKENS.interactive.border}; color: ${TOKENS.interactive.text}; }
+    .badge-unreferenced { background: ${TOKENS.interactive.bg}; border: 1px solid ${TOKENS.interactive.border}; color: ${TOKENS.interactive.text}; }
     .badge-terminal { background: ${TOKENS.background}; border: 1px solid ${TOKENS.textMuted}; color: ${TOKENS.textMuted}; }
     .legend { display: flex; gap: 1.25rem; flex-wrap: wrap; font-size: 0.875rem; color: ${TOKENS.textMuted}; margin-top: 0.75rem; }
     .legend-swatch { display: inline-block; width: 0.75rem; height: 0.75rem; border-radius: 3px; margin-right: 0.375rem; vertical-align: middle; }
@@ -389,7 +389,7 @@ function buildMermaidFlowchart(
   inScopeSet: Set<string>,
   resolvedKeys: Set<string>,
   openKeys: Set<string>,
-  orphanKeys: Set<string>,
+  unreferencedKeys: Set<string>,
   artifactSchema: ArtifactSchema,
 ): string {
   const nodeIds = new Map<string, string>();
@@ -399,7 +399,7 @@ function buildMermaidFlowchart(
     'flowchart TD',
     `classDef resolved fill:${TOKENS.success.bg},stroke:${TOKENS.success.border},color:${TOKENS.success.text}`,
     `classDef open fill:${TOKENS.important.bg},stroke:${TOKENS.important.border},color:${TOKENS.important.text}`,
-    `classDef orphan fill:${TOKENS.interactive.bg},stroke:${TOKENS.interactive.border},color:${TOKENS.interactive.text}`,
+    `classDef unreferenced fill:${TOKENS.interactive.bg},stroke:${TOKENS.interactive.border},color:${TOKENS.interactive.text}`,
     `classDef terminal fill:${TOKENS.background},stroke:${TOKENS.textMuted},color:${TOKENS.textMuted}`,
     `classDef context fill:${TOKENS.backgroundSubtle},stroke:${TOKENS.textMuted},color:${TOKENS.textMuted},stroke-dasharray: 4 4`,
   ];
@@ -414,8 +414,8 @@ function buildMermaidFlowchart(
         ? 'resolved'
         : openKeys.has(key)
           ? 'open'
-          : orphanKeys.has(key)
-            ? 'orphan'
+          : unreferencedKeys.has(key)
+            ? 'unreferenced'
             : isTerminal
               ? 'terminal'
               : '';
@@ -471,7 +471,7 @@ const MAX_SYNTHESIS_BODIES = 30;
 
 // The counts alone tell an LLM (or a reader) what happened, not why it
 // matters — including the free-text bodies of exactly the artifacts worth a
-// second look (open, unresolved; orphaned, nothing built on them yet) gives
+// second look (open, unresolved; unreferenced, nothing built on them yet) gives
 // the synthesis something to actually narrate. Bounded to a fixed cap so an
 // unusually large workspace never turns this into an unbounded prompt.
 function buildSynthesisPrompt(
@@ -479,9 +479,9 @@ function buildSynthesisPrompt(
   counts: StatusCounts,
   registry: Registry,
   openKeys: string[],
-  orphanKeys: string[],
+  unreferencedKeys: string[],
 ): string {
-  const bodies = [...new Set([...openKeys, ...orphanKeys])]
+  const bodies = [...new Set([...openKeys, ...unreferencedKeys])]
     .slice(0, MAX_SYNTHESIS_BODIES)
     .map((key) => {
       const entry = registry.get(key);
@@ -504,8 +504,8 @@ function buildSynthesisPrompt(
     `Status counts: ${JSON.stringify(counts)}`,
     '',
     bodies
-      ? `Open/orphaned artifact bodies:\n\n${bodies}`
-      : 'No open or orphaned artifacts.',
+      ? `Open/unreferenced artifact bodies:\n\n${bodies}`
+      : 'No open or unreferenced artifacts.',
   ].join('\n');
 }
 
@@ -521,7 +521,7 @@ function buildSummaryCards(counts: StatusCounts): string {
     ${typeCards}
     <div class="card"><div class="count">${counts.resolved}</div><div class="label">Resolved</div></div>
     <div class="card"><div class="count">${counts.open}</div><div class="label">Open</div></div>
-    <div class="card"><div class="count">${counts.orphans}</div><div class="label">Orphaned</div></div>
+    <div class="card"><div class="count">${counts.unreferenced}</div><div class="label">Unreferenced</div></div>
     <div class="card"><div class="count">${counts.brokenRefs}</div><div class="label">Broken references</div></div>
   </div>`;
 }
@@ -530,7 +530,7 @@ function statusBadge(
   key: string,
   resolvedSet: Set<string>,
   openSet: Set<string>,
-  orphanSet: Set<string>,
+  unreferencedSet: Set<string>,
   artifactSchema: ArtifactSchema,
 ): string {
   if (resolvedSet.has(key)) {
@@ -539,8 +539,8 @@ function statusBadge(
   if (openSet.has(key)) {
     return '<span class="badge badge-open">Open</span>';
   }
-  if (orphanSet.has(key)) {
-    return '<span class="badge badge-orphan">Orphan</span>';
+  if (unreferencedSet.has(key)) {
+    return '<span class="badge badge-unreferenced">Unreferenced</span>';
   }
   if (isTerminalKey(key, artifactSchema)) {
     return '<span class="badge badge-terminal">Closed out</span>';
@@ -558,7 +558,7 @@ function buildArtifactList(
   registry: Registry,
   resolvedSet: Set<string>,
   openSet: Set<string>,
-  orphanSet: Set<string>,
+  unreferencedSet: Set<string>,
   artifactSchema: ArtifactSchema,
 ): string {
   const byType = new Map<string, string[]>();
@@ -594,7 +594,7 @@ function buildArtifactList(
         return `<tr>
         <td><a href="#${toAnchorId(key)}">${escapeHtml(key)}</a></td>
         <td>${escapeHtml(entry?.ancestorRefs.join(', ') ?? '')}</td>
-        <td>${statusBadge(key, resolvedSet, openSet, orphanSet, artifactSchema)}</td>
+        <td>${statusBadge(key, resolvedSet, openSet, unreferencedSet, artifactSchema)}</td>
       </tr>`;
       })
       .join('');
@@ -616,7 +616,7 @@ function buildArtifactList(
         return `<tr>
         <td><a href="#${toAnchorId(key)}">${escapeHtml(key)}</a></td>
         <td>${escapeHtml(entry?.ancestorRefs.join(', ') ?? '')}</td>
-        <td>${statusBadge(key, resolvedSet, openSet, orphanSet, artifactSchema)}</td>
+        <td>${statusBadge(key, resolvedSet, openSet, unreferencedSet, artifactSchema)}</td>
       </tr>`;
       })
       .join('');
@@ -690,7 +690,7 @@ function miniCard(
   childrenMap: Map<string, string[]>,
   resolvedSet: Set<string>,
   openSet: Set<string>,
-  orphanSet: Set<string>,
+  unreferencedSet: Set<string>,
   artifactSchema: ArtifactSchema,
 ): string {
   const parsed = parseAncestorRef(key);
@@ -706,7 +706,7 @@ function miniCard(
     key,
     resolvedSet,
     openSet,
-    orphanSet,
+    unreferencedSet,
     artifactSchema,
   );
   return `<a class="mini-card" href="#${toAnchorId(key)}"><span class="mc-type">${escapeHtml(toDisplayName(type))}</span><span class="mc-name">${escapeHtml(toDisplayName(name))}</span><span class="mc-slug">${escapeHtml(name)}</span><span class="mc-meta">${badge}${childCountHtml}</span></a>`;
@@ -719,7 +719,7 @@ function buildHomePanel(params: {
   childrenMap: Map<string, string[]>;
   resolvedSet: Set<string>;
   openSet: Set<string>;
-  orphanSet: Set<string>;
+  unreferencedSet: Set<string>;
   artifactSchema: ArtifactSchema;
   synthesis: SynthesisResult;
   synthesisNote: string;
@@ -768,7 +768,7 @@ function buildHomePanel(params: {
             key,
             params.resolvedSet,
             params.openSet,
-            params.orphanSet,
+            params.unreferencedSet,
             params.artifactSchema,
           );
           const children = params.childrenMap.get(key) ?? [];
@@ -800,7 +800,7 @@ function buildHomePanel(params: {
           key,
           params.resolvedSet,
           params.openSet,
-          params.orphanSet,
+          params.unreferencedSet,
           params.artifactSchema,
         );
         return `<a class="root-card" href="#${toAnchorId(key)}"><div class="rc-type">${escapeHtml(toDisplayName(type))}</div><div class="rc-name">${escapeHtml(toDisplayName(name))}</div><div class="rc-slug">${escapeHtml(name)}</div><div class="rc-meta">${badge}</div></a>`;
@@ -864,7 +864,7 @@ function buildArtifactDetails(
   inScopeSet: Set<string>,
   resolvedSet: Set<string>,
   openSet: Set<string>,
-  orphanSet: Set<string>,
+  unreferencedSet: Set<string>,
   artifactSchema: ArtifactSchema,
 ): string {
   return renderedKeys
@@ -909,7 +909,7 @@ function buildArtifactDetails(
         key,
         resolvedSet,
         openSet,
-        orphanSet,
+        unreferencedSet,
         artifactSchema,
       );
 
@@ -963,7 +963,7 @@ function buildArtifactDetails(
               childrenMap,
               resolvedSet,
               openSet,
-              orphanSet,
+              unreferencedSet,
               artifactSchema,
             ),
           )
@@ -982,7 +982,7 @@ function buildArtifactDetails(
               childrenMap,
               resolvedSet,
               openSet,
-              orphanSet,
+              unreferencedSet,
               artifactSchema,
             ),
           )
@@ -1001,7 +1001,7 @@ function buildArtifactDetails(
               childrenMap,
               resolvedSet,
               openSet,
-              orphanSet,
+              unreferencedSet,
               artifactSchema,
             ),
           )
@@ -1101,7 +1101,7 @@ export default async function (host: Tree, options: Schema) {
     options.outputPath ??
     joinPathFragments(targetRoot, 'project-docs', 'report.html');
 
-  // Computed workspace-wide, unconditionally — an artifact's orphan/resolved
+  // Computed workspace-wide, unconditionally — an artifact's unreferenced/resolved
   // status is a workspace-wide fact, and building the index from only one
   // project's files would misclassify anything referenced across a project
   // boundary. --project filters what's rendered below, never what's
@@ -1146,7 +1146,7 @@ export default async function (host: Tree, options: Schema) {
 
   const resolvedKeySet = new Set(status.resolution.resolved);
   const openKeySet = new Set(status.resolution.open);
-  const orphanKeySet = new Set(status.orphans);
+  const unreferencedKeySet = new Set(status.unreferenced);
 
   const byType: Record<string, number> = {};
   for (const key of inScopeKeys) {
@@ -1159,7 +1159,9 @@ export default async function (host: Tree, options: Schema) {
   const inScopeResolved = [...resolvedKeySet].filter((key) =>
     inScopeSet.has(key),
   );
-  const inScopeOrphans = [...orphanKeySet].filter((key) => inScopeSet.has(key));
+  const inScopeUnreferenced = [...unreferencedKeySet].filter((key) =>
+    inScopeSet.has(key),
+  );
   // brokenRefs' own `ref` is by definition NOT a registry key (it's what's
   // missing) — scope by the ref token's own project, not registry
   // membership.
@@ -1174,7 +1176,7 @@ export default async function (host: Tree, options: Schema) {
     byType,
     open: inScopeOpen.length,
     resolved: inScopeResolved.length,
-    orphans: inScopeOrphans.length,
+    unreferenced: inScopeUnreferenced.length,
     brokenRefs: inScopeBrokenRefs.length,
   };
 
@@ -1183,7 +1185,7 @@ export default async function (host: Tree, options: Schema) {
     counts,
     registry,
     inScopeOpen,
-    inScopeOrphans,
+    inScopeUnreferenced,
   );
   const deterministicSummary = buildDeterministicSummary(counts);
   const synthesis = synthesize(
@@ -1203,7 +1205,7 @@ export default async function (host: Tree, options: Schema) {
     inScopeSet,
     resolvedKeySet,
     openKeySet,
-    orphanKeySet,
+    unreferencedKeySet,
     artifactSchema,
   );
 
@@ -1216,7 +1218,7 @@ export default async function (host: Tree, options: Schema) {
     childrenMap,
     resolvedSet: resolvedKeySet,
     openSet: openKeySet,
-    orphanSet: orphanKeySet,
+    unreferencedSet: unreferencedKeySet,
     artifactSchema,
     synthesis,
     synthesisNote,
@@ -1226,7 +1228,7 @@ export default async function (host: Tree, options: Schema) {
       registry,
       resolvedKeySet,
       openKeySet,
-      orphanKeySet,
+      unreferencedKeySet,
       artifactSchema,
     ),
     flowchart,
@@ -1241,7 +1243,7 @@ export default async function (host: Tree, options: Schema) {
     inScopeSet,
     resolvedKeySet,
     openKeySet,
-    orphanKeySet,
+    unreferencedKeySet,
     artifactSchema,
   );
 

--- a/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
+++ b/packages/nx-agent/src/generators/project-docs-report/project-docs-report.ts
@@ -8,10 +8,10 @@ import {
 import { ensureGitignoreEntries } from '../../utils/gitignore';
 import {
   Registry,
-  Violations,
+  Integrity,
   buildIndex,
   buildRegistry,
-  computeViolations,
+  computeFindings,
   parseAncestorRef,
   refKey,
 } from '../../utils/project-docs-refs';
@@ -632,7 +632,7 @@ function buildArtifactList(
   return sections.join('\n');
 }
 
-function buildBrokenRefsSection(brokenRefs: Violations['brokenRefs']): string {
+function buildBrokenRefsSection(brokenRefs: Integrity['brokenRefs']): string {
   if (brokenRefs.length === 0) {
     return '';
   }
@@ -898,7 +898,9 @@ function buildArtifactDetails(
       const content = host.read(entry.path, 'utf-8') ?? '';
       const body = stripFrontmatter(content);
       const fmYaml = extractFrontmatterYaml(content);
-      const bodyHtml = body ? (marked.parse(body, { async: false }) as string) : '';
+      const bodyHtml = body
+        ? (marked.parse(body, { async: false }) as string)
+        : '';
       const fmHtml = fmYaml
         ? `<details class="fm-details"${!body ? ' open' : ''}><summary>Frontmatter</summary><pre class="fm-pre">${escapeHtml(fmYaml)}</pre></details>`
         : '';
@@ -1107,7 +1109,11 @@ export default async function (host: Tree, options: Schema) {
   const registry = buildRegistry(host);
   const index = buildIndex(host, registry);
   const artifactSchema = readArtifactSchema(host);
-  const violations = computeViolations(registry, index, artifactSchema);
+  const { integrity, status } = computeFindings(
+    registry,
+    index,
+    artifactSchema,
+  );
 
   const allKeys = [...registry.keys()];
   const inScopeKeys = options.project
@@ -1138,9 +1144,9 @@ export default async function (host: Tree, options: Schema) {
   }
   const renderedKeys = [...inScopeKeys, ...contextKeys];
 
-  const resolvedKeySet = new Set(violations.resolutionStatus.resolved);
-  const openKeySet = new Set(violations.resolutionStatus.open);
-  const orphanKeySet = new Set(violations.orphans);
+  const resolvedKeySet = new Set(status.resolution.resolved);
+  const openKeySet = new Set(status.resolution.open);
+  const orphanKeySet = new Set(status.orphans);
 
   const byType: Record<string, number> = {};
   for (const key of inScopeKeys) {
@@ -1158,10 +1164,10 @@ export default async function (host: Tree, options: Schema) {
   // missing) — scope by the ref token's own project, not registry
   // membership.
   const inScopeBrokenRefs = options.project
-    ? violations.brokenRefs.filter(
+    ? integrity.brokenRefs.filter(
         (b) => parseAncestorRef(b.ref)?.project === options.project,
       )
-    : violations.brokenRefs;
+    : integrity.brokenRefs;
 
   const counts: StatusCounts = {
     totalArtifacts: inScopeKeys.length,

--- a/packages/nx-agent/src/generators/requirement/README.template.md
+++ b/packages/nx-agent/src/generators/requirement/README.template.md
@@ -28,7 +28,7 @@ here, so the frontmatter shape and sequential ID stay consistent. Each file:
   skill's refinement pass; left empty at intake.
 - `questions` — open questions that don't attach to a specific rule.
 
-The **body** is rationale: *why* this requirement exists, as prose. `rules` is *what* must be true
+The **body** is rationale: _why_ this requirement exists, as prose. `rules` is _what_ must be true
 and how you'd test it; the body is the constraint or obligation behind them, explained where someone
 reading the requirement will see it. The product brief ancestor carries the wider goal — this is the
 part specific to this requirement.

--- a/packages/nx-agent/src/generators/requirement/README.template.md
+++ b/packages/nx-agent/src/generators/requirement/README.template.md
@@ -15,6 +15,10 @@ here, so the frontmatter shape and sequential ID stay consistent. Each file:
     questions: []
     ---
 
+    ## Rationale
+
+    Why this requirement exists — the constraint, obligation, or user need behind it.
+
 - `title` — the short descriptive title, matching the filename slug.
 - `id` — sequential human-facing label (`req-NNN`), auto-assigned at creation time. Not the graph
   key (the file's slug is); used by agents to reference requirements in prose and conversation.
@@ -23,6 +27,16 @@ here, so the frontmatter shape and sequential ID stay consistent. Each file:
 - `rules` — example-mapped rules (Given/When/Then examples per rule). Populated by the Discover
   skill's refinement pass; left empty at intake.
 - `questions` — open questions that don't attach to a specific rule.
+
+The **body** is rationale: *why* this requirement exists, as prose. `rules` is *what* must be true
+and how you'd test it; the body is the constraint or obligation behind them, explained where someone
+reading the requirement will see it. The product brief ancestor carries the wider goal — this is the
+part specific to this requirement.
+
+Requirements are the one artifact type whose meaning lives in frontmatter rather than the body, so
+`project-docs/artifact-schema.json` declares `digestFields: ["rules"]` for them. A change to `rules`
+therefore marks descendants stale (see `project-docs-lineage`'s `status.stale`); editing the
+rationale, fixing a `title`, or answering a `question` does not.
 
 List this folder before creating a new requirement — `id` values are sequential and the next is
 auto-derived from the highest already assigned.

--- a/packages/nx-agent/src/generators/requirement/requirement.spec.ts
+++ b/packages/nx-agent/src/generators/requirement/requirement.spec.ts
@@ -90,9 +90,9 @@ describe('nx-agent requirement generator', () => {
       .read('project-docs/requirements/create-matrix.md')
       .toString();
 
-    await expect(
-      generator(host, { title: 'Create matrix' }),
-    ).rejects.toThrow(/already exists/);
+    await expect(generator(host, { title: 'Create matrix' })).rejects.toThrow(
+      /already exists/,
+    );
 
     expect(
       host.read('project-docs/requirements/create-matrix.md').toString(),
@@ -124,9 +124,7 @@ describe('nx-agent requirement generator', () => {
     await expect(
       generator(host, {
         title: 'Create evaluation matrix',
-        projectDocsAncestors: [
-          'project-docs/product-briefs/does-not-exist.md',
-        ],
+        projectDocsAncestors: ['project-docs/product-briefs/does-not-exist.md'],
       }),
     ).rejects.toThrow(/not found/);
 
@@ -139,9 +137,7 @@ describe('nx-agent requirement generator', () => {
   it('creates the container README on first run', async () => {
     await generator(host, { title: 'Create matrix' });
 
-    const readme = host
-      .read('project-docs/requirements/README.md')
-      .toString();
+    const readme = host.read('project-docs/requirements/README.md').toString();
     expect(readme).toContain('# Requirements');
     expect(readme).toContain('nx g @abgov/nx-agent:requirement');
   });
@@ -221,12 +217,29 @@ describe('nx-agent requirement generator', () => {
     expect(content).toContain(
       'project-docs-ancestors: [open-questions:what-to-call-this]',
     );
-    expect(content).toContain(
-      'resolves: [open-questions:what-to-call-this]',
-    );
+    expect(content).toContain('resolves: [open-questions:what-to-call-this]');
     expect(logSpy).toHaveBeenCalledWith(
       '✓ this requirement resolves open-questions:what-to-call-this',
     );
     logSpy.mockRestore();
+  });
+
+  it('scaffolds a Rationale body, so the why has somewhere to live', async () => {
+    await generator(host, { title: 'Some requirement' });
+
+    const content = host
+      .read('project-docs/requirements/some-requirement.md', 'utf-8')
+      .toString();
+    expect(content).toContain('## Rationale');
+    expect(content).toContain('Why this requirement exists');
+  });
+
+  it('declares rules as the digest field for requirements', async () => {
+    await generator(host, { title: 'Some requirement' });
+
+    const schema = JSON.parse(
+      host.read('project-docs/artifact-schema.json', 'utf-8').toString(),
+    );
+    expect(schema.requirements.digestFields).toEqual(['rules']);
   });
 });

--- a/packages/nx-agent/src/generators/requirement/requirement.ts
+++ b/packages/nx-agent/src/generators/requirement/requirement.ts
@@ -88,7 +88,12 @@ export default async function (host: Tree, options: Schema) {
 
   const readmeContent = readFileSync(README_TEMPLATE_PATH, 'utf-8');
   ensureReadme(host, containerDir, readmeContent);
-  ensureArtifactSchemaEntry(host, 'requirements', ['product-briefs']);
+  // rules is the requirement; the body is rationale prose. So a rules change
+  // is what should mark descendants stale, and a title fix or an answered
+  // question should not.
+  ensureArtifactSchemaEntry(host, 'requirements', ['product-briefs'], {
+    digestFields: ['rules'],
+  });
 
   const content = [
     '---',
@@ -99,6 +104,20 @@ export default async function (host: Tree, options: Schema) {
     'rules: []',
     'questions: []',
     '---',
+    '',
+    // The body is rationale — *why* this requirement exists — deliberately
+    // separate from `rules`, which is *what* must be true and how you'd test
+    // it. Rules stay structured frontmatter because three consumers parse them
+    // (check-example-mapping, task-identification's refinement signal, and the
+    // lineage metadata passthrough), and prose in the body is where the
+    // constraint behind them can be explained at the point someone reads it.
+    // Scaffolded as a prompt rather than left blank so the gap is visible.
+    '## Rationale',
+    '',
+    '<!-- Why this requirement exists: the constraint, obligation, or user need',
+    '     behind it. What breaks, or who is blocked, without it. The product brief',
+    '     this derives from carries the wider goal; this is the part specific to',
+    '     this requirement. Replace this comment. -->',
     '',
   ].join('\n');
   host.write(requirementPath, content);

--- a/packages/nx-agent/src/index.ts
+++ b/packages/nx-agent/src/index.ts
@@ -1,11 +1,13 @@
 // The querying half of the project-docs-ancestors convention — see
 // packages/nx-agent/src/utils/project-docs-refs.ts. This is nx-agent's first
 // public, importable API: everything else in the package is consumed only
-// via `nx g @abgov/nx-agent:x`, but a reference lookup is meant for
-// programmatic callers (an ESLint rule, an agent resolving context for a
-// file it's about to touch) that need a stable contract, not the raw shape
-// of .nx-agent/lineage.json — which stays an internal implementation detail,
-// free to change as long as these signatures don't.
+// via `nx g @abgov/nx-agent:x`, but a reference lookup is meant for JS
+// callers that need a stable contract — an ESLint rule, or a build step
+// resolving context for a file it's about to touch. Not an agent: the
+// generated design/develop/discover skills all tell it to run
+// project-docs-lineage and read the file instead. That file's own consumed
+// shape is declared and versioned in the README (schemaVersion); everything
+// outside that declaration stays free to change, as do these signatures.
 export {
   getAncestors,
   getDescendants,

--- a/packages/nx-agent/src/utils/artifact-schema.spec.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.spec.ts
@@ -73,7 +73,9 @@ describe('ensureArtifactSchemaEntry', () => {
   });
 
   it('records tracksResolution when passed, and omits it when not', () => {
-    ensureArtifactSchemaEntry(host, 'open-questions', [], true);
+    ensureArtifactSchemaEntry(host, 'open-questions', [], {
+      tracksResolution: true,
+    });
     ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
 
     expect(readArtifactSchema(host)).toEqual({
@@ -83,13 +85,9 @@ describe('ensureArtifactSchemaEntry', () => {
   });
 
   it('records terminal when passed, and omits it when not', () => {
-    ensureArtifactSchemaEntry(
-      host,
-      'iteration-retrospectives',
-      [],
-      undefined,
-      true,
-    );
+    ensureArtifactSchemaEntry(host, 'iteration-retrospectives', [], {
+      terminal: true,
+    });
     ensureArtifactSchemaEntry(host, 'domain-terms', ['bounded-contexts']);
 
     expect(readArtifactSchema(host)).toEqual({
@@ -99,7 +97,10 @@ describe('ensureArtifactSchemaEntry', () => {
   });
 
   it('records both tracksResolution and terminal together when both are passed', () => {
-    ensureArtifactSchemaEntry(host, 'blockers', [], true, true);
+    ensureArtifactSchemaEntry(host, 'blockers', [], {
+      tracksResolution: true,
+      terminal: true,
+    });
 
     expect(readArtifactSchema(host)).toEqual({
       blockers: {

--- a/packages/nx-agent/src/utils/artifact-schema.ts
+++ b/packages/nx-agent/src/utils/artifact-schema.ts
@@ -16,6 +16,14 @@ export interface ArtifactTypeSchema {
   expectedAncestorTypes: string[];
   tracksResolution?: boolean;
   terminal?: boolean;
+  // Frontmatter fields that carry this type's *content* rather than bookkeeping,
+  // and so belong in its digest alongside the body. A structural fact about
+  // where a type keeps its meaning, not a policy switch: `requirements` declare
+  // `rules` because their rules ARE the artifact (their body is rationale
+  // prose), while a `title` or an emptied `questions` list is of no interest to
+  // anything downstream. Absent or empty means body-only, which is right for
+  // every type that explains itself in prose.
+  digestFields?: string[];
 }
 
 export type ArtifactSchema = Record<string, ArtifactTypeSchema>;
@@ -34,14 +42,22 @@ export function ensureArtifactSchemaEntry(
   host: Tree,
   type: string,
   expectedAncestorTypes: string[],
-  tracksResolution?: boolean,
-  terminal?: boolean,
+  options: {
+    tracksResolution?: boolean;
+    terminal?: boolean;
+    digestFields?: string[];
+  } = {},
 ): void {
   const schema = readArtifactSchema(host);
   schema[type] = {
     expectedAncestorTypes,
-    ...(tracksResolution ? { tracksResolution } : {}),
-    ...(terminal ? { terminal } : {}),
+    ...(options.tracksResolution
+      ? { tracksResolution: options.tracksResolution }
+      : {}),
+    ...(options.terminal ? { terminal: options.terminal } : {}),
+    ...(options.digestFields?.length
+      ? { digestFields: options.digestFields }
+      : {}),
   };
   writeJson(host, ARTIFACT_SCHEMA_PATH, schema);
 }

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -904,7 +904,7 @@ describe('unparseableRefs', () => {
 
   // The other direction: the offending characters are in the artifact's own
   // filename, so its key can't be parsed back. It stays registered — hiding it
-  // is the failure being fixed — but resolutionStatus silently skipped it, so a
+  // is the failure being fixed — but status.resolution silently skipped it, so a
   // tracked question stopped being reported either open or resolved.
   it('records an artifact whose own path-derived key cannot be parsed, and still registers it', () => {
     host.write(

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -4,7 +4,7 @@ import { addProjectConfiguration, Tree } from '@nx/devkit';
 import {
   buildIndex,
   buildRegistry,
-  computeViolations,
+  computeFindings,
   extractCommentAncestorRefs,
   extractFrontmatterAncestorRefs,
   extractFrontmatterMetadata,
@@ -477,11 +477,11 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     const registry = buildRegistry(host);
     const index = buildIndex(host);
-    const violations = computeViolations(registry, index);
+    const findings = computeFindings(registry, index);
 
     expect(registry.has('domain-terms:collision-report')).toBe(true);
-    expect(violations.brokenRefs).toEqual([]);
-    expect(violations.orphans).toEqual([]);
+    expect(findings.integrity.brokenRefs).toEqual([]);
+    expect(findings.status.orphans).toEqual([]);
   });
 
   it('flags a reference to a nonexistent artifact as broken', () => {
@@ -490,9 +490,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       '// project-docs-ancestors: domain-terms:typo-id\nexport {};',
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+    const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(violations.brokenRefs).toEqual([
+    expect(findings.integrity.brokenRefs).toEqual([
       {
         ref: 'domain-terms:typo-id',
         referencedFrom: 'apps/test/src/routes/collision-reports.ts',
@@ -506,10 +506,10 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: Unused', '---'].join('\n'),
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+    const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(violations.orphans).toEqual(['domain-terms:unused']);
-    expect(violations.brokenRefs).toEqual([]);
+    expect(findings.status.orphans).toEqual(['domain-terms:unused']);
+    expect(findings.integrity.brokenRefs).toEqual([]);
   });
 
   it('does not flag a hand-authored resolution as an orphan, even without duplicating the ref into project-docs-ancestors', () => {
@@ -535,9 +535,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'name: Some requirement', '---'].join('\n'),
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+    const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(violations.orphans).not.toContain('blockers:some-blocker');
+    expect(findings.status.orphans).not.toContain('blockers:some-blocker');
   });
 
   it('excludes a terminal-typed artifact from orphans even with zero descendants', () => {
@@ -546,7 +546,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'project-docs-ancestors: []', '---'].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -557,7 +557,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.orphans).not.toContain('iteration-retrospectives:first');
+    expect(findings.status.orphans).not.toContain('iteration-retrospectives:first');
   });
 
   it('still flags a non-terminal artifact with zero descendants as an orphan, alongside a terminal one with none', () => {
@@ -570,7 +570,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'name: Unpicked up', '---'].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -581,7 +581,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.orphans).toEqual(['domain-models:unpicked-up']);
+    expect(findings.status.orphans).toEqual(['domain-models:unpicked-up']);
   });
 
   it('handles a multi-ref file deriving from more than one artifact', () => {
@@ -598,10 +598,10 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       '// project-docs-ancestors: domain-terms:a, bounded-contexts:b\nexport {};',
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+    const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(violations.brokenRefs).toEqual([]);
-    expect(violations.orphans).toEqual([]);
+    expect(findings.integrity.brokenRefs).toEqual([]);
+    expect(findings.status.orphans).toEqual([]);
   });
 
   it("does not treat a type folder's own README.md as an artifact", () => {
@@ -618,9 +618,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: A', '---'].join('\n'),
     );
 
-    const violations = computeViolations(buildRegistry(host), buildIndex(host));
+    const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(violations.unscoped).toEqual([]);
+    expect(findings.status.unscoped).toEqual([]);
   });
 
   it('flags an artifact missing an expected ancestor type as unscoped', () => {
@@ -629,7 +629,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: A', '---'].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -637,7 +637,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.unscoped).toEqual(['domain-terms:a']);
+    expect(findings.status.unscoped).toEqual(['domain-terms:a']);
   });
 
   it('does not flag an artifact that has one of the expected ancestor types', () => {
@@ -655,7 +655,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -663,7 +663,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.unscoped).toEqual([]);
+    expect(findings.status.unscoped).toEqual([]);
   });
 
   it('does not check a type with no schema entry, or one with an empty expectation', () => {
@@ -676,7 +676,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'name: B', '---'].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -684,7 +684,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.unscoped).toEqual([]);
+    expect(findings.status.unscoped).toEqual([]);
   });
 
   it('flags an artifact with only some of several expected ancestor types (all-of, not any-of)', () => {
@@ -702,7 +702,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -712,7 +712,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.unscoped).toEqual(['domain-models:m']);
+    expect(findings.status.unscoped).toEqual(['domain-models:m']);
   });
 
   it('does not flag an artifact that has all of several expected ancestor types', () => {
@@ -734,7 +734,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -744,7 +744,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.unscoped).toEqual([]);
+    expect(findings.status.unscoped).toEqual([]);
   });
 
   const OPEN_QUESTIONS_SCHEMA = {
@@ -757,13 +757,13 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       OPEN_QUESTIONS_SCHEMA,
     );
 
-    expect(violations.resolutionStatus).toEqual({
+    expect(findings.status.resolution).toEqual({
       open: ['open-questions:q'],
       resolved: [],
     });
@@ -785,13 +785,13 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       OPEN_QUESTIONS_SCHEMA,
     );
 
-    expect(violations.resolutionStatus).toEqual({
+    expect(findings.status.resolution).toEqual({
       open: [],
       resolved: ['open-questions:q'],
     });
@@ -823,7 +823,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -835,8 +835,8 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.resolutionStatus.open).toContain('open-questions:q');
-    expect(violations.resolutionStatus.resolved).not.toContain(
+    expect(findings.status.resolution.open).toContain('open-questions:q');
+    expect(findings.status.resolution.resolved).not.toContain(
       'open-questions:q',
     );
   });
@@ -847,7 +847,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: T', '---'].join('\n'),
     );
 
-    const violations = computeViolations(
+    const findings = computeFindings(
       buildRegistry(host),
       buildIndex(host),
       {
@@ -855,7 +855,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       },
     );
 
-    expect(violations.resolutionStatus).toEqual({ open: [], resolved: [] });
+    expect(findings.status.resolution).toEqual({ open: [], resolved: [] });
   });
 });
 
@@ -938,14 +938,14 @@ describe('unparseableRefs', () => {
 
     const registry = buildRegistry(host, [], unparseableRefs);
     const index = buildIndex(host, registry, unparseableRefs);
-    const violations = computeViolations(registry, index, {}, [], unparseableRefs);
+    const findings = computeFindings(registry, index, {}, [], unparseableRefs);
 
-    expect(violations.unparseableRefs).toEqual([
+    expect(findings.integrity.unparseableRefs).toEqual([
       { ref: 'open-questions:otel-1.23.0', foundIn: 'apps/test/src/telemetry.ts' },
     ]);
     // Not a broken reference — it never parsed, so there was never a key to
     // look up in the registry.
-    expect(violations.brokenRefs).toEqual([]);
+    expect(findings.integrity.brokenRefs).toEqual([]);
   });
 
   // extractCommentAncestorRefs matches the bare token anywhere in a source
@@ -980,10 +980,10 @@ describe('unparseableRefs', () => {
 
     const registry = buildRegistry(host, [], unparseableRefs);
     const index = buildIndex(host, registry, unparseableRefs);
-    const violations = computeViolations(registry, index, {}, [], unparseableRefs);
+    const findings = computeFindings(registry, index, {}, [], unparseableRefs);
 
-    expect(violations.unparseableRefs).toEqual([]);
-    expect(violations.brokenRefs).toEqual([]);
+    expect(findings.integrity.unparseableRefs).toEqual([]);
+    expect(findings.integrity.brokenRefs).toEqual([]);
   });
 });
 

--- a/packages/nx-agent/src/utils/project-docs-refs.spec.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.spec.ts
@@ -138,16 +138,25 @@ describe('extractFrontmatterAncestorRefs', () => {
 
   it('returns an empty array rather than throwing on malformed YAML', () => {
     const content = ['---', 'not: [valid: yaml: at all', '---'].join('\n');
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     expect(extractFrontmatterAncestorRefs(content)).toEqual([]);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[project-docs] YAML parse error'));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[project-docs] YAML parse error'),
+    );
     warn.mockRestore();
   });
 
   it('includes the source path in the YAML parse warning when provided', () => {
     const content = ['---', 'not: [valid: yaml: at all', '---'].join('\n');
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-    extractFrontmatterAncestorRefs(content, 'project-docs/features/my-feature.md');
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    extractFrontmatterAncestorRefs(
+      content,
+      'project-docs/features/my-feature.md',
+    );
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('project-docs/features/my-feature.md'),
     );
@@ -240,15 +249,21 @@ describe('extractFrontmatterMetadata', () => {
 
   it('returns {} and warns when the frontmatter YAML is malformed', () => {
     const content = ['---', 'not: [valid: yaml: at all', '---'].join('\n');
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     expect(extractFrontmatterMetadata(content)).toEqual({});
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[project-docs] YAML parse error'));
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('[project-docs] YAML parse error'),
+    );
     warn.mockRestore();
   });
 
   it('includes the source path in the YAML parse warning when provided', () => {
     const content = ['---', 'not: [valid: yaml: at all', '---'].join('\n');
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     extractFrontmatterMetadata(content, 'project-docs/specs/my-spec.md');
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('project-docs/specs/my-spec.md'),
@@ -359,7 +374,11 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
     const entry = registry.get('requirements:create-matrix');
 
     expect(entry).toBeDefined();
-    expect(entry!.metadata).toEqual({ title: 'Create matrix', id: 'req-001', rules: [] });
+    expect(entry!.metadata).toEqual({
+      title: 'Create matrix',
+      id: 'req-001',
+      rules: [],
+    });
   });
 
   it('registry entry metadata is {} for an artifact with no frontmatter', () => {
@@ -459,7 +478,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
     // The index entry for dm has metadata equal to registry.get('domain-models:dm').metadata.
     const registryMetaForDM = registry.get('domain-models:dm')!.metadata;
     const indexDescendants = index.get('requirements:r') ?? [];
-    const domainModelEntry = indexDescendants.find((e) => e.type === 'domain-models');
+    const domainModelEntry = indexDescendants.find(
+      (e) => e.type === 'domain-models',
+    );
 
     expect(domainModelEntry).toBeDefined();
     expect(domainModelEntry!.metadata).toEqual(registryMetaForDM);
@@ -481,7 +502,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     expect(registry.has('domain-terms:collision-report')).toBe(true);
     expect(findings.integrity.brokenRefs).toEqual([]);
-    expect(findings.status.orphans).toEqual([]);
+    expect(findings.status.unreferenced).toEqual([]);
   });
 
   it('flags a reference to a nonexistent artifact as broken', () => {
@@ -500,7 +521,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
     ]);
   });
 
-  it('flags an artifact nothing references as an orphan, without failing', () => {
+  it('flags an artifact nothing references as unreferenced, without failing', () => {
     host.write(
       'project-docs/domain-terms/unused.md',
       ['---', 'term: Unused', '---'].join('\n'),
@@ -508,11 +529,11 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(findings.status.orphans).toEqual(['domain-terms:unused']);
+    expect(findings.status.unreferenced).toEqual(['domain-terms:unused']);
     expect(findings.integrity.brokenRefs).toEqual([]);
   });
 
-  it('does not flag a hand-authored resolution as an orphan, even without duplicating the ref into project-docs-ancestors', () => {
+  it('does not flag a hand-authored resolution as unreferenced, even without duplicating the ref into project-docs-ancestors', () => {
     // Mirrors the real case that motivated this: a resolution authored by
     // hand (no generator for the referencing type yet) that only sets
     // `resolves`, unlike a generator-authored one which also duplicates the
@@ -537,30 +558,28 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
 
     const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
-    expect(findings.status.orphans).not.toContain('blockers:some-blocker');
+    expect(findings.status.unreferenced).not.toContain('blockers:some-blocker');
   });
 
-  it('excludes a terminal-typed artifact from orphans even with zero descendants', () => {
+  it('excludes a terminal-typed artifact from unreferenced even with zero descendants', () => {
     host.write(
       'project-docs/iteration-retrospectives/first.md',
       ['---', 'project-docs-ancestors: []', '---'].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'iteration-retrospectives': {
-          expectedAncestorTypes: [],
-          terminal: true,
-        },
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'iteration-retrospectives': {
+        expectedAncestorTypes: [],
+        terminal: true,
       },
-    );
+    });
 
-    expect(findings.status.orphans).not.toContain('iteration-retrospectives:first');
+    expect(findings.status.unreferenced).not.toContain(
+      'iteration-retrospectives:first',
+    );
   });
 
-  it('still flags a non-terminal artifact with zero descendants as an orphan, alongside a terminal one with none', () => {
+  it('still flags a non-terminal artifact with zero descendants as unreferenced, alongside a terminal one with none', () => {
     host.write(
       'project-docs/iteration-retrospectives/first.md',
       ['---', 'project-docs-ancestors: []', '---'].join('\n'),
@@ -570,18 +589,14 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'name: Unpicked up', '---'].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'iteration-retrospectives': {
-          expectedAncestorTypes: [],
-          terminal: true,
-        },
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'iteration-retrospectives': {
+        expectedAncestorTypes: [],
+        terminal: true,
       },
-    );
+    });
 
-    expect(findings.status.orphans).toEqual(['domain-models:unpicked-up']);
+    expect(findings.status.unreferenced).toEqual(['domain-models:unpicked-up']);
   });
 
   it('handles a multi-ref file deriving from more than one artifact', () => {
@@ -601,7 +616,7 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
     const findings = computeFindings(buildRegistry(host), buildIndex(host));
 
     expect(findings.integrity.brokenRefs).toEqual([]);
-    expect(findings.status.orphans).toEqual([]);
+    expect(findings.status.unreferenced).toEqual([]);
   });
 
   it("does not treat a type folder's own README.md as an artifact", () => {
@@ -629,13 +644,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: A', '---'].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
-      },
-    );
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
 
     expect(findings.status.unscoped).toEqual(['domain-terms:a']);
   });
@@ -655,13 +666,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
-      },
-    );
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'domain-terms': { expectedAncestorTypes: ['bounded-contexts'] },
+    });
 
     expect(findings.status.unscoped).toEqual([]);
   });
@@ -676,13 +683,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'name: B', '---'].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'bounded-contexts': { expectedAncestorTypes: [] },
-      },
-    );
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'bounded-contexts': { expectedAncestorTypes: [] },
+    });
 
     expect(findings.status.unscoped).toEqual([]);
   });
@@ -702,15 +705,11 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'domain-models': {
-          expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
-        },
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'domain-models': {
+        expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
       },
-    );
+    });
 
     expect(findings.status.unscoped).toEqual(['domain-models:m']);
   });
@@ -734,15 +733,11 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'domain-models': {
-          expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
-        },
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'domain-models': {
+        expectedAncestorTypes: ['bounded-contexts', 'domain-terms'],
       },
-    );
+    });
 
     expect(findings.status.unscoped).toEqual([]);
   });
@@ -823,17 +818,13 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'open-questions': {
-          expectedAncestorTypes: [],
-          tracksResolution: true,
-        },
-        blockers: { expectedAncestorTypes: [], tracksResolution: true },
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'open-questions': {
+        expectedAncestorTypes: [],
+        tracksResolution: true,
       },
-    );
+      blockers: { expectedAncestorTypes: [], tracksResolution: true },
+    });
 
     expect(findings.status.resolution.open).toContain('open-questions:q');
     expect(findings.status.resolution.resolved).not.toContain(
@@ -847,13 +838,9 @@ describe('buildRegistry / buildIndex / computeViolations', () => {
       ['---', 'term: T', '---'].join('\n'),
     );
 
-    const findings = computeFindings(
-      buildRegistry(host),
-      buildIndex(host),
-      {
-        'domain-terms': { expectedAncestorTypes: [] },
-      },
-    );
+    const findings = computeFindings(buildRegistry(host), buildIndex(host), {
+      'domain-terms': { expectedAncestorTypes: [] },
+    });
 
     expect(findings.status.resolution).toEqual({ open: [], resolved: [] });
   });
@@ -870,7 +857,7 @@ describe('unparseableRefs', () => {
 
   // The grammar admits letters, digits, hyphens and underscores. A version
   // number in a title is the ordinary way a period reaches an id, and dropping
-  // the reference silently made the target read as unreferenced — an orphan —
+  // the reference silently made the target read as unreferenced —
   // rather than as something nobody can resolve.
   it('records a reference the grammar cannot read, rather than dropping it', () => {
     host.write(
@@ -886,7 +873,10 @@ describe('unparseableRefs', () => {
     buildIndex(host, registry, unparseableRefs);
 
     expect(unparseableRefs).toEqual([
-      { ref: 'open-questions:otel-1.23.0', foundIn: 'apps/test/src/telemetry.ts' },
+      {
+        ref: 'open-questions:otel-1.23.0',
+        foundIn: 'apps/test/src/telemetry.ts',
+      },
     ]);
   });
 
@@ -905,7 +895,10 @@ describe('unparseableRefs', () => {
     buildIndex(host, registry, unparseableRefs);
 
     expect(unparseableRefs).toEqual([
-      { ref: 'requirements:v1.2-scope', foundIn: 'project-docs/domain-models/m.md' },
+      {
+        ref: 'requirements:v1.2-scope',
+        foundIn: 'project-docs/domain-models/m.md',
+      },
     ]);
   });
 
@@ -913,7 +906,7 @@ describe('unparseableRefs', () => {
   // filename, so its key can't be parsed back. It stays registered — hiding it
   // is the failure being fixed — but resolutionStatus silently skipped it, so a
   // tracked question stopped being reported either open or resolved.
-  it("records an artifact whose own path-derived key cannot be parsed, and still registers it", () => {
+  it('records an artifact whose own path-derived key cannot be parsed, and still registers it', () => {
     host.write(
       'project-docs/open-questions/otel-1.23.0.md',
       ['---', 'project-docs-ancestors: []', 'resolves: []', '---'].join('\n'),
@@ -941,7 +934,10 @@ describe('unparseableRefs', () => {
     const findings = computeFindings(registry, index, {}, [], unparseableRefs);
 
     expect(findings.integrity.unparseableRefs).toEqual([
-      { ref: 'open-questions:otel-1.23.0', foundIn: 'apps/test/src/telemetry.ts' },
+      {
+        ref: 'open-questions:otel-1.23.0',
+        foundIn: 'apps/test/src/telemetry.ts',
+      },
     ]);
     // Not a broken reference — it never parsed, so there was never a key to
     // look up in the registry.
@@ -956,7 +952,7 @@ describe('unparseableRefs', () => {
     host.write(
       'packages/p/src/generators/thing/thing.ts',
       [
-        "const content = [",
+        'const content = [',
         "  `project-docs-ancestors: [${projectDocsAncestors.join(', ')}]`,",
         "].join('\\n');",
       ].join('\n'),

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -123,6 +123,50 @@ export function digestBody(content: string): string {
     .slice(0, 12);
 }
 
+// Recursively key-sorted, so a frontmatter reorder — which YAML tooling and
+// Prettier are both free to do — can't masquerade as a content change. The
+// whole point of a digest is that it moves only when meaning does.
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonical).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map(
+        (k) =>
+          `${JSON.stringify(k)}:${canonical((value as Record<string, unknown>)[k])}`,
+      )
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+// The digest a reference is compared against — the single way to compute one,
+// so a caller can't accidentally derive a different value and manufacture
+// staleness. Body-only unless the type declares digestFields, and when it
+// declares none this returns bodyDigest untouched rather than a hash of it, so
+// adding the feature left every pin already recorded still valid.
+//
+// A declared field that the artifact doesn't have contributes `null` rather
+// than being skipped, so *removing* the field is a change the digest sees.
+export function artifactDigest(
+  entry: Pick<RegistryEntry, 'bodyDigest' | 'metadata'>,
+  digestFields: string[] = [],
+): string {
+  if (digestFields.length === 0) {
+    return entry.bodyDigest;
+  }
+  const selected = [...digestFields]
+    .sort()
+    .map((field) => `${field}=${canonical(entry.metadata[field] ?? null)}`)
+    .join('\n');
+  return createHash('sha256')
+    .update(`${entry.bodyDigest}\n${selected}`)
+    .digest('hex')
+    .slice(0, 12);
+}
+
 // The closed set of frontmatter fields the graph already models as structural
 // relationships — excluded from Artifact Metadata so the metadata map never
 // duplicates what the registry's own ancestorRefs/resolves fields already
@@ -765,15 +809,24 @@ export function computeFindings(
       if (!parsed?.digest) {
         continue;
       }
-      const ancestor = registry.get(refKey(parsed));
-      if (!ancestor || ancestor.bodyDigest === parsed.digest) {
+      const ancestorKey = refKey(parsed);
+      const ancestor = registry.get(ancestorKey);
+      if (!ancestor) {
+        continue;
+      }
+      const ancestorType = parseAncestorRef(ancestorKey)?.type;
+      const currentDigest = artifactDigest(
+        ancestor,
+        ancestorType ? artifactSchema[ancestorType]?.digestFields : undefined,
+      );
+      if (currentDigest === parsed.digest) {
         continue;
       }
       stale.push({
         artifact: key,
-        ancestor: refKey(parsed),
+        ancestor: ancestorKey,
         pinnedDigest: parsed.digest,
-        currentDigest: ancestor.bodyDigest,
+        currentDigest,
       });
     }
   }

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -154,7 +154,7 @@ export function extractFrontmatterField(
 // to write without remembering to duplicate the ref into
 // project-docs-ancestors too — nothing enforces that duplication. Unioning
 // here, in the one function every ancestor-ref reader (the registry, the
-// index buildIndex uses for orphans/brokenRefs, and getAncestors at depth 1)
+// index buildIndex uses for unreferenced/brokenRefs, and getAncestors at depth 1)
 // already shares, makes the invariant true unconditionally instead of only
 // for generator-produced content.
 export function extractFrontmatterAncestorRefs(
@@ -450,7 +450,7 @@ function registerArtifact(
   const key = refKey(ref);
   // An artifact whose own key can't be parsed back is still registered — it
   // exists, and hiding it would be the very failure this records. But every
-  // parse-dependent check below degrades on it: orphans counts it as an orphan
+  // parse-dependent check below degrades on it: it counts as unreferenced
   // regardless, and resolutionStatus skips it entirely, so a tracked artifact
   // silently stops being reported open or resolved. Since 7b777dd the
   // generators reject these at creation time, so this only catches a
@@ -512,7 +512,7 @@ export function buildIndex(
       if (!parsed) {
         // Recorded rather than skipped: a grammar will always meet an id it
         // didn't expect, and dropping it silently turns that into a wrong
-        // report (the target looks unreferenced, so it reads as an orphan)
+        // report (the target looks unreferenced, so it reads as a leaf)
         // instead of a loud one.
         recordUnparseable(unparseableRefs, raw, file);
         continue;
@@ -574,7 +574,13 @@ export interface Integrity {
 // workflow-agnostic is the property that makes it consumable from outside.
 export interface Status {
   resolution: { open: string[]; resolved: string[] };
-  orphans: string[];
+  // Nothing derives from it. Named for the mechanism — the index, which is the
+  // computed "what references this" inverse, has no entry — rather than
+  // "orphan", which inverts the metaphor: references are backward-only, so
+  // this is an artifact with no *descendants*, whereas an orphan conventionally
+  // has no parents. That case is `unscoped`, and only when a type declares an
+  // expectation it fails to meet.
+  unreferenced: string[];
   unscoped: string[];
 }
 
@@ -668,9 +674,9 @@ export function computeFindings(
   // A terminal type (declared, same as expectedAncestorTypes/tracksResolution,
   // by its own generator — no hardcoded type name here either) always has
   // zero descendants by design once it's closed out correctly: that's what
-  // correct looks like, not neglect, so it's excluded from orphans rather
+  // correct looks like, not neglect, so it's excluded from unreferenced rather
   // than reported alongside a domain-model nobody's designed against yet.
-  const orphans = [...registry.keys()].filter((key) => {
+  const unreferenced = [...registry.keys()].filter((key) => {
     if (index.has(key)) {
       return false;
     }
@@ -787,7 +793,7 @@ export function computeFindings(
       cycles: findCycles(registry),
       schemaErrors,
     },
-    status: { resolution, orphans, unscoped },
+    status: { resolution, unreferenced, unscoped },
   };
 }
 

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -1,4 +1,5 @@
 import { Tree, getProjects } from '@nx/devkit';
+import { createHash } from 'node:crypto';
 import * as yaml from 'yaml';
 import { ArtifactSchema } from './artifact-schema';
 
@@ -33,11 +34,21 @@ export interface AncestorRef {
   project?: string;
   type: string;
   id?: string;
+  // The ancestor's body digest at the time this reference was written — a
+  // provenance record, not part of the target's identity, so refKey drops it
+  // exactly as it drops `fragment`. Putting it in the key would mean the key
+  // changed whenever content changed, fragmenting the registry and index on
+  // every edit.
+  digest?: string;
   fragment?: string;
 }
 
+// `@digest` sits between the id and the fragment — version, then location, the
+// way a package spec then anchor reads. Hex-only rather than SLUG_CHARS so it
+// can't be confused with an id, and `@` isn't a SLUG char, so a bare id still
+// terminates cleanly against it.
 const ANCESTOR_REF_TOKEN = new RegExp(
-  `^(?:([^/]+)/)?([${SLUG_CHARS}]+)(?::([${SLUG_CHARS}]+))?(?:#([${SLUG_CHARS}]+))?$`,
+  `^(?:([^/]+)/)?([${SLUG_CHARS}]+)(?::([${SLUG_CHARS}]+))?(?:@([0-9a-f]+))?(?:#([${SLUG_CHARS}]+))?$`,
 );
 
 export function parseAncestorRef(token: string): AncestorRef | null {
@@ -49,14 +60,17 @@ export function parseAncestorRef(token: string): AncestorRef | null {
   if (!match) {
     return null;
   }
-  const [, project, type, id, fragment] = match;
-  return { project, type, id, fragment };
+  const [, project, type, id, digest, fragment] = match;
+  return { project, type, id, digest, fragment };
 }
 
 // The canonical string identity of a reference — everything parseAncestorRef
-// can recover except the fragment, which stays opaque/unparsed by design (a
-// hint for a human reader, not something this resolves) and so isn't part of
-// what makes two references "the same target."
+// can recover except the fragment and the digest. The fragment stays
+// opaque/unparsed by design (a hint for a human reader, not something this
+// resolves); the digest records which version of the target the reference was
+// written against. Neither is part of
+// what makes two references "the same target," and a
+// content-derived key would change on every edit.
 export function refKey(
   ref: Pick<AncestorRef, 'project' | 'type' | 'id'>,
 ): string {
@@ -66,6 +80,48 @@ export function refKey(
 }
 
 const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/;
+
+// Everything after the frontmatter block, or the whole file when there isn't
+// one. Deliberately the *body* only, which is what makes a digest usable at
+// all: recording one edits `project-docs-ancestors`, so a whole-file hash would
+// make re-pinning a content change and cascade staleness through the entire
+// transitive descendancy in waves, each wave's fix triggering the next. A body
+// digest stops at depth 1 — and propagates one more hop exactly when the
+// re-pin came *with* a real revision, which is when descendants should look.
+//
+// Excluding frontmatter wholesale, rather than only the two structural fields,
+// keeps this independent of where a digest is stored and avoids having to
+// canonicalise a parsed YAML object (key order, serialisation) to keep the hash
+// stable. The cost, recorded because it is permanent rather than a wart to fix
+// later: a type that keeps its meaning in frontmatter is not covered at all.
+// `requirements` is that type — its `rules` are the artifact — and they live
+// there deliberately, so a real YAML parser can read them (see
+// check-example-mapping.mjs, which had two regex-parsing bugs before the move).
+export function extractBody(content: string): string {
+  const block = FRONTMATTER_BLOCK.exec(content);
+  const body = block ? content.slice(block[0].length) : content;
+  // Normalised for the three things that vary without meaning: line endings,
+  // the blank line Prettier inserts between the frontmatter delimiter and the
+  // first line of prose, and trailing whitespace. The middle one is not
+  // cosmetic to get right — formatFiles() runs at the end of every generator,
+  // so a digest that counted that blank line would be invalidated by the very
+  // formatting pass that follows writing it. Leading *indentation* on the first
+  // real line is left alone, since that can be a code block.
+  return body
+    .replace(/\r\n/g, '\n')
+    .replace(/^(?:[ \t]*\n)+/, '')
+    .trimEnd();
+}
+
+// Truncated sha256. Not adversarial — a collision costs one missed staleness
+// report, not a security property — so 48 bits is ample margin over the 8 hex
+// characters the original proposal sketched.
+export function digestBody(content: string): string {
+  return createHash('sha256')
+    .update(extractBody(content))
+    .digest('hex')
+    .slice(0, 12);
+}
 
 // The closed set of frontmatter fields the graph already models as structural
 // relationships — excluded from Artifact Metadata so the metadata map never
@@ -268,6 +324,10 @@ export function resolveAncestorsAndResolves(
 
 export interface RegistryEntry {
   path: string;
+  // This artifact's own body digest, so a descendant's recorded pin can be
+  // checked without re-reading any file — buildRegistry already holds the
+  // content.
+  bodyDigest: string;
   ancestorRefs: string[];
   // Refs this artifact explicitly claims to resolve (via --resolves), not
   // just build on — a strict subset of ancestorRefs, since a resolved ref is
@@ -468,12 +528,19 @@ function registerArtifact(
       yamlErrors.push({ path, error });
       // eslint-disable-next-line no-console
       console.log(`[nx-agent] YAML parse error in ${path}: ${error}`);
-      registry.set(key, { path, ancestorRefs: [], resolves: [], metadata: {} });
+      registry.set(key, {
+        path,
+        bodyDigest: digestBody(content),
+        ancestorRefs: [],
+        resolves: [],
+        metadata: {},
+      });
       return;
     }
   }
   registry.set(key, {
     path,
+    bodyDigest: digestBody(content),
     ancestorRefs: extractFrontmatterAncestorRefs(content, path),
     resolves: extractFrontmatterField(content, 'resolves', path),
     metadata: extractFrontmatterMetadata(content, path),
@@ -574,6 +641,17 @@ export interface Integrity {
 // workflow-agnostic is the property that makes it consumable from outside.
 export interface Status {
   resolution: { open: string[]; resolved: string[] };
+  // A reference recording a digest that no longer matches the ancestor's body:
+  // the ancestor was revised after this artifact was written, so downstream
+  // review is pending. Three states, and the silent first one is what makes
+  // adoption survivable — an unpinned reference is never reported, so turning
+  // this on reports nothing until something is deliberately pinned.
+  stale: {
+    artifact: string;
+    ancestor: string;
+    pinnedDigest: string;
+    currentDigest: string;
+  }[];
   // Nothing derives from it. Named for the mechanism — the index, which is the
   // computed "what references this" inverse, has no entry — rather than
   // "orphan", which inverts the metaphor: references are backward-only, so
@@ -676,6 +754,30 @@ export function computeFindings(
   // zero descendants by design once it's closed out correctly: that's what
   // correct looks like, not neglect, so it's excluded from unreferenced rather
   // than reported alongside a domain-model nobody's designed against yet.
+  // Only a recorded digest that *disagrees* is a finding. Absent means unknown
+  // (hand-authored, or predates adoption) and stays silent; a digest recorded
+  // against an ancestor that isn't registered is a broken reference, already
+  // reported as one, so it isn't second-guessed here.
+  const stale: Status['stale'] = [];
+  for (const [key, entry] of registry) {
+    for (const raw of entry.ancestorRefs) {
+      const parsed = parseAncestorRef(raw);
+      if (!parsed?.digest) {
+        continue;
+      }
+      const ancestor = registry.get(refKey(parsed));
+      if (!ancestor || ancestor.bodyDigest === parsed.digest) {
+        continue;
+      }
+      stale.push({
+        artifact: key,
+        ancestor: refKey(parsed),
+        pinnedDigest: parsed.digest,
+        currentDigest: ancestor.bodyDigest,
+      });
+    }
+  }
+
   const unreferenced = [...registry.keys()].filter((key) => {
     if (index.has(key)) {
       return false;
@@ -793,7 +895,7 @@ export function computeFindings(
       cycles: findCycles(registry),
       schemaErrors,
     },
-    status: { resolution, unreferenced, unscoped },
+    status: { resolution, unreferenced, unscoped, stale },
   };
 }
 

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -664,12 +664,18 @@ export interface Integrity {
   // ['a', 'b'] means a derives from b and b derives from a. A single-element
   // cycle is an artifact naming itself.
   cycles: string[][];
-  // An expectedAncestorTypes entry that differs from a real type only by
-  // pluralization or case, so `didYouMean` always names the type it meant.
+  // A declaration in artifact-schema.json that can never do what it says.
+  // `problem` discriminates: 'misspelled' names a value differing from a real
+  // one only by pluralization or case, so `didYouMean` is always present;
+  // 'structural-field' is a digestFields entry naming a field the graph already
+  // models as a relationship, which is excluded from metadata by design and so
+  // would silently contribute nothing.
   schemaErrors: {
     type: string;
-    expectedAncestorType: string;
-    didYouMean: string;
+    property: 'expectedAncestorTypes' | 'digestFields';
+    value: string;
+    problem: 'misspelled' | 'structural-field';
+    didYouMean?: string;
   }[];
 }
 
@@ -876,6 +882,22 @@ export function computeFindings(
     byLooseName.set(loosely(type), type);
   }
 
+  // Which non-structural frontmatter fields artifacts of each type actually
+  // carry, so a digestFields entry can be checked against observed reality
+  // rather than against a list nobody maintains.
+  const fieldsByType = new Map<string, Set<string>>();
+  for (const [key, entry] of registry) {
+    const type = parseAncestorRef(key)?.type;
+    if (!type) {
+      continue;
+    }
+    const seen = fieldsByType.get(type) ?? new Set<string>();
+    for (const field of Object.keys(entry.metadata)) {
+      seen.add(field);
+    }
+    fieldsByType.set(type, seen);
+  }
+
   const schemaErrors: Integrity['schemaErrors'] = [];
   const misspelled = new Set<string>();
   for (const [type, entry] of Object.entries(artifactSchema)) {
@@ -885,8 +907,51 @@ export function computeFindings(
       }
       const didYouMean = byLooseName.get(loosely(expected));
       if (didYouMean) {
-        schemaErrors.push({ type, expectedAncestorType: expected, didYouMean });
+        schemaErrors.push({
+          type,
+          property: 'expectedAncestorTypes',
+          value: expected,
+          problem: 'misspelled',
+          didYouMean,
+        });
         misspelled.add(expected);
+      }
+    }
+
+    // digestFields names frontmatter fields, so the type-name check above
+    // doesn't apply — but the same two things go wrong one property over, and
+    // both are silent: a structural field is excluded from metadata by design,
+    // and a misspelled one contributes null for every artifact, leaving the
+    // digest stable while it quietly stops tracking the field that was meant.
+    const observed = fieldsByType.get(type);
+    const byLooseField = new Map(
+      [...(observed ?? [])].map((field) => [loosely(field), field]),
+    );
+    for (const field of entry.digestFields ?? []) {
+      if (STRUCTURAL_FRONTMATTER_FIELDS.has(field)) {
+        schemaErrors.push({
+          type,
+          property: 'digestFields',
+          value: field,
+          problem: 'structural-field',
+        });
+        continue;
+      }
+      if (observed?.has(field)) {
+        continue;
+      }
+      // Same discipline as the type check: only a near-miss of a field these
+      // artifacts demonstrably carry is decidable. A field nothing has yet is
+      // indistinguishable from one that will exist, so it stays silent.
+      const didYouMean = byLooseField.get(loosely(field));
+      if (didYouMean) {
+        schemaErrors.push({
+          type,
+          property: 'digestFields',
+          value: field,
+          problem: 'misspelled',
+          didYouMean,
+        });
       }
     }
   }

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -348,7 +348,7 @@ export function resolveRefFromPath(host: Tree, rawPath: string): string {
 // traversal sees it regardless of which flag added it — while keeping the
 // resolved refs available separately so the caller can also write the
 // distinct `resolves` frontmatter field project-docs-lineage's
-// resolutionStatus actually reads.
+// status.resolution actually reads.
 export function resolveAncestorsAndResolves(
   host: Tree,
   projectDocsAncestors: string[] | undefined,
@@ -555,7 +555,7 @@ function registerArtifact(
   // An artifact whose own key can't be parsed back is still registered — it
   // exists, and hiding it would be the very failure this records. But every
   // parse-dependent check below degrades on it: it counts as unreferenced
-  // regardless, and resolutionStatus skips it entirely, so a tracked artifact
+  // regardless, and status.resolution skips it entirely, so a tracked artifact
   // silently stops being reported open or resolved. Since 7b777dd the
   // generators reject these at creation time, so this only catches a
   // hand-authored or pre-existing file.

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -4,21 +4,21 @@ import { ArtifactSchema } from './artifact-schema';
 
 // The allowed character set for project-docs slugs — used by both the
 // lineage parser and generator validation so they cannot drift apart.
-export const SLUG_CHARS = 'a-zA-Z0-9_-'
+export const SLUG_CHARS = 'a-zA-Z0-9_-';
 
-const SLUG_INVALID_RE = new RegExp(`[^${SLUG_CHARS}]`, 'g')
+const SLUG_INVALID_RE = new RegExp(`[^${SLUG_CHARS}]`, 'g');
 
 export function validateProjectDocsSlug(
   slug: string,
   originalInput: string,
 ): void {
-  const invalid = slug.match(SLUG_INVALID_RE)
-  if (!invalid) return
-  const chars = [...new Set(invalid)].map((c) => `"${c}"`).join(', ')
+  const invalid = slug.match(SLUG_INVALID_RE);
+  if (!invalid) return;
+  const chars = [...new Set(invalid)].map((c) => `"${c}"`).join(', ');
   throw new Error(
     `[nx-agent] "${originalInput}" produces slug "${slug}" containing invalid character(s): ${chars}. ` +
       `Project-docs slugs must contain only letters, digits, hyphens, and underscores.`,
-  )
+  );
 }
 
 // project-docs-ancestors convention: <type>[:<id>][#fragment], optionally
@@ -38,7 +38,7 @@ export interface AncestorRef {
 
 const ANCESTOR_REF_TOKEN = new RegExp(
   `^(?:([^/]+)/)?([${SLUG_CHARS}]+)(?::([${SLUG_CHARS}]+))?(?:#([${SLUG_CHARS}]+))?$`,
-)
+);
 
 export function parseAncestorRef(token: string): AncestorRef | null {
   const trimmed = token.trim();
@@ -65,7 +65,7 @@ export function refKey(
   return `${prefix}${ref.type}${suffix}`;
 }
 
-const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/
+const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/;
 
 // The closed set of frontmatter fields the graph already models as structural
 // relationships — excluded from Artifact Metadata so the metadata map never
@@ -75,7 +75,7 @@ const FRONTMATTER_BLOCK = /^---\n([\s\S]*?)\n---/
 const STRUCTURAL_FRONTMATTER_FIELDS = new Set([
   'project-docs-ancestors',
   'resolves',
-])
+]);
 
 // Returns all frontmatter fields that are not structural (i.e. not already
 // modelled by the registry's ancestorRefs/resolves). Values are verbatim —
@@ -86,27 +86,27 @@ export function extractFrontmatterMetadata(
   content: string,
   sourcePath?: string,
 ): Record<string, unknown> {
-  const block = FRONTMATTER_BLOCK.exec(content)
-  if (!block) return {}
-  let frontmatter: unknown
+  const block = FRONTMATTER_BLOCK.exec(content);
+  if (!block) return {};
+  let frontmatter: unknown;
   try {
-    frontmatter = yaml.parse(block[1])
+    frontmatter = yaml.parse(block[1]);
   } catch (e) {
     console.warn(
       `[project-docs] YAML parse error${sourcePath ? ` in ${sourcePath}` : ''}: ${e instanceof Error ? e.message : String(e)}`,
-    )
-    return {}
+    );
+    return {};
   }
-  if (!frontmatter || typeof frontmatter !== 'object') return {}
-  const metadata: Record<string, unknown> = {}
+  if (!frontmatter || typeof frontmatter !== 'object') return {};
+  const metadata: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(
     frontmatter as Record<string, unknown>,
   )) {
     if (!STRUCTURAL_FRONTMATTER_FIELDS.has(key)) {
-      metadata[key] = value
+      metadata[key] = value;
     }
   }
-  return metadata
+  return metadata;
 }
 
 // Real YAML parsing, not hand-rolled per-shape regexes — frontmatter is YAML,
@@ -134,7 +134,7 @@ export function extractFrontmatterField(
   } catch (e) {
     console.warn(
       `[project-docs] YAML parse error${sourcePath ? ` in ${sourcePath}` : ''}: ${e instanceof Error ? e.message : String(e)}`,
-    )
+    );
     return [];
   }
 
@@ -161,7 +161,11 @@ export function extractFrontmatterAncestorRefs(
   content: string,
   sourcePath?: string,
 ): string[] {
-  const ancestors = extractFrontmatterField(content, 'project-docs-ancestors', sourcePath);
+  const ancestors = extractFrontmatterField(
+    content,
+    'project-docs-ancestors',
+    sourcePath,
+  );
   const resolves = extractFrontmatterField(content, 'resolves', sourcePath);
   return [...new Set([...ancestors, ...resolves])];
 }
@@ -267,7 +271,7 @@ export interface RegistryEntry {
   ancestorRefs: string[];
   // Refs this artifact explicitly claims to resolve (via --resolves), not
   // just build on — a strict subset of ancestorRefs, since a resolved ref is
-  // also written there for traversal. See computeViolations' resolutionStatus.
+  // also written there for traversal. See computeFindings' status.resolution.
   resolves: string[];
   // All non-structural frontmatter fields, verbatim. Never undefined — an
   // artifact with no parseable frontmatter block has metadata: {}. Excludes
@@ -303,7 +307,15 @@ function buildPathToKeyMap(registry: Registry): Map<string, string> {
   return pathToKey;
 }
 
-const REF_SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.cs', '.md'];
+const REF_SOURCE_EXTENSIONS = [
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.vue',
+  '.cs',
+  '.md',
+];
 const SKIP_DIRS = new Set(['node_modules', 'dist', '.git', '.nx']);
 
 function walk(host: Tree, dir: string): string[] {
@@ -337,8 +349,8 @@ function projectDocsRoots(host: Tree): string[] {
 // comment or frontmatter), or an artifact's own path-derived key, where the
 // offending characters are in the filename itself and the fix is a rename.
 export interface UnparseableRef {
-  ref: string
-  foundIn: string
+  ref: string;
+  foundIn: string;
 }
 
 // Whether a scanned token was plausibly *meant* to be a reference, and so is
@@ -350,7 +362,7 @@ export interface UnparseableRef {
 // noise (35 such matches in this repo alone). Code punctuation is the tell, so
 // this admits only the grammar's own charset plus the characters that
 // realistically slip into a hand-written id: a period, a stray slash, a space.
-const PLAUSIBLE_REF = /^[\w .:/#-]+$/
+const PLAUSIBLE_REF = /^[\w .:/#-]+$/;
 
 function recordUnparseable(
   unparseableRefs: UnparseableRef[],
@@ -358,7 +370,7 @@ function recordUnparseable(
   foundIn: string,
 ): void {
   if (PLAUSIBLE_REF.test(ref)) {
-    unparseableRefs.push({ ref, foundIn })
+    unparseableRefs.push({ ref, foundIn });
   }
 }
 
@@ -435,7 +447,7 @@ function registerArtifact(
   yamlErrors: YamlError[],
   unparseableRefs: UnparseableRef[],
 ): void {
-  const key = refKey(ref)
+  const key = refKey(ref);
   // An artifact whose own key can't be parsed back is still registered — it
   // exists, and hiding it would be the very failure this records. But every
   // parse-dependent check below degrades on it: orphans counts it as an orphan
@@ -444,20 +456,20 @@ function registerArtifact(
   // generators reject these at creation time, so this only catches a
   // hand-authored or pre-existing file.
   if (!parseAncestorRef(key)) {
-    unparseableRefs.push({ ref: key, foundIn: path })
+    unparseableRefs.push({ ref: key, foundIn: path });
   }
-  const content = host.read(path, 'utf-8') ?? ''
-  const block = FRONTMATTER_BLOCK.exec(content)
+  const content = host.read(path, 'utf-8') ?? '';
+  const block = FRONTMATTER_BLOCK.exec(content);
   if (block) {
     try {
-      yaml.parse(block[1])
+      yaml.parse(block[1]);
     } catch (e) {
-      const error = e instanceof Error ? e.message : String(e)
-      yamlErrors.push({ path, error })
+      const error = e instanceof Error ? e.message : String(e);
+      yamlErrors.push({ path, error });
       // eslint-disable-next-line no-console
-      console.log(`[nx-agent] YAML parse error in ${path}: ${error}`)
-      registry.set(key, { path, ancestorRefs: [], resolves: [], metadata: {} })
-      return
+      console.log(`[nx-agent] YAML parse error in ${path}: ${error}`);
+      registry.set(key, { path, ancestorRefs: [], resolves: [], metadata: {} });
+      return;
     }
   }
   registry.set(key, {
@@ -465,7 +477,7 @@ function registerArtifact(
     ancestorRefs: extractFrontmatterAncestorRefs(content, path),
     resolves: extractFrontmatterField(content, 'resolves', path),
     metadata: extractFrontmatterMetadata(content, path),
-  })
+  });
 }
 
 // Every project-docs-ancestors reference found anywhere in the workspace's
@@ -520,17 +532,44 @@ export function buildIndex(
 }
 
 export interface YamlError {
-  path: string
-  error: string
+  path: string;
+  error: string;
 }
 
-export interface Violations {
+// Two containers, split on a property intrinsic to the graph rather than on
+// severity: is the defect *in* the graph, or is it a fact the graph is
+// correctly reporting?
+//
+// Integrity means the graph cannot be trusted as a graph — an edge whose
+// endpoint doesn't exist, a token that isn't an edge at all, a node whose
+// edges couldn't be read. That's a validity claim, not a threshold, which is
+// why --strict fails on it and why that isn't configurable: a consumer asking
+// "was this graph even constructible" isn't expressing a preference.
+export interface Integrity {
   brokenRefs: { ref: string; referencedFrom: string }[];
   unparseableRefs: UnparseableRef[];
+  yamlErrors: YamlError[];
+}
+
+// Status means the graph is sound and is telling you where the work stands.
+// Nothing here is malformed, so none of it fails --strict; gating on any of it
+// is a project policy and belongs to the consumer.
+//
+// Computed from *structure* only — edges and schema expectations. Status an
+// artifact declares about itself in frontmatter (a `questions` list, a
+// `status:` field) deliberately stays in `metadata`, passed through verbatim
+// for the consumer to interpret: the moment this computed a finding from one,
+// the library would have taken a position on somebody's workflow, and being
+// workflow-agnostic is the property that makes it consumable from outside.
+export interface Status {
+  resolution: { open: string[]; resolved: string[] };
   orphans: string[];
   unscoped: string[];
-  resolutionStatus: { open: string[]; resolved: string[] };
-  yamlErrors: YamlError[];
+}
+
+export interface Findings {
+  integrity: Integrity;
+  status: Status;
 }
 
 // `artifactSchema` is plain data the workspace owns (see utils/artifact-schema.ts)
@@ -541,14 +580,14 @@ export interface Violations {
 // expects both a bounded-contexts and a domain-terms ancestor, not either —
 // a model with only the former is still missing the vocabulary it should be
 // built from, so it's still worth flagging.
-export function computeViolations(
+export function computeFindings(
   registry: Registry,
   index: Index,
   artifactSchema: ArtifactSchema = {},
   yamlErrors: YamlError[] = [],
   unparseableRefs: UnparseableRef[] = [],
-): Violations {
-  const brokenRefs: Violations['brokenRefs'] = [];
+): Findings {
+  const brokenRefs: Integrity['brokenRefs'] = [];
   for (const [key, entries] of index) {
     if (!registry.has(key)) {
       for (const entry of entries) {
@@ -601,7 +640,7 @@ export function computeViolations(
     }
   }
 
-  const resolutionStatus: Violations['resolutionStatus'] = {
+  const resolution: Status['resolution'] = {
     open: [],
     resolved: [],
   };
@@ -610,19 +649,12 @@ export function computeViolations(
     if (!parsedKey || !artifactSchema[parsedKey.type]?.tracksResolution) {
       continue;
     }
-    (resolvedKeys.has(key)
-      ? resolutionStatus.resolved
-      : resolutionStatus.open
-    ).push(key);
+    (resolvedKeys.has(key) ? resolution.resolved : resolution.open).push(key);
   }
 
   return {
-    brokenRefs,
-    unparseableRefs,
-    orphans,
-    unscoped,
-    resolutionStatus,
-    yamlErrors,
+    integrity: { brokenRefs, unparseableRefs, yamlErrors },
+    status: { resolution, orphans, unscoped },
   };
 }
 

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -549,6 +549,17 @@ export interface Integrity {
   brokenRefs: { ref: string; referencedFrom: string }[];
   unparseableRefs: UnparseableRef[];
   yamlErrors: YamlError[];
+  // Each cycle as its own node sequence, first node repeated only implicitly:
+  // ['a', 'b'] means a derives from b and b derives from a. A single-element
+  // cycle is an artifact naming itself.
+  cycles: string[][];
+  // An expectedAncestorTypes entry that differs from a real type only by
+  // pluralization or case, so `didYouMean` always names the type it meant.
+  schemaErrors: {
+    type: string;
+    expectedAncestorType: string;
+    didYouMean: string;
+  }[];
 }
 
 // Status means the graph is sound and is telling you where the work stands.
@@ -565,6 +576,64 @@ export interface Status {
   resolution: { open: string[]; resolved: string[] };
   orphans: string[];
   unscoped: string[];
+}
+
+// project-docs-ancestors is a derivation relation: it declares what an artifact
+// was built *from*. So two artifacts each declaring the other are internally
+// contradictory — neither can precede the other — which makes a cycle a defect
+// in the graph rather than a fact about the work, however valid each individual
+// edge is. Traversal has always terminated safely on one (getAncestors skips a
+// revisited key rather than re-expanding it); what it never did was say so, so
+// getAncestors(..., Infinity) returned a correct-looking finite set that
+// quietly omitted the fact that the ancestry isn't a hierarchy at all.
+//
+// One cycle per back edge, not every elementary cycle — enumerating those is
+// exponential, and naming the nodes involved is what a reader needs to go fix
+// it. Edges to keys outside the registry aren't followed: an unresolvable
+// target has no outgoing edges of its own, so it can't close a loop, and it's
+// already reported as a broken or unparseable reference.
+function findCycles(registry: Registry): string[][] {
+  // Absent = unvisited, true = on the current DFS path, false = fully explored.
+  const onPath = new Map<string, boolean>();
+  const path: string[] = [];
+  const cycles: string[][] = [];
+  const recorded = new Set<string>();
+
+  const visit = (key: string): void => {
+    onPath.set(key, true);
+    path.push(key);
+    for (const raw of registry.get(key)?.ancestorRefs ?? []) {
+      const parsed = parseAncestorRef(raw);
+      const next = parsed ? refKey(parsed) : null;
+      if (!next || !registry.has(next)) {
+        continue;
+      }
+      if (onPath.get(next)) {
+        // Rotated so the lexicographically smallest node leads, so the same
+        // cycle reached from a different entry point is recognised as the one
+        // it already is rather than reported once per member.
+        const cycle = path.slice(path.indexOf(next));
+        const lowest = cycle.indexOf([...cycle].sort()[0]);
+        const canonical = [...cycle.slice(lowest), ...cycle.slice(0, lowest)];
+        const fingerprint = canonical.join('\u0000');
+        if (!recorded.has(fingerprint)) {
+          recorded.add(fingerprint);
+          cycles.push(canonical);
+        }
+      } else if (!onPath.has(next)) {
+        visit(next);
+      }
+    }
+    path.pop();
+    onPath.set(key, false);
+  };
+
+  for (const key of registry.keys()) {
+    if (!onPath.has(key)) {
+      visit(key);
+    }
+  }
+  return cycles;
 }
 
 export interface Findings {
@@ -609,11 +678,69 @@ export function computeFindings(
     return !parsedKey || !artifactSchema[parsedKey.type]?.terminal;
   });
 
+  // A type exists if the schema declares it or some artifact is of it — types
+  // are literal project-docs/ subfolder names, so a folder with artifacts in it
+  // is a real type whether or not it has a schema entry.
+  const knownTypes = new Set<string>(Object.keys(artifactSchema));
+  for (const key of registry.keys()) {
+    const parsedKey = parseAncestorRef(key);
+    if (parsedKey) {
+      knownTypes.add(parsedKey.type);
+    }
+  }
+
+  // Deliberately narrower than "names a type that doesn't exist". A type is a
+  // literal project-docs/ subfolder name, with no authoritative list of valid
+  // ones, so an unknown type is genuinely ambiguous: `requirements` expecting
+  // `product-briefs` before the first product brief is written looks identical
+  // to a misspelling. Flagging that would fail --strict on a correct schema —
+  // and in a fresh workspace, on most of it.
+  //
+  // What *is* decidable is a value that differs from a real type only by
+  // pluralization or case, which is the slip that actually happens (every type
+  // name here is plural, so `bounded-context` for `bounded-contexts` is one
+  // keystroke). High confidence, so it can name the fix — and a typo that
+  // isn't a near-miss of any known type stays unreported, which is the honest
+  // outcome for a case nothing can distinguish from a not-yet-populated type.
+  //
+  // Validated here rather than where an entry is written, because hand-editing
+  // artifact-schema.json is a supported path by design ("a hand-added entry for
+  // a custom artifact kind gets the same checks for free") — and a check that
+  // runs only when someone remembers to run a generator is a check that doesn't
+  // run. One implementation covers hand-edited, generator-written and migrated
+  // entries.
+  const loosely = (type: string) => type.toLowerCase().replace(/s$/, '');
+  const byLooseName = new Map<string, string>();
+  for (const type of knownTypes) {
+    byLooseName.set(loosely(type), type);
+  }
+
+  const schemaErrors: Integrity['schemaErrors'] = [];
+  const misspelled = new Set<string>();
+  for (const [type, entry] of Object.entries(artifactSchema)) {
+    for (const expected of entry.expectedAncestorTypes ?? []) {
+      if (knownTypes.has(expected)) {
+        continue;
+      }
+      const didYouMean = byLooseName.get(loosely(expected));
+      if (didYouMean) {
+        schemaErrors.push({ type, expectedAncestorType: expected, didYouMean });
+        misspelled.add(expected);
+      }
+    }
+  }
+
   const unscoped: string[] = [];
   for (const [key, entry] of registry) {
     const parsedKey = parseAncestorRef(key);
-    const expected =
+    const declared =
       parsedKey && artifactSchema[parsedKey.type]?.expectedAncestorTypes;
+    // Only a *confirmed* misspelling is dropped. It can never be satisfied, so
+    // checking it would report every artifact of this type as unscoped forever,
+    // pointing at artifacts that are correct — the schema is what's wrong, and
+    // schemaErrors says so with the fix. An expectation that's merely unknown
+    // is still checked, since it may well be a real type nothing populates yet.
+    const expected = declared?.filter((type) => !misspelled.has(type));
     if (!expected || expected.length === 0) {
       continue;
     }
@@ -653,7 +780,13 @@ export function computeFindings(
   }
 
   return {
-    integrity: { brokenRefs, unparseableRefs, yamlErrors },
+    integrity: {
+      brokenRefs,
+      unparseableRefs,
+      yamlErrors,
+      cycles: findCycles(registry),
+      schemaErrors,
+    },
     status: { resolution, orphans, unscoped },
   };
 }

--- a/packages/nx-agent/src/utils/project-docs-refs.ts
+++ b/packages/nx-agent/src/utils/project-docs-refs.ts
@@ -466,7 +466,12 @@ export interface UnparseableRef {
 // noise (35 such matches in this repo alone). Code punctuation is the tell, so
 // this admits only the grammar's own charset plus the characters that
 // realistically slip into a hand-written id: a period, a stray slash, a space.
-const PLAUSIBLE_REF = /^[\w .:/#-]+$/;
+// '@' is in the charset because the grammar accepts a digest there, and a
+// malformed one is the likeliest bad token now that the README documents
+// hand-pinning `<type>:<id>@<digest>` — uppercase hex, straight off a SHA, is
+// enough. Without it such a ref failed the parse *and* this gate, so it was
+// dropped in silence and its target read as unreferenced.
+const PLAUSIBLE_REF = /^[\w .:/#@-]+$/;
 
 function recordUnparseable(
   unparseableRefs: UnparseableRef[],
@@ -570,8 +575,12 @@ function registerArtifact(
     } catch (e) {
       const error = e instanceof Error ? e.message : String(e);
       yamlErrors.push({ path, error });
+      // stderr, not stdout: --json prints one JSON document to stdout, and this
+      // line landing there made the stream unparseable in precisely the case a
+      // machine consumer cares about it. Matches the sibling helpers, which
+      // already warn.
       // eslint-disable-next-line no-console
-      console.log(`[nx-agent] YAML parse error in ${path}: ${error}`);
+      console.warn(`[nx-agent] YAML parse error in ${path}: ${error}`);
       registry.set(key, {
         path,
         bodyDigest: digestBody(content),
@@ -799,11 +808,6 @@ export function computeFindings(
     }
   }
 
-  // A terminal type (declared, same as expectedAncestorTypes/tracksResolution,
-  // by its own generator — no hardcoded type name here either) always has
-  // zero descendants by design once it's closed out correctly: that's what
-  // correct looks like, not neglect, so it's excluded from unreferenced rather
-  // than reported alongside a domain-model nobody's designed against yet.
   // Only a recorded digest that *disagrees* is a finding. Absent means unknown
   // (hand-authored, or predates adoption) and stays silent; a digest recorded
   // against an ancestor that isn't registered is a broken reference, already
@@ -837,6 +841,11 @@ export function computeFindings(
     }
   }
 
+  // A terminal type (declared, same as expectedAncestorTypes/tracksResolution,
+  // by its own generator — no hardcoded type name here either) always has
+  // zero descendants by design once it's closed out correctly: that's what
+  // correct looks like, not neglect, so it's excluded from unreferenced rather
+  // than reported alongside a domain-model nobody's designed against yet.
   const unreferenced = [...registry.keys()].filter((key) => {
     if (index.has(key)) {
       return false;
@@ -989,7 +998,12 @@ export function computeFindings(
   const resolvedKeys = new Set<string>();
   for (const entry of registry.values()) {
     for (const resolved of entry.resolves) {
-      resolvedKeys.add(resolved);
+      // Normalised through the grammar rather than taken verbatim: a resolves
+      // entry may now carry an @digest, and a raw token never matches the
+      // registry key, so a genuinely resolved question would silently revert to
+      // open — which the loop treats as a top-priority resolution signal.
+      const parsed = parseAncestorRef(resolved);
+      resolvedKeys.add(parsed ? refKey(parsed) : resolved);
     }
   }
 

--- a/packages/nx-agent/src/utils/synthesis.spec.ts
+++ b/packages/nx-agent/src/utils/synthesis.spec.ts
@@ -137,13 +137,13 @@ describe('synthesize', () => {
 });
 
 describe('buildDeterministicSummary', () => {
-  it('states the total and type breakdown with no open/orphan/broken activity', () => {
+  it('states the total and type breakdown with no open/unreferenced/broken activity', () => {
     const summary = buildDeterministicSummary({
       totalArtifacts: 3,
       byType: { 'domain-terms': 2, 'bounded-contexts': 1 },
       open: 0,
       resolved: 0,
-      orphans: 0,
+      unreferenced: 0,
       brokenRefs: 0,
     });
     expect(summary).toBe(
@@ -151,17 +151,17 @@ describe('buildDeterministicSummary', () => {
     );
   });
 
-  it('includes open/resolved, orphan, and broken-ref sentences when present', () => {
+  it('includes open/resolved, unreferenced, and broken-ref sentences when present', () => {
     const summary = buildDeterministicSummary({
       totalArtifacts: 5,
       byType: { 'open-questions': 2 },
       open: 1,
       resolved: 1,
-      orphans: 2,
+      unreferenced: 2,
       brokenRefs: 1,
     });
     expect(summary).toContain('1 resolved, 1 still open.');
-    expect(summary).toContain('2 orphaned (nothing derives from them yet).');
+    expect(summary).toContain('2 unreferenced (nothing derives from them yet).');
     expect(summary).toContain('1 broken reference(s).');
   });
 
@@ -171,7 +171,7 @@ describe('buildDeterministicSummary', () => {
       byType: {},
       open: 0,
       resolved: 0,
-      orphans: 0,
+      unreferenced: 0,
       brokenRefs: 0,
     });
     expect(summary).toBe('0 project-docs artifact(s) tracked.');

--- a/packages/nx-agent/src/utils/synthesis.ts
+++ b/packages/nx-agent/src/utils/synthesis.ts
@@ -64,7 +64,7 @@ export interface StatusCounts {
   byType: Record<string, number>;
   open: number;
   resolved: number;
-  orphans: number;
+  unreferenced: number;
   brokenRefs: number;
 }
 
@@ -83,9 +83,9 @@ export function buildDeterministicSummary(counts: StatusCounts): string {
   if (counts.open > 0 || counts.resolved > 0) {
     sentences.push(`${counts.resolved} resolved, ${counts.open} still open.`);
   }
-  if (counts.orphans > 0) {
+  if (counts.unreferenced > 0) {
     sentences.push(
-      `${counts.orphans} orphaned (nothing derives from them yet).`,
+      `${counts.unreferenced} unreferenced (nothing derives from them yet).`,
     );
   }
   if (counts.brokenRefs > 0) {

--- a/scripts/task-identification.mjs
+++ b/scripts/task-identification.mjs
@@ -99,7 +99,24 @@ if (!existsSync(LINEAGE_PATH)) {
 }
 
 const lineage = JSON.parse(readFileSync(LINEAGE_PATH, 'utf-8'));
-const { registry, index, violations } = lineage;
+
+// What the schemaVersion in lineage.json is for. This script is generated
+// write-if-missing, so a workspace can end up running an older copy of it
+// against a newer graph (or the reverse, off a stale gitignored file) -- fail
+// here, naming both versions, rather than 40 lines down with a TypeError on a
+// container that moved.
+const EXPECTED_LINEAGE_SCHEMA_VERSION = 1;
+if (lineage.schemaVersion !== EXPECTED_LINEAGE_SCHEMA_VERSION) {
+  console.error(
+    `[task-identification] ${LINEAGE_PATH} is schemaVersion ${lineage.schemaVersion ?? '(absent)'}, ` +
+      `this script expects ${EXPECTED_LINEAGE_SCHEMA_VERSION}. Re-run ` +
+      `\`npx nx g @abgov/nx-agent:project-docs-lineage\`; if that doesn't fix it, this copy of ` +
+      `the script is older than the installed @abgov/nx-agent and needs updating.`,
+  );
+  process.exit(1);
+}
+
+const { registry, index, integrity, status } = lineage;
 
 const descendantTypes = (key) => (index[key] ?? []).map((e) => e.type).filter(Boolean);
 const hasUntypedDescendant = (key) => (index[key] ?? []).some((e) => !e.type);
@@ -107,9 +124,18 @@ const designArtifactsOf = (key) => (index[key] ?? []).filter((e) => DESIGN_TYPES
 
 // --- Signals, in priority order --------------------------------------------------------------
 
+// A reference token can carry an @digest and/or a #fragment, neither of which is
+// part of the target's identity, so strip both before using one as a registry
+// key. Without this, ancestor-scope traversal silently stopped at the first
+// pinned reference: registry['domain-terms:a@a3f9c2e1b004'] is undefined, so a
+// descendant of a scoped artifact stopped being recognised as in scope.
+function refKeyOf(token) {
+  return String(token).split('@')[0].split('#')[0];
+}
+
 const signals = [];
 
-for (const yamlError of violations.yamlErrors ?? []) {
+for (const yamlError of integrity.yamlErrors ?? []) {
   signals.push({
     key: `yaml-error:${yamlError.path}`,
     stage: 'unknown',
@@ -117,7 +143,7 @@ for (const yamlError of violations.yamlErrors ?? []) {
   });
 }
 
-for (const unparseable of violations.unparseableRefs ?? []) {
+for (const unparseable of integrity.unparseableRefs ?? []) {
   signals.push({
     key: `unparseable:${unparseable.ref}`,
     stage: 'unknown',
@@ -129,7 +155,7 @@ for (const unparseable of violations.unparseableRefs ?? []) {
   });
 }
 
-for (const broken of violations.brokenRefs ?? []) {
+for (const broken of integrity.brokenRefs ?? []) {
   signals.push({
     key: `broken:${broken.ref}`,
     stage: 'unknown',
@@ -137,7 +163,45 @@ for (const broken of violations.brokenRefs ?? []) {
   });
 }
 
-for (const openKey of violations.resolutionStatus?.open ?? []) {
+for (const cycle of integrity.cycles ?? []) {
+  signals.push({
+    // Keyed on the canonical cycle, which project-docs-lineage already rotates
+    // so the smallest node leads — otherwise the same loop would produce a
+    // different key each run and stall detection would never see a repeat.
+    key: `cycle:${cycle.join(',')}`,
+    // Every node in the cycle, so the signal is in scope when any member is.
+    artifacts: cycle,
+    stage: 'unknown',
+    reason:
+      `Reference cycle: ${[...cycle, cycle[0]].join(' -> ')}. project-docs-ancestors is a ` +
+      `derivation relation, so these artifacts each claim to be built from the other and ` +
+      `neither can precede it. Break the cycle by removing whichever reference is not a real ` +
+      `derivation — fix this before anything else.`,
+  });
+}
+
+for (const schemaError of integrity.schemaErrors ?? []) {
+  // Keyed on all three of type/property/value: two bad values on one type are
+  // two things to fix, and collapsing them would let stall detection read the
+  // second as a repeat of the first.
+  signals.push({
+    key: `schema-error:${schemaError.type}:${schemaError.property}:${schemaError.value}`,
+    // Explicitly no artifact: the schema is what's wrong, so no artifact scope
+    // should exclude it.
+    artifacts: null,
+    stage: 'unknown',
+    reason:
+      schemaError.problem === 'structural-field'
+        ? `project-docs/artifact-schema.json: "${schemaError.type}".${schemaError.property} names ` +
+          `"${schemaError.value}", a structural field the graph already models as a relationship. ` +
+          `It is excluded from metadata, so the declaration does nothing — remove it.`
+        : `project-docs/artifact-schema.json: "${schemaError.type}".${schemaError.property} names ` +
+          `"${schemaError.value}" — did you mean "${schemaError.didYouMean}"? Nothing can satisfy ` +
+          `it as written. Fix the schema, not the artifacts.`,
+  });
+}
+
+for (const openKey of status.resolution?.open ?? []) {
   const entry = registry[openKey];
   signals.push({
     key: `open:${openKey}`,
@@ -146,11 +210,27 @@ for (const openKey of violations.resolutionStatus?.open ?? []) {
   });
 }
 
-for (const unscopedKey of violations.unscoped ?? []) {
+for (const unscopedKey of status.unscoped ?? []) {
   signals.push({
     key: `unscoped:${unscopedKey}`,
     stage: stageFor(typeOf(unscopedKey)),
     reason: `${unscopedKey} is missing one of its kind's expected ancestors.`,
+  });
+}
+
+// Staleness is a status finding, not integrity: the graph is sound and reporting
+// that an ancestor moved after this artifact derived from it. So it's ordinary
+// work at the descendant's own stage, not a repair — which is also why it stays
+// out of RESOLUTION_PREFIXES below, same as 'unscoped:'.
+for (const entry of status.stale ?? []) {
+  signals.push({
+    key: `stale:${entry.artifact}:${entry.ancestor}`,
+    artifacts: [entry.artifact],
+    stage: stageFor(typeOf(entry.artifact)),
+    reason:
+      `${entry.ancestor} was revised after ${entry.artifact} derived from it, so ${entry.artifact} ` +
+      `may no longer reflect it. Read both, revise ${entry.artifact} if it needs it, then record ` +
+      `that you have by re-pinning: nx g @abgov/nx-agent:pin-ancestors --artifact=${entry.artifact}.`,
   });
 }
 
@@ -210,11 +290,15 @@ for (const key of Object.keys(registry)) {
 }
 
 // api-design/ux-design with no implementing code, and no unresolved blocker/open-question naming it.
-const openKeys = violations.resolutionStatus?.open ?? [];
+const openKeys = status.resolution?.open ?? [];
 for (const key of Object.keys(registry)) {
   if (!isDesignKey(key)) continue;
   if (hasUntypedDescendant(key)) continue; // already has implementing code
-  const blockedByOpen = openKeys.some((ok) => (registry[ok]?.ancestorRefs ?? []).includes(key));
+  // refKeyOf, not a raw includes(): an ancestorRef may carry an @digest, and the
+  // raw token never equals the bare key, so a pinned blocker stopped blocking.
+  const blockedByOpen = openKeys.some((ok) =>
+    (registry[ok]?.ancestorRefs ?? []).some((anc) => refKeyOf(anc) === key),
+  );
   if (blockedByOpen) continue;
   signals.push({
     key: `undeveloped:${key}`,
@@ -229,7 +313,9 @@ for (const path of mdFilesIn('project-docs/requirements')) {
   if ((fm.rules ?? []).length === 0) continue;
   const reqKey = `requirements:${slugOf(path)}`;
   const domainModelKeys = Object.keys(registry).filter(
-    (k) => k.startsWith('domain-models:') && (registry[k].ancestorRefs ?? []).includes(reqKey),
+    (k) =>
+      k.startsWith('domain-models:') &&
+      (registry[k].ancestorRefs ?? []).some((anc) => refKeyOf(anc) === reqKey),
   );
   if (domainModelKeys.length === 0) continue;
 
@@ -268,10 +354,16 @@ const isFixBranch = branchName.startsWith('fix/');
 // each names one specific thing to repair, not new work to start. Both only became reachable
 // once project-docs-lineage stopped aborting its write on them; without them here, a fix/**
 // branch would see the signal and then be told it isn't eligible to act on it.
+//
+// 'cycle:' and 'schema-error:' join them on the same test: both are integrity findings naming
+// one specific thing to repair. 'stale:' deliberately does not — it's a status finding, so
+// revisiting the descendant is ordinary work at its own stage, same as 'unscoped:'.
 const RESOLUTION_PREFIXES = [
   'broken:',
   'unparseable:',
   'yaml-error:',
+  'cycle:',
+  'schema-error:',
   'open:',
 ];
 
@@ -296,37 +388,54 @@ if (scopedPaths.length > 0 && scopedKeys.size === 0) {
   );
 }
 
-function isInArtifactScope(signalKey) {
+function isInArtifactScope(signal) {
   if (openScope) return true;             // explicit * → unfiltered
   if (noScope) return false;             // first commit touched no project-docs files → nothing in scope
   if (scopedKeys.size === 0) return true; // paths specified but unresolvable → fall back to unfiltered (warn already printed)
-  // Signal keys look like 'open:features:x', 'unrefined:requirements:x', etc. -- the artifact
-  // registry key is everything after the first colon-prefix segment.
-  const artifactKey = signalKey.includes(':') ? signalKey.replace(/^[^:]+:/, '') : signalKey;
+
   function ancestorInScope(key, visited = new Set()) {
     if (visited.has(key)) return false;
     visited.add(key);
     if (scopedKeys.has(key)) return true;
     for (const anc of registry[key]?.ancestorRefs ?? []) {
-      if (ancestorInScope(anc, visited)) return true;
+      if (ancestorInScope(refKeyOf(anc), visited)) return true;
     }
     return false;
   }
+
+  // Most signal keys are 'prefix:artifactKey', so the artifact is recoverable
+  // from the string. The keys added for cycles, staleness and schema errors are
+  // not: a cycle names every node in it, a stale edge names both ends, and a
+  // schema error names no artifact at all. Those signals therefore declare
+  // `artifacts` outright. Recovering by string would have derived
+  // 'domain-models:m:domain-terms:t' from a stale signal, matched nothing in the
+  // registry, and dropped the signal on every branch except ARTIFACT_SCOPE='*'.
+  if (signal.artifacts === null) {
+    // About the workspace's own configuration rather than any artifact, so no
+    // artifact scope can legitimately exclude it.
+    return true;
+  }
+  if (Array.isArray(signal.artifacts)) {
+    return signal.artifacts.some((key) => ancestorInScope(refKeyOf(key)));
+  }
+  const artifactKey = signal.key.includes(':')
+    ? signal.key.replace(/^[^:]+:/, '')
+    : signal.key;
   return ancestorInScope(artifactKey);
 }
 
 const eligibleSignals = isFixBranch
   ? signals.filter(
-      (s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)) && isInArtifactScope(s.key),
+      (s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)) && isInArtifactScope(s),
     )
-  : signals.filter((s) => isInArtifactScope(s.key));
+  : signals.filter((s) => isInArtifactScope(s));
 const excludedCount = signals.length - eligibleSignals.length;
 
 // Diagnostic breakdown — computed only when filtering produced nothing, so the log doesn't
 // just say "nothing to do" when the real answer is "scope and branch type disagree."
 let noEligibleNote = null;
 if (eligibleSignals.length === 0 && signals.length > 0) {
-  const inScope = scopedKeys.size > 0 ? signals.filter((s) => isInArtifactScope(s.key)) : signals;
+  const inScope = scopedKeys.size > 0 ? signals.filter((s) => isInArtifactScope(s)) : signals;
   const inBranchType = isFixBranch
     ? signals.filter((s) => RESOLUTION_PREFIXES.some((p) => s.key.startsWith(p)))
     : signals;
@@ -375,7 +484,7 @@ if (process.env.PEEK_ONLY !== 'true') {
   // nothing to stall on, and 'none' entries corrupt the stall-detection window when
   // a real signal recurs across a no-work gap.
   if (topSignal) {
-    const lineageFingerprint = JSON.stringify(violations);
+    const lineageFingerprint = JSON.stringify({ integrity, status });
     history.push({ key: topSignal.key, lineageFingerprint });
     history = history.slice(-HISTORY_KEEP);
     writeFileSync(HISTORY_PATH, JSON.stringify(history, null, 2) + '\n');


### PR DESCRIPTION
E3 from the lineage integrity findings, split along the additive/breaking line. **This PR is
additive only** — no existing field moves, so nothing in the field needs a migration.

## Why

`.nx-agent/lineage.json` is documented as an internal implementation detail, free to change as long
as `getAncestors`/`getDescendants` hold. It isn't. It's already the agent-facing interface by
deliberate design (`design/SKILL.md:43` tells the agent to read the file and says the exported
functions are "not something an agent" does), and **five** things depend on its shape:

| Reader | Reads |
| --- | --- |
| `scripts/task-identification.mjs` | every `violations` key, plus `registry[].ancestorRefs`, `registry[].path`, `index[].type` |
| `skills/design/SKILL.md` | `index` entries and their `type` |
| `skills/develop/SKILL.md` | the `index` entry for a domain-model or its bounded-context ancestor |
| `skills/discover/SKILL.md` | `violations.resolutionStatus.open` / `.resolved` |
| `task-identification.mjs:378` | `JSON.stringify(violations)` as the **stall-detection fingerprint** |

That last one isn't in the findings doc. Any reshape of `violations` silently changes what stall
detection compares across iterations — and a future split that left one container out of the
fingerprint would make the loop stop noticing changes in it.

All of these are generated **write-if-missing**, so a workspace keeps its own copy and re-running
the generator cannot repair a shape change. The freedom the "internal" designation buys is already
spent, and the skills fail worst: they're prose instructing a model, so a stale field path produces
no error at all — the model looks for something absent and improvises.

## What's in it

**`schemaVersion: 1`**, plus a README table declaring exactly which paths it covers. This records
what's already load-bearing rather than adding a new promise, and leaves the rest of the file
genuinely free to change. A consumer that pins the version now fails loudly on a bump instead of
reading around a renamed field.

**`--json`** prints the same object to stdout for a machine consumer, built from a single `payload`
so the stream and the file cannot describe different graphs (there's a test asserting exactly that).

Two things about `--json` that weren't obvious and that I verified rather than assumed:

- **Nx's `NX Generating ...` banner goes to stdout, not stderr.** So a bare `--json` is not
  parseable; it needs `--quiet`, which does suppress it. Both directions confirmed empirically, and
  the flag description and README say so.
- **stdout isn't subject to Nx's write rollback.** So `--json --strict` yields the graph *and* a
  failing exit code in one run — which is exactly the case the README (as of this morning's F1 fix)
  said required running the generator twice. Corrected there, and there's a test pinning the
  ordering, since it only works because the print happens before the throw.

Verified end to end in this workspace:

```
$ npx nx g @abgov/nx-agent:project-docs-lineage --json --quiet 2>/dev/null | jq ...
schemaVersion: 1 | registry: 21 | index: 17 | brokenRefs: 0 | open: 0
```

## The `integrity` / `status` split (second commit)

Scope grew, because the split turned out **not** to need a migration — which was the only reason
I'd deferred it.

Findings now split on a property intrinsic to the graph rather than on severity: **is the defect
_in_ the graph, or is it a fact the graph is correctly reporting?**

- **`integrity`** (`brokenRefs`, `unparseableRefs`, `yamlErrors`) — the graph can't be trusted as a
  graph. `--strict` fails on it, and that deliberately isn't configurable: a consumer asking "was
  this graph even constructible" isn't expressing a preference.
- **`status`** (`resolution`, `orphans`, `unscoped`) — the graph is sound and is reporting where the
  work stands. Nothing fails `--strict`; gating on any of it is a project policy and belongs to the
  consumer.

`violations` was misnamed for holding both, and held `resolutionStatus`, which isn't a violation at
all — the README had to say so in prose. Under `status` that stops being an anomaly, and it sheds a
redundant suffix to become `status.resolution`.

**Why no migration.** `violations` stays as a deprecated flat view, assembled from the *same arrays*
so it cannot drift (there's a test asserting that), and removed at `schemaVersion` 2. So
`schemaVersion` stays 1, since adding fields is additive by the rule in the code comment. The
alternative was a fixture-based migration for 510-line `task-identification.mjs` — roughly 1000
lines of shipped assets to rename a field that can simply keep working.

**Two things now pinned that were previously only prose:**

- `INTEGRITY_FAILURES` is keyed on `keyof Integrity`, so a category added to that interface won't
  compile until it has a `--strict` message. F3's cycles and F4's schema errors can't be added and
  silently fail to gate.
- `status` is computed from **structure only**. Status an artifact declares about itself in
  frontmatter (a `questions` list) stays in `metadata`, verbatim. Computing a finding from one would
  take a position on somebody's workflow, and workflow-agnosticism is what makes this consumable
  from outside. That line is now in the README and the type comments.

**A sixth reader, previously uncounted.** `project-docs-report` imports `Violations` and
`computeViolations` directly rather than reading the file, so neither the findings doc's table nor
my own count caught it. Retargeted in-repo, no migration needed. First-party readers moved now:
`task-identification.mjs`, `discover/SKILL.md`, `project-docs-report`.

**The stall fingerprint had to widen.** `JSON.stringify(violations)` became
`JSON.stringify({ integrity, status })` — left as-is it would have stopped noticing changes in
whichever container it no longer read.

`task-identification.mjs` now also checks `schemaVersion` and names both versions on a mismatch,
which is what that field was added for. Tested: a pre-split graph produces
`schemaVersion (absent) ... expects 1` rather than a `TypeError` forty lines later.

Verified on the real workspace:

```
schemaVersion: 1
integrity keys: brokenRefs,unparseableRefs,yamlErrors
status keys:    orphans,resolution,unscoped
alias matches integrity: true
alias matches status:    true
```

## F3 and F4 (third commit)

Both land as `integrity` members, and **both were forced to gate by the `keyof Integrity` guard** —
neither compiled until it had a `--strict` message. The mechanism working, not a claim about it.

### Cycles (F3)

Colour-marked DFS over the registry that's already built. One cycle per back edge rather than every
elementary cycle — enumerating those is exponential, and naming the nodes involved is what a reader
needs. Canonicalised by rotation, so a loop reachable from either member is reported once rather
than once per node. Edges leaving the registry aren't followed: an unresolvable target has no
outgoing edges of its own, so it can't close a loop, and it's already a broken reference.

Covers the mutual pair, the self-reference, `--strict` failing on it, and a diamond **not** being
mistaken for one.

### Schema expectations (F4) — narrower than the finding asked for

The finding specifies checking each `expectedAncestorTypes` value "against the set of types the
schema itself declares plus the types present in the registry." **I implemented that first and it
was wrong.** A type is a literal `project-docs/` subfolder name with no authoritative list of valid
ones, so an unknown type is genuinely ambiguous: `requirements` expecting `product-briefs` before
the first product brief is written is indistinguishable from a misspelling.

As specified it failed `--strict` on a correct schema — in a fresh workspace, on most of it — *and*
silently dropped the `unscoped` check that was the whole point. Two existing tests caught it, and
the design is now shaped around what they showed:

> a broken **reference** names one artifact, so it's decidable. A **type** names a category, and an
> empty category looks exactly like a misspelled one.

So it detects only what's decidable: a value differing from a real type by **pluralization or
case**. That's the slip that actually happens — every type name here is plural, so
`bounded-context` is one keystroke from `bounded-contexts` — and it's high-confidence enough to name
the fix:

```
[nx-agent] artifact-schema.json: "domain-terms" expects ancestor type "bounded-context" —
  did you mean "bounded-contexts"? Nothing can satisfy it as written, so every domain-terms
  artifact would report unscoped.
```

Those are also the **only** expectations dropped from the `unscoped` check, which addresses the
finding's actual complaint — one bad value reporting every artifact of its type as unscoped
forever, pointing at artifacts that are correct. An expectation that is merely *unknown* is still
checked, since it may well be a real type nothing has populated yet.

A typo that isn't a near-miss of any known type stays unreported. That's the honest outcome for a
case nothing can distinguish from a not-yet-populated type, and it's stated in the README rather
than left as a silent gap.

Verified on the real workspace:

```
integrity: brokenRefs,cycles,schemaErrors,unparseableRefs,yamlErrors
cycles: 0 | schemaErrors: 0 | unscoped: 0 | alias has cycles: true
```

## `status.orphans` → `status.unreferenced` (fourth commit)

"Orphan" inverted the metaphor. References are backward-only — a descendant names its ancestors —
so the check is `index.has(key)`, against the computed "what references this" inverse. An artifact
it flags therefore has no **descendants**, while an orphan conventionally has no **parents**. The
parentless case is a different finding entirely (`unscoped`), so the name pointed a reader at the
wrong one of the two.

`unreferenced` names the mechanism, and pairs with `unscoped`: nothing references it, versus missing
an expected ancestor. This workspace shows why the distinction matters — 5 roots, 4 leaves, 0
flagged:

```
roots  (no ancestors):   bounded-contexts:…, bugs:…, features:…   (5, all silent — correct roots)
leaves (no descendants): iteration-retrospectives:…               (4, all terminal: true)
unreferenced:            []
```

**Free to do now, and only now.** `status.unreferenced` has never shipped — it arrives with the
container split in this same unmerged branch, and published `1.29.0` still emits the pre-split
shape. So **no `schemaVersion` bump and no migration**. The deprecated `violations.orphans` view
deliberately keeps its old key, which is exactly its job: serving readers written against the
1.29.0-era shape.

Renamed through to `project-docs-report`, which would otherwise have rendered an "Unreferenced"
count card beside "Orphan" badges, and through the generated skills, guidance and retrospective
prose. Two mentions survive on purpose — the comment and README paragraph explaining the change.
`develop/SKILL.md`'s "orphaned from navigation" is a different concept (a page unreachable from nav)
and is untouched.

Also fixes a stale README heading the split missed: `### resolutionStatus` still documenting
`violations.resolutionStatus`, now `### status.resolution`.

## F5 — ancestor digests (fifth commit)

A reference may optionally record the ancestor's body digest — `domain-terms:case@a3f9c2e1b004` —
and a later mismatch reports as `status.stale`. Plus a `pin-ancestors` generator, without which
nothing would ever be pinned and the feature would ship inert.

**Status, not integrity, for a structural reason.** The graph still builds: every node exists, every
edge resolves, the topology is a valid DAG. What diverged is a content snapshot against current
content — data *about* nodes, not the graph. So `--strict` never fails on it. The digest is likewise
excluded from `refKey`, exactly as `#fragment` already is; a content-derived key would change on
every edit and fragment the registry and index. One new grammar clause, following that precedent.

**Three states, and the silent one makes it adoptable.** Absent means unknown and reports nothing,
so this ships inert until something is pinned deliberately. No per-type schema flag — an opt-in
check is a check that doesn't run, and "was this edge written against current content" is uniformly
a fact about the graph.

### The body-only decision is load-bearing, not a shortcut

Recording a pin edits `project-docs-ancestors`. So a whole-file hash would make **re-pinning itself
a content change**, cascading staleness through the entire transitive descendancy in waves, each
wave's fix triggering the next — the graph would never settle. Body-only stops at depth 1, and
propagates one hop further *exactly* when a re-pin came with a real revision, which is when
descendants should look. It also keeps the hash independent of where a digest is stored, and avoids
canonicalising a parsed YAML object to keep it stable.

The cost is permanent and documented as such: **a type keeping its meaning in frontmatter isn't
covered at all.** `requirements` is that type — its `rules` *are* the artifact — and they live there
deliberately so a real YAML parser can read them (`check-example-mapping.mjs` carries the note that
it had two regex-parsing bugs before the move). For those, a material change is a different
artifact, not an edit.

### Two bugs found by running it, not by reasoning about it

- **`formatFiles()` reformats bodies.** Prettier inserts a blank line after the frontmatter
  delimiter, so the first pin was invalidated by the formatting pass that immediately followed
  writing it. Only surfaced because an idempotency test ran the generator twice. `extractBody` now
  normalises that blank line alongside line endings and trailing whitespace, and leaves first-line
  indentation alone since that can be a code block.
- **The generators emit both YAML sequence styles.** `requirements` write block lists;
  `domain-terms` write `project-docs-ancestors: [bounded-contexts:lineage-graph]` on one line.
  Handling only block style skipped the rest **silently** — indistinguishable from a deliberately
  unpinned reference. Both are handled now, and anything neither matches warns rather than skipping.
  Caught by a scoped dry-run against the real workspace finding 0 references where the graph showed
  3.

### `pin-ancestors` is a generator, not a `--repin` flag

`project-docs-lineage` reads and reports; this writes to artifacts. A mutation sitting next to
`--strict` is how a check ends up silently dead in a workflow. Human-invoked only — never a hook, a
CI step, or a clean-run path, since a pin asserts "I have read this ancestor as it stands" and a
blind bulk re-pin bakes in existing drift and reports it as the floor. Scoped via
`--ancestor`/`--artifact`, and because digests live in the committed artifact the re-pin lands in
the author's own diff, which is what makes the assertion reviewable — unlike a central baseline that
re-seals where nobody looks.

Verified with `--dry-run` against this workspace (no artifact modified):

```
$ nx g @abgov/nx-agent:pin-ancestors --ancestor=bounded-contexts:lineage-graph --dry-run
domain-models:lineage-graph-metadata: pinned bounded-contexts:lineage-graph
domain-terms:artifact-metadata: pinned bounded-contexts:lineage-graph
iteration-retrospectives:implement-…: pinned bounded-contexts:lineage-graph
pinned 3 reference(s).
```

## Requirements: a rationale body, and declared digest fields (sixth commit)

Two halves of one gap, found by measuring rather than assuming. Every artifact type carries a
**639–6857 character body except `requirements`, which carry none**:

| type | body chars (min/med/max) | content-bearing frontmatter |
| --- | --- | --- |
| **requirements** | **0/0/0** | `rules` — the whole artifact |
| product-briefs | 762/917/917 | `capability`, `audience`, `known-platforms` |
| domain-models | 1657/6857/6857 | `name` only |
| domain-terms | 639/1225/1225 | `term`, `aliases`, `not_confused_with` |
| bounded-contexts | 667/675/675 | `name`, `aliases`, `not_confused_with` |
| bugs / features / retrospectives / skill-designs | 653–2036 | `title` or nothing |

So requirements were the one type the body-only digest couldn't see **at all**, and also the one
type with nowhere to record *why* a requirement exists.

### The rationale body

The generator now scaffolds a `## Rationale` section with a prompt instead of leaving the body
empty, so the gap is visible to whoever writes the requirement rather than silently absent. `rules`
stays in frontmatter — that placement is deliberate and evidenced (`check-example-mapping.mjs`
records two regex-parsing bugs from before the move, and `task-identification.mjs` reads `fm.rules`
in three places to decide whether a requirement is refined yet).

### `digestFields`

`artifact-schema.json` can now declare which frontmatter fields carry a type's content rather than
its bookkeeping, and they count toward its digest alongside the body:

```json
"requirements": { "expectedAncestorTypes": ["product-briefs"], "digestFields": ["rules"] }
```

The requirement generator registers this itself, so the default arrives from code rather than from
someone remembering to set it. A change to `rules` marks descendants stale; a `title` fix or an
answered `question` does not.

**This is a structural fact, not the policy switch we retired.** `revisedInPlace` would have said
*whether the check runs* — an opt-in check being a check that doesn't run. This says *where a type
keeps its meaning*, same category as `expectedAncestorTypes`, which is why it belongs in the schema
the workspace owns.

Three properties worth calling out:

- **`artifactDigest` is the single way to compute one**, taking declared fields as an argument, so a
  caller can't derive a different value and manufacture staleness at a distance. `pin-ancestors`
  routes through it and now reads the schema to do so.
- **Absent or empty means body-only**, and it returns `bodyDigest` *unchanged* rather than a hash of
  it — so every pin recorded before this existed stays valid. There's a test asserting exactly that.
- **Selected values are canonicalised with recursively sorted keys**, so a frontmatter reorder —
  which YAML tooling and Prettier are both free to do — can't masquerade as a content change. A
  declared field the artifact lacks contributes `null` rather than being skipped, so *removing* it
  is a change the digest sees.

`ensureArtifactSchemaEntry`'s optional flags become an options object rather than gaining a sixth
positional parameter; ten call sites updated.

### One known over-fire, documented rather than hidden

Declared fields are hashed *alongside* the body, not instead of it, so editing a requirement's
rationale also marks its descendants stale. Rationale is explanatory, not contractual, so that's
imprecise — but it's written once at creation, requirements have few descendants, and the
alternative (declared fields replacing the body) would silently drop body coverage for any type
with meaningful content in both places. Called out in the README so it's a known trade rather than
a surprise.

## Documentation and guidance audit (seventh commit)

Audited what this branch changed against what documents it. **Three gaps, one functional.**

### Functional: three findings nothing acted on

`task-identification.mjs` derived signals from `yamlErrors`, `unparseableRefs`, `brokenRefs`,
`resolution.open` and `unscoped` — but **nothing from `cycles`, `schemaErrors` or `stale`**. So
three categories were computed, reported, and gating `--strict`, while the delivery loop could never
pick them up as work. A finding nothing acts on is half-delivered, which is the pattern this branch
has been closing everywhere else.

`cycle:` and `schema-error:` join `RESOLUTION_PREFIXES` on the test the script's own comment already
sets out for `unparseable:`/`yaml-error:` — each names one specific thing to repair rather than new
work to start, so a `fix/**` branch has to be eligible to act on it. The cycle key uses the
canonical rotated form `project-docs-lineage` already produces; keyed on the raw traversal order the
same loop would key differently each run and **stall detection would never see a repeat**.

`stale:` deliberately does *not* join them — it's a status finding, so revisiting the descendant is
ordinary work at its own stage, same as `unscoped:`. Its reason names the re-pin command, so the
loop can close the review rather than leaving the report to recur forever.

Two tests drive the script end-to-end on a `fix/` branch and assert both new keys reach
`signals` with `ready=true`.

### Agent guidance

The `fix/**` eligibility table listed only the four original resolution signals — in the generated
`AGENTS.ci-harness.md` **and** this repo's own `AGENTS.md`. Both updated. The `init` guidance's
lineage section gained the integrity/status distinction and the digest, since a consuming
workspace's agents read that file rather than this package's README.

### Docs site

`docs/nx-agent/nx-agent.md` is a hand-maintained mirror of the README (88% identical, no generation
script) and had **none** of this branch's changes. Ported the lineage span and the new
`pin-ancestors` section verbatim, plus the report section's renamed wording.

Left its pre-existing structural divergence alone: it deliberately omits `TLDR`, install steps and
per-generator `Options` sections, and it trailed the README by ~150 lines *before* this branch. That
backlog is a separate cleanup, not something to absorb silently into this PR.

### Four stale field paths the audit caught in this branch's own work

Porting to the mirror surfaced them in the README too, not just the copy:

- the consumed-shape paragraph still said `discover` reads `violations.resolutionStatus`
- two cross-references still pointed at `resolutionStatus`
- **`design/SKILL.md` still told an agent to read `project-docs-lineage`'s `resolutionStatus` field**

That last one is exactly the failure this branch keeps guarding against: a skill is prose
instructing a model, so a moved field path raises no error — the model looks for something absent
and improvises.

## Validating `digestFields` (eighth commit)

F4 validated `expectedAncestorTypes` and nothing else, so `digestFields` — added later on this same
branch — arrived **unvalidated**, with the same two failures one property over and both silent:

| problem | why it's silent today |
| --- | --- |
| a **structural field** (`project-docs-ancestors`, `resolves`) | excluded from `metadata` by design, so the declaration contributes nothing and the digest quietly ignores it |
| a **misspelled field** | contributes `null` for every artifact, leaving the digest stable while it stops tracking the field that was meant |

Both now report through `schemaErrors`, whose shape generalises from
`{ type, expectedAncestorType, didYouMean }` to `{ type, property, value, problem, didYouMean? }` —
one category for "the schema says something unsatisfiable," with enough structure to say which
property and why. Free to reshape because it hasn't shipped: `schemaErrors` arrived earlier on this
same unmerged branch.

The structural case is **always** wrong, so it's always reported. Misspelling is checked against the
fields artifacts of that type actually carry, and reported on the same pluralization-or-case basis
as the type check — for the same reason: a field nothing carries yet is indistinguishable from one
that will, and failing `--strict` on a legitimately optional field is the mistake F4 nearly shipped.

A substitution typo therefore stays silent, and a test records that deliberately so it isn't
mistaken for a bug later. I found that limit by writing the test wrong first — `rulez` against
`rules` is a substitution, not a pluralization, so my expectation was at fault rather than the code.

`problem` exists as a discriminator because the structural case has no sensible `didYouMean`.

Verified against this workspace: `requirements` declares `digestFields: ["rules"]` and validates
clean, `schemaErrors: 0`.

## Still not here

`supersedes`, for material change — a new artifact rather than an edit — which the digest
deliberately doesn't cover. Removing the deprecated `violations` view is the eventual `schemaVersion` 2, and the one
thing that genuinely needs a migration.

## Gate

- `nx test nx-agent` — 332 passed (57 new)
- `nx lint nx-agent` — 0 errors (27 pre-existing warnings)
- `nx build nx-agent` — clean
- `project-docs-lineage --strict` — passes
- `secretlint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)







