### PR TITLE
fix(nx-adsp): bump react-router-dom to 6.30.6, past a fourth advisory

### DIFF
--- a/packages/nx-adsp/src/generators/react-app/react-app.ts
+++ b/packages/nx-adsp/src/generators/react-app/react-app.ts
@@ -154,14 +154,20 @@ export default async function (host: Tree, options: Schema) {
       '@reduxjs/toolkit': '^2.5.1',
       'keycloak-js': '^23.0.7',
       'react-redux': '^9.2.0',
-      // 6.30.4, not 6.30.3: GHSA-2j2x-hqr9-3h42 (moderate) — a same-origin
-      // redirect whose path starts with "//" was reinterpreted as a
-      // protocol-relative URL, causing an open redirect. Fixed in 6.30.4,
-      // the last 6.x release. Two other advisories affecting this line
-      // (GHSA-jjmj-jmhj-qwj2, GHSA-wrjc-x8rr-h8h6) have no 6.x fix at all —
-      // only React Router v7 (a breaking migration: v7 merges
-      // react-router-dom into react-router and changes several APIs).
-      'react-router-dom': '6.30.4',
+      // Pinned to the newest 6.x, which is not advisory-free — the 6 and 7
+      // lines differ in what they can fix, so the distinction matters:
+      //   GHSA-2j2x-hqr9-3h42, GHSA-jjmj-jmhj-qwj2 — open redirect, both
+      //     patched within 6.x (6.30.4 and 6.30.6 respectively).
+      //   GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg — vulnerable
+      //     >=6.0.0 <7.18.0, so no 6.x release clears them. Only React Router
+      //     v7 does, and v7 merges react-router-dom into react-router and
+      //     changes several APIs — a breaking migration for a generated app,
+      //     not a version bump. Accepted in
+      //     tools/audit-emitted-deps/allowlist.json, with a reviewed date.
+      // Check the patched version per advisory before assuming a 6.x bump is
+      // pointless: 6.30.6 does clear jjmj, which an earlier version of this
+      // comment claimed had no 6.x fix.
+      'react-router-dom': '6.30.6',
     },
     {
       '@axe-core/playwright': '^4.12.1',


### PR DESCRIPTION
Split out of #466 after that merged. Found by #467's check, and it corrects both the old comment and my own earlier read of it.

## The defect

`react-app` pinned `react-router-dom` at `6.30.4`, and the pin's comment listed GHSA-jjmj-jmhj-qwj2 alongside GHSA-wrjc-x8rr-h8h6 as having *"no 6.x fix at all — only React Router v7"*.

That's true of wrjc and GHSA-337j-9hxr-rhxg, both vulnerable `>=6.0.0 <7.18.0`. It is **not** true of jjmj. Per `gh api /advisories/GHSA-jjmj-jmhj-qwj2`:

```json
{"pkg": "react-router-dom", "vulnerable": ">= 6.30.2, <= 6.30.5", "patched": "6.30.6"}
```

So `6.30.4` was exposed to an advisory that a patch release fixes. Grouping the three hid an available fix behind a correct statement about two different advisories.

## The fix

`6.30.6`, and a comment that records the patched version **per advisory** rather than a verdict on the whole line — including an explicit note not to assume a 6.x bump is pointless, since that assumption is what kept this open.

`wrjc` and `337j` remain unfixable in 6.x and are accepted in `tools/audit-emitted-deps/allowlist.json` (#467) with a reviewed date.

## How it was found

`AUDIT_LEVEL=moderate npm run audit:emitted-deps` (from #467) reported it as *"pinned directly by a generator — bump it"*. It sits below that check's default `high` threshold, so the weekly run wouldn't have blocked on it — worth knowing when reading the check's output.

I'd also told you earlier that `6.30.6` "does not help". That was wrong: I verified the two `<7.18.0` advisories and generalised to the third without checking it.

## Verification

`nx-adsp` lint + test + build green via the pre-commit hook. After this, `react-router-dom` disappears from the audit's findings entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)