### PR TITLE
fix(nx-adsp): bring generated frontend dependency pins current

### DIFF
--- a/packages/nx-adsp/src/generators/angular-app/angular-app.ts
+++ b/packages/nx-adsp/src/generators/angular-app/angular-app.ts
@@ -157,17 +157,21 @@ export default async function (host: Tree, options: AngularAppGeneratorSchema) {
   addDependenciesToPackageJson(
     host,
     {
-      '@abgov/angular-components': '5.3.0',
+      '@abgov/angular-components': '5.5.0',
       '@abgov/design-tokens': '2.12.8',
-      // Pin exact (not ^2.0.0): angular-components 5.3.0 imports symbols added in
-      // ui-components-common 2.3.0 (e.g. GoabWorkspaceLayoutScrollState), so a
-      // lower 2.x resolves and fails the build. Keep this in lockstep with the
-      // angular-components version above.
-      '@abgov/ui-components-common': '2.3.0',
-      '@abgov/web-components': '2.4.0',
+      // Pin exact (not ^2.0.0): angular-components 5.5.0 imports symbols added in
+      // ui-components-common 2.4.0 (e.g. GoabDropdownMultiselectOnChangeDetail,
+      // GoabIconButtonType), so a lower 2.x resolves and fails the build. Keep
+      // this in lockstep with the angular-components version above.
+      '@abgov/ui-components-common': '2.5.0',
+      '@abgov/web-components': '2.5.0',
       'keycloak-angular': '^19.0.2',
       'keycloak-js': '^23.0.7',
-      'zone.js': '~0.15.0',
+      // @nx/angular defaults `zoneless` to true on Angular >= 21, so it writes no
+      // zone.js entry of its own — but our main.ts and test-setup.ts import it.
+      // This pin is the only thing putting zone.js in package.json, not an
+      // override of Nx's choice. Angular 22 peers `~0.15.0 || ~0.16.0`.
+      'zone.js': '~0.16.2',
     },
     {
       '@axe-core/playwright': '^4.12.1',

--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -149,8 +149,8 @@ export default async function (host: Tree, options: Schema) {
     host,
     {
       '@abgov/design-tokens': '2.12.8',
-      '@abgov/react-components': '7.3.0',
-      '@abgov/web-components': '2.4.0',
+      '@abgov/react-components': '7.5.0',
+      '@abgov/web-components': '2.5.0',
       '@reduxjs/toolkit': '^2.5.1',
       'keycloak-js': '^23.0.7',
       'react-redux': '^9.2.0',

--- a/packages/nx-adsp/src/generators/vue-app/vue-app.ts
+++ b/packages/nx-adsp/src/generators/vue-app/vue-app.ts
@@ -188,12 +188,14 @@ export default async function (host: Tree, options: Schema) {
     host,
     {
       '@abgov/design-tokens': '2.12.8',
-      '@abgov/web-components': '2.4.0',
+      '@abgov/web-components': '2.5.0',
       // keycloak-js is a transitive dependency of @dsb-norge/vue-keycloak-js;
       // don't pin it directly or the versions diverge into two copies.
       '@dsb-norge/vue-keycloak-js': '^3.0.0',
       pinia: '^2.0.0',
-      'vue-router': '^4.0.0',
+      // @nx/vue's application generator (--routing) writes ^4.5.0; ours runs
+      // after it and wins, so keep the floor at or above Nx's choice.
+      'vue-router': '^4.5.0',
     },
     {
       '@axe-core/playwright': '^4.12.1',


### PR DESCRIPTION
## Why

The versions the frontend generators write into a consuming workspace are string literals in generator bodies. None of these packages appear in any `package.json` in this repo, so they are invisible to our own `npm audit` and to Dependabot and Renovate alike — both read manifests and lockfiles. They move only when someone notices, and several hadn't.

## What

- **GoA design system**: `angular-components` 5.3.0 → 5.5.0, `react-components` 7.3.0 → 7.5.0, `web-components` 2.4.0 → 2.5.0 across all three frontends. `design-tokens` 2.12.8 was already current.
- **`ui-components-common` 2.3.0 → 2.5.0** — required, not cosmetic. `angular-components@5.5.0` imports 129 symbols from it, and 10 of them (`GoabDropdownMultiselectOnChangeDetail`, `GoabIconButtonType`, the `*OnFocusDetail` types) don't exist before 2.4.0, so 5.5.0 against 2.3.0 fails to build. Verified by comparing the published `.d.ts` exports of 2.3.0, 2.4.0 and 2.5.0 against what 5.5.0 imports. The lockstep comment now names symbols that actually exercise the floor.
- **`zone.js` `~0.15.0` → `~0.16.2`** — the old tilde couldn't reach the 0.16 line at all. Angular 22 peers `~0.15.0 || ~0.16.0`, so this was stale rather than broken. Comment added because *why* we pin zone.js isn't obvious: `@nx/angular` defaults `zoneless` to true on Angular >= 21 and writes no `zone.js` entry, while our `main.ts` and `test-setup.ts` import it.
- **`vue-router` `^4.0.0` → `^4.5.0`** — `@nx/vue`'s application generator writes `^4.5.0` when `--routing` is passed (we pass it), and our `addDependenciesToPackageJson` runs afterwards without `keepExistingVersions`, so we were overwriting Nx's floor with a looser one.

## `react-router-dom` 6.30.4 → 6.30.6 (second commit)

Added after #467's check flagged it — and it corrects both the old comment and my own earlier read of it.

The pin's comment listed GHSA-jjmj-jmhj-qwj2 alongside GHSA-wrjc-x8rr-h8h6 as having "no 6.x fix at all". That's true of wrjc and GHSA-337j-9hxr-rhxg — both vulnerable `>=6.0.0 <7.18.0` — but **not** of jjmj, which GitHub's advisory API gives as vulnerable `>= 6.30.2, <= 6.30.5`, patched in `6.30.6`. So 6.30.4 was exposed to it and a 6.x bump does fix it. Grouping the three hid an available fix behind a correct statement about two different advisories; the replacement comment records the patched version per advisory instead of a verdict on the whole line.

wrjc and 337j remain unfixable in 6.x and are accepted in `tools/audit-emitted-deps/allowlist.json` (#467) with a reviewed date. The only remediation for those is React Router 7, a breaking migration rather than a version bump.

## Verification

`nx-adsp` lint + test + build green via the pre-commit hook (29 suites / 272 tests). No spec asserted any of these version strings, so no test changes were needed.

Also worth flagging separately: `@abgov/angular-components@5.5.0` still peers `@angular/core ^17–^21` while `@nx/angular` 23 scaffolds Angular `~22.0.4`, so a fresh `angular-app` has an unmet peer between the two layers. That needs the GoA library to ship Angular 22 support; it isn't fixable by pinning either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

