### PR TITLE
fix(nx-oc): make the sandbox --imageTag reach the Deployment

### DIFF
--- a/packages/nx-oc/migrations.json
+++ b/packages/nx-oc/migrations.json
@@ -11,6 +11,11 @@
       "description": "Split the generated pipeline workflow into a check-only pull-request.yml and a deploy-only pipeline.yml, so an in-flight deploy is queued rather than cancelled by a later push.",
       "implementation": "./src/migrations/split-pipeline-workflows/split-pipeline-workflows",
       "prompt": "./src/migrations/split-pipeline-workflows/split-pipeline-workflows.md"
+    },
+    "parameterize-sandbox-image-tag": {
+      "version": "13.12.1",
+      "description": "Add an IMAGE_TAG parameter to generated sandbox manifests, so the sandbox executor's --imageTag reaches the Deployment instead of being ignored.",
+      "implementation": "./src/migrations/parameterize-sandbox-image-tag/parameterize-sandbox-image-tag"
     }
   }
 }

--- a/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.spec.ts
@@ -9,6 +9,7 @@ jest.mock('child_process', () => ({
 jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   existsSync: jest.fn(),
+  readFileSync: jest.fn(),
 }));
 jest.mock('../../utils/oc-utils', () => ({ ensureOcLogin: jest.fn() }));
 jest.mock('@abgov/adsp-cli', () => ({
@@ -18,7 +19,29 @@ jest.mock('@abgov/adsp-cli', () => ({
 }));
 
 const { execSync } = require('child_process') as { execSync: jest.Mock };
-const { existsSync } = require('fs') as { existsSync: jest.Mock };
+const { existsSync, readFileSync } = require('fs') as {
+  existsSync: jest.Mock;
+  readFileSync: jest.Mock;
+};
+
+// A sandbox manifest that declares the IMAGE_TAG parameter, i.e. one generated
+// after the tag was parameterized. Only the parameter declaration matters to
+// the executor — it is what `oc process -p IMAGE_TAG=` requires.
+const MANIFEST_WITH_IMAGE_TAG = [
+  'parameters:',
+  '  - name: PROJECT',
+  '    required: true',
+  '  - name: IMAGE_TAG',
+  '    value: sandbox',
+  'objects:',
+].join('\n');
+
+const MANIFEST_WITHOUT_IMAGE_TAG = [
+  'parameters:',
+  '  - name: PROJECT',
+  '    required: true',
+  'objects:',
+].join('\n');
 
 /** Only the given workspace-relative paths exist. */
 function onlyTheseFilesExist(...paths: string[]) {
@@ -64,20 +87,30 @@ function commands(): string[] {
 beforeEach(() => {
   execSync.mockReset();
   existsSync.mockReset();
+  readFileSync.mockReset();
+  // Pre-parameterization manifest by default, so the existing cases exercise
+  // the back-compatible path.
+  readFileSync.mockReturnValue(MANIFEST_WITHOUT_IMAGE_TAG);
   // The generated default: the sandbox generator emits this path.
   onlyTheseFilesExist('.openshift/test/Dockerfile');
   execSync.mockImplementation(() => Buffer.from(''));
   adspCli.getAccessToken.mockReset();
-  adspCli.getAccessToken.mockResolvedValue({ status: 'ok', token: 'test-token' });
+  adspCli.getAccessToken.mockResolvedValue({
+    status: 'ok',
+    token: 'test-token',
+  });
   adspCli.getDirectoryServiceUrl.mockReset();
-  adspCli.getDirectoryServiceUrl.mockReturnValue('https://directory.adsp.alberta.ca');
+  adspCli.getDirectoryServiceUrl.mockReturnValue(
+    'https://directory.adsp.alberta.ca',
+  );
   adspCli.registerDirectoryService.mockReset();
   adspCli.registerDirectoryService.mockResolvedValue('registered');
 });
 
 describe('sandbox executor', () => {
   describe('container build file resolution', () => {
-    const buildCmd = () => commands().find((cmd) => cmd.startsWith('podman build'));
+    const buildCmd = () =>
+      commands().find((cmd) => cmd.startsWith('podman build'));
 
     it('defaults to the path the sandbox generator emits', async () => {
       await runExecutor(baseOptions, context());
@@ -101,14 +134,20 @@ describe('sandbox executor', () => {
 
     it('honours --dockerfile, e.g. the root Dockerfile the OpenShift container contract requires', async () => {
       onlyTheseFilesExist('Dockerfile');
-      await runExecutor({ ...baseOptions, dockerfile: 'Dockerfile' }, context());
+      await runExecutor(
+        { ...baseOptions, dockerfile: 'Dockerfile' },
+        context(),
+      );
       expect(buildCmd()).toContain('-f Dockerfile');
     });
 
     it('fails fast when --dockerfile points at nothing, naming the value given', async () => {
       onlyTheseFilesExist('.openshift/test/Dockerfile');
       await expect(
-        runExecutor({ ...baseOptions, dockerfile: 'build/Containerfile' }, context()),
+        runExecutor(
+          { ...baseOptions, dockerfile: 'build/Containerfile' },
+          context(),
+        ),
       ).resolves.toEqual({ success: false });
       expect(buildCmd()).toBeUndefined();
     });
@@ -394,7 +433,9 @@ describe('sandbox executor', () => {
       ).toBe(true);
       expect(cmds.some((c) => c.includes('test-db.yml'))).toBe(true);
       // No plain Deployment provisioning or shim resources
-      expect(cmds.some((c) => c.includes('sandbox-postgres-creds'))).toBe(false);
+      expect(cmds.some((c) => c.includes('sandbox-postgres-creds'))).toBe(
+        false,
+      );
       expect(cmds.some((c) => c.includes('sandbox-postgres.yml'))).toBe(false);
       // Database CR applied before the app rollout
       const dbCrIdx = cmds.findIndex((c) => c.includes('test-db.yml'));
@@ -437,9 +478,9 @@ describe('sandbox executor', () => {
       expect(cmds.some((c) => c.includes('sandbox-postgres-rw'))).toBe(true);
       // No CNPG-specific provisioning commands
       expect(cmds.some((c) => c.includes('add-scc-to-user'))).toBe(false);
-      expect(
-        cmds.some((c) => c.includes('sandbox-postgres-cnpg.yml')),
-      ).toBe(false);
+      expect(cmds.some((c) => c.includes('sandbox-postgres-cnpg.yml'))).toBe(
+        false,
+      );
 
       warn.mockRestore();
     });
@@ -470,10 +511,7 @@ describe('sandbox executor', () => {
         if (cmd.includes('oc api-resources')) {
           return Buffer.from('ok');
         }
-        if (
-          cmd.includes('oc describe resourcequota') &&
-          cmd.includes('grep')
-        ) {
+        if (cmd.includes('oc describe resourcequota') && cmd.includes('grep')) {
           return Buffer.from(
             'azure-disk.storageclass.storage.k8s.io/requests.storage  10Gi  10Gi',
           );
@@ -560,7 +598,8 @@ describe('sandbox executor', () => {
 
     it('registers the service when route resolves and tenant tag is present', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        if (cmd.includes('oc get route test'))
+          return Buffer.from('test.apps.example.com');
         return Buffer.from('');
       });
       const result = await runExecutor(
@@ -579,11 +618,14 @@ describe('sandbox executor', () => {
 
     it('logs skip when the directory entry already exists (409)', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        if (cmd.includes('oc get route test'))
+          return Buffer.from('test.apps.example.com');
         return Buffer.from('');
       });
       adspCli.registerDirectoryService.mockResolvedValue('exists');
-      const info = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+      const info = jest
+        .spyOn(logger, 'info')
+        .mockImplementation(() => undefined);
       const result = await runExecutor(
         { ...baseOptions, registerDirectory: true },
         context([TENANT_TAG]),
@@ -597,7 +639,9 @@ describe('sandbox executor', () => {
 
     it('warns and skips registration when the route cannot be resolved', async () => {
       // default execSync mock returns '' → no route host
-      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const warn = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
       const result = await runExecutor(
         { ...baseOptions, registerDirectory: true },
         context([TENANT_TAG]),
@@ -612,10 +656,13 @@ describe('sandbox executor', () => {
 
     it('warns and skips registration when no ADSP tenant tag is present', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        if (cmd.includes('oc get route test'))
+          return Buffer.from('test.apps.example.com');
         return Buffer.from('');
       });
-      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const warn = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
       const result = await runExecutor(
         { ...baseOptions, registerDirectory: true },
         context(), // no tenant tag
@@ -630,11 +677,14 @@ describe('sandbox executor', () => {
 
     it('warns and skips registration when not authenticated to ADSP', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        if (cmd.includes('oc get route test'))
+          return Buffer.from('test.apps.example.com');
         return Buffer.from('');
       });
       adspCli.getAccessToken.mockResolvedValue({ status: 'not-authenticated' });
-      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const warn = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
       const result = await runExecutor(
         { ...baseOptions, registerDirectory: true },
         context([TENANT_TAG]),
@@ -649,13 +699,18 @@ describe('sandbox executor', () => {
 
     it('warns (non-fatal) when registerDirectoryService throws (e.g. 403)', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        if (cmd.includes('oc get route test'))
+          return Buffer.from('test.apps.example.com');
         return Buffer.from('');
       });
       adspCli.registerDirectoryService.mockRejectedValue(
-        new Error("Not authorized to register services in namespace 'my-tenant'."),
+        new Error(
+          "Not authorized to register services in namespace 'my-tenant'.",
+        ),
       );
-      const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const warn = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
       const result = await runExecutor(
         { ...baseOptions, registerDirectory: true },
         context([TENANT_TAG]),
@@ -669,7 +724,8 @@ describe('sandbox executor', () => {
 
     it('skips registration entirely for frontend app types', async () => {
       execSync.mockImplementation((cmd: string) => {
-        if (cmd.includes('oc get route test')) return Buffer.from('test.apps.example.com');
+        if (cmd.includes('oc get route test'))
+          return Buffer.from('test.apps.example.com');
         return Buffer.from('');
       });
       const result = await runExecutor(
@@ -688,5 +744,82 @@ describe('sandbox executor', () => {
       expect(result.success).toBe(true);
       expect(adspCli.registerDirectoryService).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('--imageTag', () => {
+  // The defect this covers: the sandbox branch of the deployment templates baked
+  // the tag in as the literal `:sandbox`, so a non-default --imageTag pushed and
+  // imported one tag while the Deployment kept reading another — a deploy that
+  // silently ran the previously-imported image.
+  function manifestExists(content: string) {
+    onlyTheseFilesExist(
+      '.openshift/test/Dockerfile',
+      '.openshift/test/test.sandbox.yml',
+    );
+    readFileSync.mockReturnValue(content);
+  }
+
+  it('passes IMAGE_TAG to oc process when the manifest declares it', async () => {
+    manifestExists(MANIFEST_WITH_IMAGE_TAG);
+
+    const result = await runExecutor(
+      { ...baseOptions, imageTag: 'pr-42' },
+      context(),
+    );
+
+    expect(result).toEqual({ success: true });
+    const process = commands().find((c) => c.startsWith('oc process'));
+    expect(process).toContain('-p IMAGE_TAG=pr-42');
+    // The imagestream tag has to match, or the parameter points at nothing.
+    expect(commands()).toContainEqual(expect.stringContaining('test:pr-42'));
+  });
+
+  it('still passes IMAGE_TAG for the default tag, so the manifest has no second source of truth', async () => {
+    manifestExists(MANIFEST_WITH_IMAGE_TAG);
+
+    await runExecutor(baseOptions, context());
+
+    expect(commands().find((c) => c.startsWith('oc process'))).toContain(
+      '-p IMAGE_TAG=sandbox',
+    );
+  });
+
+  it('omits IMAGE_TAG on a pre-parameterization manifest, which oc process would reject', async () => {
+    manifestExists(MANIFEST_WITHOUT_IMAGE_TAG);
+
+    const result = await runExecutor(baseOptions, context());
+
+    expect(result).toEqual({ success: true });
+    expect(commands().find((c) => c.startsWith('oc process'))).not.toContain(
+      'IMAGE_TAG',
+    );
+  });
+
+  it('fails in the preflight when a non-default tag cannot reach the Deployment', async () => {
+    manifestExists(MANIFEST_WITHOUT_IMAGE_TAG);
+    const error = jest
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined);
+
+    const result = await runExecutor(
+      { ...baseOptions, imageTag: 'pr-42' },
+      context(),
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('--imageTag=pr-42 cannot take effect'),
+    );
+    // Preflight, not partway through: nothing may have been built, pushed, or
+    // provisioned by the time this fails.
+    expect(commands()).not.toContainEqual(
+      expect.stringContaining('podman build'),
+    );
+    expect(commands()).not.toContainEqual(
+      expect.stringContaining('podman push'),
+    );
+    expect(commands()).not.toContainEqual(expect.stringContaining('oc apply'));
+    error.mockRestore();
   });
 });

--- a/packages/nx-oc/src/executors/sandbox/sandbox.ts
+++ b/packages/nx-oc/src/executors/sandbox/sandbox.ts
@@ -5,13 +5,17 @@ import {
   registerDirectoryService,
 } from '@abgov/adsp-cli';
 import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { detectApplicationType } from '../../utils/app-type';
 import { activeAccountScopes } from '../../utils/gh-utils';
 import { ensureOcLogin } from '../../utils/oc-utils';
 import { detectAdspTenant } from '../../adsp/adsp-utils';
 import { SandboxExecutorSchema } from './schema';
+
+// Mirrors the `default` in schema.json and the `value` of the manifest's
+// IMAGE_TAG parameter; the preflight guard below compares against it.
+const DEFAULT_IMAGE_TAG = 'sandbox';
 
 const PROXY_TAG_PREFIX = 'adsp:proxy-service:';
 
@@ -55,6 +59,24 @@ function resolveContainerfile(
     );
   }
   return found;
+}
+
+// Whether the manifest exposes IMAGE_TAG as an `oc process` parameter.
+//
+// It didn't always: the sandbox branch of the deployment templates baked the tag
+// in as the literal `:sandbox`, so a non-default --imageTag pushed and imported
+// one tag while the Deployment kept reading another. `oc process` hard-errors on
+// an unknown parameter name, so the flag can't simply be passed unconditionally
+// — a manifest generated before that fix would break on every deploy, including
+// the default path that works today.
+function manifestAcceptsImageTag(cwd: string, manifestPath: string): boolean {
+  if (!existsSync(join(cwd, manifestPath))) return false;
+  // Matching the parameter declaration, not any occurrence: `${IMAGE_TAG}` in an
+  // object body without the matching `parameters:` entry is exactly the
+  // half-migrated state that would still fail in `oc process`.
+  return /^\s*-\s*name:\s*IMAGE_TAG\s*$/m.test(
+    readFileSync(join(cwd, manifestPath), 'utf8'),
+  );
 }
 
 // Fail fast, with an actionable message, before the (slow) production build —
@@ -198,7 +220,7 @@ export default async function runExecutor(
   const {
     sandboxProject,
     registry,
-    imageTag = 'sandbox',
+    imageTag = DEFAULT_IMAGE_TAG,
     skipBuild = false,
     skipPush = false,
     deployBackend = false,
@@ -247,6 +269,22 @@ export default async function runExecutor(
     const containerfile = skipBuild
       ? undefined
       : resolveContainerfile(cwd, projectName, options.dockerfile);
+
+    // Same reasoning as the containerfile above: a --imageTag that cannot reach
+    // the Deployment should stop the run here, not after it has pushed an image
+    // and provisioned a database. Silently deploying the previously-imported
+    // `:sandbox` tag is the defect this replaces.
+    const manifestPath = `.openshift/${projectName}/${projectName}.sandbox.yml`;
+    const imageTagIsParameter = manifestAcceptsImageTag(cwd, manifestPath);
+    if (!imageTagIsParameter && imageTag !== DEFAULT_IMAGE_TAG) {
+      throw new Error(
+        `--imageTag=${imageTag} cannot take effect: ${manifestPath} has no IMAGE_TAG ` +
+          `parameter, so its Deployment reads a hard-coded '${DEFAULT_IMAGE_TAG}' tag and would ` +
+          `run whatever was imported last, not the image this run pushes.\n` +
+          `Regenerate the manifest with \`nx g @abgov/nx-oc:sandbox ${projectName}\`, ` +
+          `or run \`nx migrate\` to pick up the parameterize-sandbox-image-tag migration.`,
+      );
+    }
 
     // ---- service client secret (node services authenticate to ADSP) ----
     // Upserted from the current .env.local so re-runs pick up a rotated secret.
@@ -559,7 +597,9 @@ EOF`,
 
     run(
       'Apply manifest',
-      `oc process -f .openshift/${projectName}/${projectName}.sandbox.yml -p PROJECT=${sandboxProject} | oc apply -f -`,
+      `oc process -f ${manifestPath} -p PROJECT=${sandboxProject}` +
+        (imageTagIsParameter ? ` -p IMAGE_TAG=${imageTag}` : '') +
+        ` | oc apply -f -`,
       cwd,
     );
     run(

--- a/packages/nx-oc/src/executors/sandbox/schema.json
+++ b/packages/nx-oc/src/executors/sandbox/schema.json
@@ -36,7 +36,7 @@
     "imageTag": {
       "type": "string",
       "default": "sandbox",
-      "description": "Image tag pushed and imported into the namespace imagestream."
+      "description": "Image tag to push, import into the namespace imagestream, and deploy. Requires a manifest with an IMAGE_TAG parameter \u2014 re-run the sandbox generator or `nx migrate` if a non-default tag is rejected."
     },
     "skipBuild": {
       "type": "boolean",

--- a/packages/nx-oc/src/generators/deployment/dotnet-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/dotnet-files/__projectName__.yml__tmpl__
@@ -28,6 +28,12 @@ parameters:
     displayName: Deploy Tag
     value: latest
     required: true
+<% } else { %>
+  - name: IMAGE_TAG
+    description: Image tag to deploy. Set by the sandbox executor's --imageTag.
+    displayName: Image Tag
+    value: sandbox
+    required: true
 <% } %>
 objects:
 <% if (!sandbox) { %>
@@ -103,7 +109,7 @@ objects:
           containers:
             - name: ${APP_NAME}
 <% if (sandbox) { %>
-              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:sandbox
+              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:${IMAGE_TAG}
 <% } else { %>
               image: ${APP_NAME}:${DEPLOY_TAG}
 <% } %>

--- a/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
+++ b/packages/nx-oc/src/generators/deployment/node-files/__projectName__.yml__tmpl__
@@ -28,6 +28,12 @@ parameters:
     displayName: Deploy Tag
     value: latest
     required: true
+<% } else { %>
+  - name: IMAGE_TAG
+    description: Image tag to deploy. Set by the sandbox executor's --imageTag.
+    displayName: Image Tag
+    value: sandbox
+    required: true
 <% } %>
 objects:
 <% if (!sandbox) { %>
@@ -88,7 +94,7 @@ objects:
           initContainers:
             - name: ${APP_NAME}-migrate
 <% if (sandbox) { %>
-              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:sandbox
+              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:${IMAGE_TAG}
 <% } else { %>
               image: image-registry.openshift-image-registry.svc:5000/${INFRA_PROJECT}/${APP_NAME}:${DEPLOY_TAG}
 <% } %>
@@ -121,7 +127,7 @@ objects:
           containers:
             - name: ${APP_NAME}
 <% if (sandbox) { %>
-              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:sandbox
+              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:${IMAGE_TAG}
 <% } else { %>
               image: ${APP_NAME}:${DEPLOY_TAG}
 <% } %>

--- a/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
+++ b/packages/nx-oc/src/generators/sandbox/files/SANDBOX.md__tmpl__
@@ -56,7 +56,7 @@ workspace-wide) and provisioned into GitHub Actions secrets by
 ```bash
 nx run <%= projectName %>:sandbox --skipBuild              # reuse the built image; re-push + import + roll out
 nx run <%= projectName %>:sandbox --skipBuild --skipPush   # reuse the pushed image; re-import + roll out only
-nx run <%= projectName %>:sandbox --imageTag=<tag>         # push/import under a different tag
+nx run <%= projectName %>:sandbox --imageTag=<tag>         # push, import and deploy a different tag
 nx run <%= projectName %>:sandbox --importRetries=8        # more import retries on a slow cluster
 nx run <%= projectName %>:sandbox --registerDirectory      # register in ADSP directory after rollout (opt-in)
 nx run <%= projectName %>:sandbox --dockerfile=Dockerfile  # build file elsewhere (e.g. a repo-root Dockerfile)

--- a/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
+++ b/packages/nx-oc/src/generators/sandbox/sandbox.spec.ts
@@ -71,7 +71,9 @@ describe('Sandbox Generator', () => {
     expect(host.exists('.openshift/test/test.yml')).toBeFalsy();
     const manifest = host.read('.openshift/test/test.sandbox.yml').toString();
     expect(manifest).toContain('imagePullPolicy: Always');
-    expect(manifest).not.toContain('ImageStream');
+    // `kind:`-qualified: the assertion is that the sandbox manifest declares no
+    // ImageStream object, not that the word never appears in it.
+    expect(manifest).not.toContain('kind: ImageStream');
     expect(manifest).not.toContain('DEPLOY_TAG');
     expect(manifest).toContain('sandbox');
     expect(manifest).toContain('deployment-mode: sandbox');
@@ -111,7 +113,9 @@ describe('Sandbox Generator', () => {
     expect(host.exists('.openshift/test/test.sandbox.yml')).toBeTruthy();
     const manifest = host.read('.openshift/test/test.sandbox.yml').toString();
     expect(manifest).toContain('imagePullPolicy: Always');
-    expect(manifest).not.toContain('ImageStream');
+    // `kind:`-qualified: the assertion is that the sandbox manifest declares no
+    // ImageStream object, not that the word never appears in it.
+    expect(manifest).not.toContain('kind: ImageStream');
     expect(manifest).toContain(
       'haproxy.router.openshift.io/rate-limit-connections',
     );

--- a/packages/nx-oc/src/migrations/parameterize-sandbox-image-tag/parameterize-sandbox-image-tag.spec.ts
+++ b/packages/nx-oc/src/migrations/parameterize-sandbox-image-tag/parameterize-sandbox-image-tag.spec.ts
@@ -1,0 +1,125 @@
+import { logger, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import migration from './parameterize-sandbox-image-tag';
+
+// A verbatim capture of what the node-files template emitted for a
+// postgres-backed sandbox app before the tag was parameterized: rendered
+// through generateFiles and then formatFiles, which is what the generator does,
+// so it matches the bytes a consuming workspace actually holds. (Prettier
+// therefore leaves it alone — if a format run ever changes it, the capture has
+// drifted from generator output, not the other way round.)
+//
+// Held as its own file rather than re-rendered from the live template: this
+// migration must keep applying the same change to that old output forever, so a
+// later template edit must not be able to change what these tests assert.
+const PRE_FIX = readFileSync(
+  join(__dirname, 'pre-fix-node.fixture.yml'),
+  'utf8',
+);
+
+const MANIFEST = '.openshift/my-api/my-api.sandbox.yml';
+
+function treeWith(files: Record<string, string>): Tree {
+  const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+  for (const [path, content] of Object.entries(files)) {
+    tree.write(path, content);
+  }
+  return tree;
+}
+
+describe('parameterize-sandbox-image-tag migration', () => {
+  it('declares IMAGE_TAG and repoints every sandbox image at it', async () => {
+    const tree = treeWith({ [MANIFEST]: PRE_FIX });
+
+    await migration(tree);
+    const result = tree.read(MANIFEST, 'utf8');
+
+    expect(result).toContain('  - name: IMAGE_TAG');
+    expect(result).toContain('    value: sandbox');
+    // The fixture has two: the drizzle migrate init container and the app container.
+    expect(
+      result.match(/image: [^\n]*\/my-api:\$\{IMAGE_TAG\}$/gm),
+    ).toHaveLength(2);
+    // No literal tag left behind — a half-converted manifest deploys the wrong
+    // image just as silently as the unconverted one.
+    expect(result).not.toMatch(/image: [^\n]*\/my-api:sandbox$/m);
+    // The parameter has to land in `parameters:`, before `objects:` — oc process
+    // rejects a ${IMAGE_TAG} reference whose parameter is declared nowhere.
+    expect(result.indexOf('- name: IMAGE_TAG')).toBeLessThan(
+      result.indexOf('objects:'),
+    );
+  });
+
+  it('leaves unrelated content alone', async () => {
+    const tree = treeWith({ [MANIFEST]: PRE_FIX });
+
+    await migration(tree);
+    const result = tree.read(MANIFEST, 'utf8');
+
+    // The database name and the postgres secret references are a different
+    // hard-coded-name problem; this migration must not touch them.
+    expect(result).toContain(
+      'postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@sandbox-postgres-rw:5432/my-api_sandbox',
+    );
+    expect(result).toContain('name: sandbox-postgres-app');
+    expect(result).toContain('deployment-mode: sandbox');
+    expect(result).toContain('- name: APP_NAME');
+  });
+
+  it('is idempotent', async () => {
+    const tree = treeWith({ [MANIFEST]: PRE_FIX });
+
+    await migration(tree);
+    const once = tree.read(MANIFEST, 'utf8');
+    await migration(tree);
+    const twice = tree.read(MANIFEST, 'utf8');
+
+    expect(twice).toEqual(once);
+    expect(twice.match(/- name: IMAGE_TAG/g)).toHaveLength(1);
+  });
+
+  it('ignores the pipeline manifest a project can carry alongside', async () => {
+    // Same project directory, no `deployment-mode: sandbox` label — this is the
+    // `deployment`-generated manifest, which has its own DEPLOY_TAG parameter.
+    const pipeline = PRE_FIX.replace(
+      'deployment-mode: sandbox',
+      'deployment-mode: pipeline',
+    );
+    const tree = treeWith({
+      [MANIFEST]: PRE_FIX,
+      '.openshift/my-api/my-api.yml': pipeline,
+    });
+
+    await migration(tree);
+
+    expect(tree.read('.openshift/my-api/my-api.yml', 'utf8')).toEqual(pipeline);
+    expect(tree.read(MANIFEST, 'utf8')).toContain('- name: IMAGE_TAG');
+  });
+
+  it('warns and skips a manifest it does not recognise, and reports it', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    // Sandbox-labelled, but the image line has been rewritten by hand, so the
+    // migration cannot know which tag to repoint.
+    const handEdited = PRE_FIX.replace(
+      /image: image-registry[^\n]*\n/g,
+      'image: ghcr.io/my-org/my-api:custom\n',
+    );
+    const tree = treeWith({ [MANIFEST]: handEdited });
+
+    const result = await migration(tree);
+
+    expect(tree.read(MANIFEST, 'utf8')).toEqual(handEdited);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(MANIFEST));
+    expect(result?.nextSteps?.[0]).toContain(MANIFEST);
+    expect(result?.agentContext?.[0]).toContain('IMAGE_TAG');
+    warn.mockRestore();
+  });
+
+  it('does nothing when the workspace has no .openshift directory', async () => {
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+
+    await expect(migration(tree)).resolves.toBeUndefined();
+  });
+});

--- a/packages/nx-oc/src/migrations/parameterize-sandbox-image-tag/parameterize-sandbox-image-tag.ts
+++ b/packages/nx-oc/src/migrations/parameterize-sandbox-image-tag/parameterize-sandbox-image-tag.ts
@@ -1,0 +1,128 @@
+import { formatFiles, logger, Tree } from '@nx/devkit';
+
+// Retrofits the IMAGE_TAG parameter into sandbox manifests generated before the
+// tag was parameterized. Those bake the tag in as the literal `:sandbox`, so the
+// executor's --imageTag pushed and imported one tag while the Deployment kept
+// reading another — a deploy that silently ran the previously-imported image.
+//
+// Frozen literals, not imports from the deployment templates: a released
+// migration has to keep applying the same change forever, and reading the live
+// template would let a later edit there silently change what this migration does
+// to an old workspace.
+const IMAGE_LINE =
+  /^(\s*)image: (image-registry\.openshift-image-registry\.svc:5000\/\$\{PROJECT\}\/[A-Za-z0-9._-]+):sandbox[ \t]*$/gm;
+
+const PARAMETER_BLOCK = [
+  '  - name: IMAGE_TAG',
+  "    description: Image tag to deploy. Set by the sandbox executor's --imageTag.",
+  '    displayName: Image Tag',
+  '    value: sandbox',
+  '    required: true',
+].join('\n');
+
+const OBJECTS_LINE = /^objects:[ \t]*$/m;
+
+// Positive identification, rather than editing anything that happens to look
+// close enough. `deployment-mode: sandbox` is the label only the sandbox branch
+// of the deployment templates emits, so it distinguishes these from the
+// pipeline-shaped manifest a project can carry alongside.
+function isSandboxManifest(content: string): boolean {
+  return (
+    /^kind: Template[ \t]*$/m.test(content) &&
+    /^\s{2}deployment-mode: sandbox[ \t]*$/m.test(content) &&
+    /^parameters:[ \t]*$/m.test(content) &&
+    OBJECTS_LINE.test(content)
+  );
+}
+
+function sandboxManifestPaths(tree: Tree): string[] {
+  const found: string[] = [];
+  if (!tree.exists('.openshift')) return found;
+  for (const dir of tree.children('.openshift')) {
+    const projectDir = `.openshift/${dir}`;
+    if (!tree.isFile(projectDir)) {
+      for (const file of tree.children(projectDir)) {
+        if (file.endsWith('.sandbox.yml')) {
+          found.push(`${projectDir}/${file}`);
+        }
+      }
+    }
+  }
+  return found;
+}
+
+export default async function (tree: Tree) {
+  const skipped: string[] = [];
+  const updated: string[] = [];
+
+  for (const path of sandboxManifestPaths(tree)) {
+    const content = tree.read(path, 'utf8');
+    if (!content) continue;
+
+    if (/^\s*-\s*name:\s*IMAGE_TAG\s*$/m.test(content)) {
+      // Already parameterized — re-running is a no-op, not a second insertion.
+      continue;
+    }
+
+    if (!isSandboxManifest(content)) {
+      skipped.push(path);
+      continue;
+    }
+
+    // Both halves or neither: a manifest with `${IMAGE_TAG}` in an object body
+    // and no matching parameter declaration fails in `oc process`, which is
+    // worse than the defect being fixed.
+    IMAGE_LINE.lastIndex = 0;
+    if (!IMAGE_LINE.test(content)) {
+      skipped.push(path);
+      continue;
+    }
+
+    IMAGE_LINE.lastIndex = 0;
+    const withTag = content.replace(
+      IMAGE_LINE,
+      (_match, indent, image) => `${indent}image: ${image}:\${IMAGE_TAG}`,
+    );
+    tree.write(
+      path,
+      withTag.replace(OBJECTS_LINE, `${PARAMETER_BLOCK}\nobjects:`),
+    );
+    updated.push(path);
+  }
+
+  if (updated.length) {
+    logger.info(
+      `[nx-oc] Parameterized the sandbox image tag in ${updated.length} manifest(s): ${updated.join(', ')}`,
+    );
+  }
+
+  if (!skipped.length) {
+    await formatFiles(tree);
+    return;
+  }
+
+  for (const path of skipped) {
+    logger.warn(
+      `[nx-oc] ${path} is not the shape this migration knows how to edit — left unchanged. ` +
+        `Its Deployment still reads a hard-coded ':sandbox' tag, so --imageTag will be rejected by the executor.`,
+    );
+  }
+
+  await formatFiles(tree);
+
+  return {
+    nextSteps: skipped.map(
+      (path) =>
+        `${path} was not updated: --imageTag will fail against it until it declares an IMAGE_TAG parameter. ` +
+        `Regenerate it with \`nx g @abgov/nx-oc:sandbox <project>\`, or add the parameter by hand.`,
+    ),
+    agentContext: [
+      `These sandbox manifests were skipped because they do not match the generated shape: ${skipped.join(', ')}. ` +
+        `For each, add an \`IMAGE_TAG\` parameter to the template's \`parameters:\` list ` +
+        `(description "Image tag to deploy. Set by the sandbox executor's --imageTag.", value "sandbox", required true) ` +
+        `and change every container image ending in \`:sandbox\` to end in \`:\${IMAGE_TAG}\` instead. ` +
+        `Both halves are required — a \`\${IMAGE_TAG}\` reference with no parameter declaration makes \`oc process\` fail. ` +
+        `Preserve any other customisation in the file.`,
+    ],
+  };
+}

--- a/packages/nx-oc/src/migrations/parameterize-sandbox-image-tag/pre-fix-node.fixture.yml
+++ b/packages/nx-oc/src/migrations/parameterize-sandbox-image-tag/pre-fix-node.fixture.yml
@@ -1,18 +1,11 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: <%= projectName %>
+  name: my-api
 labels:
-  app: <%= projectName %>
-  deployment-mode: <%= sandbox ? 'sandbox' : 'pipeline' %>
+  app: my-api
+  deployment-mode: sandbox
 parameters:
-<% if (!sandbox) { %>
-  - name: INFRA_PROJECT
-    description: Project used for build infrastructure.
-    displayName: Infrastructure Project
-    value: <%= ocInfraProject %>
-    required: true
-<% } %>
   - name: PROJECT
     description: Project to deploy into.
     displayName: Project
@@ -20,65 +13,26 @@ parameters:
   - name: APP_NAME
     description: Name of the application.
     displayName: Application Name
-    value: <%= projectName %>
+    value: my-api
     required: true
-<% if (!sandbox) { %>
-  - name: DEPLOY_TAG
-    description: ImageStream tag to deploy.
-    displayName: Deploy Tag
-    value: latest
-    required: true
-<% } else { %>
-  - name: IMAGE_TAG
-    description: Image tag to deploy. Set by the sandbox executor's --imageTag.
-    displayName: Image Tag
-    value: sandbox
-    required: true
-<% } %>
+
 objects:
-<% if (!sandbox) { %>
-  - apiVersion: image.openshift.io/v1
-    kind: ImageStream
-    metadata:
-      name: ${APP_NAME}
-      namespace: ${INFRA_PROJECT}
-<% } %>
   - apiVersion: v1
     kind: ConfigMap
     metadata:
       name: ${APP_NAME}
       namespace: ${PROJECT}
       labels:
-        reference: "true"
+        reference: 'true'
     data:
-      config.json: |-
-        {
-          "access": {
-            "url": "<%= accessServiceUrl %>",
-            "realm": "<%= tenantRealm %>",
-            "client_id": "urn:ads:<%= tenant %>:<%= projectName %>"
-          }
-        }
+      TENANT_REALM: my-tenant
+      ACCESS_SERVICE_URL: https://access.adsp-dev.gov.ab.ca
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: ${APP_NAME}
       namespace: ${PROJECT}
-<% if (!sandbox) { %>
-      annotations:
-        image.openshift.io/triggers: |-
-          [
-            {
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "${APP_NAME}:${DEPLOY_TAG}",
-                "namespace": "${INFRA_PROJECT}"
-              },
-              "fieldPath": "spec.template.spec.containers[0].image",
-              "paused": true
-            }
-          ]
-<% } %>
+
     spec:
       replicas: 1
       selector:
@@ -96,16 +50,68 @@ objects:
           labels:
             name: ${APP_NAME}
         spec:
+          initContainers:
+            - name: ${APP_NAME}-migrate
+
+              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/my-api:sandbox
+
+              command: ['node', 'migrate.js']
+              envFrom:
+                - configMapRef:
+                    name: ${APP_NAME}
+              env:
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: sandbox-postgres-app
+                      key: username
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: sandbox-postgres-app
+                      key: password
+                - name: DATABASE_URL
+                  value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@sandbox-postgres-rw:5432/my-api_sandbox
+
           containers:
             - name: ${APP_NAME}
-<% if (sandbox) { %>
-              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/<%= projectName %>:${IMAGE_TAG}
-<% } else { %>
-              image: ${APP_NAME}:${DEPLOY_TAG}
-<% } %>
-              imagePullPolicy: <%= sandbox ? 'Always' : 'IfNotPresent' %>
+
+              image: image-registry.openshift-image-registry.svc:5000/${PROJECT}/my-api:sandbox
+
+              envFrom:
+                - configMapRef:
+                    name: ${APP_NAME}
+              env:
+                - name: PORT
+                  value: '3333'
+                - name: LOG_LEVEL
+                  value: info
+                # ADSP confidential-client secret the service uses to authenticate
+                # with the access service. Sandbox: created by `nx run <app>:sandbox`
+                # from the service's .env.
+
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: ${APP_NAME}-secrets
+                      key: CLIENT_SECRET
+
+                - name: POSTGRES_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: sandbox-postgres-app
+                      key: username
+                - name: POSTGRES_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: sandbox-postgres-app
+                      key: password
+                - name: DATABASE_URL
+                  value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@sandbox-postgres-rw:5432/my-api_sandbox
+
+              imagePullPolicy: Always
               ports:
-                - containerPort: 8080
+                - containerPort: 3333
                   name: http
                   protocol: TCP
               resources:
@@ -117,29 +123,19 @@ objects:
                   memory: 50Mi
               readinessProbe:
                 httpGet:
-                  path: /
-                  port: 8080
+                  path: /health/ready
+
+                  port: 3333
                 initialDelaySeconds: 10
                 periodSeconds: 10
                 failureThreshold: 3
               livenessProbe:
                 httpGet:
-                  path: /
-                  port: 8080
+                  path: /health
+                  port: 3333
                 initialDelaySeconds: 30
                 periodSeconds: 30
                 failureThreshold: 3
-              volumeMounts:
-                - mountPath: /opt/app-root/src/config
-                  name: config-volume
-          volumes:
-            - configMap:
-                defaultMode: 420
-                items:
-                  - key: config.json
-                    path: config.json
-                name: ${APP_NAME}
-              name: config-volume
   - apiVersion: v1
     kind: Service
     metadata:
@@ -148,9 +144,9 @@ objects:
     spec:
       ports:
         - name: http
-          port: 8080
+          port: 3333
           protocol: TCP
-          targetPort: 8080
+          targetPort: 3333
       selector:
         name: ${APP_NAME}
       sessionAffinity: None


### PR DESCRIPTION
## The defect

`--imageTag` pushed to `ghcr.io/<org>/<ns>-<app>:<tag>` and ran `oc tag … <project>:<tag>`, but the sandbox branch of all three deployment templates baked the tag in as a compile-time EJS literal:

```yaml
image: …svc:5000/${PROJECT}/<%= projectName %>:sandbox
```

`DEPLOY_TAG` exists only in the `!sandbox` branch, so there was no parameter for the executor to set — and `oc process` was only ever passed `-p PROJECT=`. Any non-default `--imageTag` therefore pushed and imported one tag while the Deployment kept reading `:sandbox`: it silently ran whatever was imported last, or failed outright if `:sandbox` had never been created.

Both the schema (*"Image tag pushed and imported into the namespace imagestream"*) and `SANDBOX.md` (*"push/import under a different tag"*) advertised the flag, so it read as supported.

## The fix

The sandbox branch now declares an `IMAGE_TAG` parameter (default `sandbox`, matching the executor's own default) and both container images read `${IMAGE_TAG}`. The pipeline branch is untouched.

`oc process` **hard-errors** on an unknown parameter name:

```
$ oc process --local -f t.yml -p PROJECT=x -p IMAGE_TAG=sandbox
error: unknown parameter name "IMAGE_TAG"
```

So the executor can't just always pass it — that would break every manifest generated before this change, *including* the default path that works today. It detects the parameter instead, and when a non-default tag was asked for and can't reach the Deployment it fails in the **preflight**, beside the containerfile check and for the same stated reason: before the build, the push, and any database provisioning.

## Migration

`parameterize-sandbox-image-tag` retrofits already-generated manifests. Pinned `13.12.1` — `latest` is `13.12.0` and this is a `fix:`; nothing is above `13.12.0` yet, so there's no workspace it could be silently skipped for, and if the release lands higher it still falls inside the upgrade range.

It identifies a manifest **positively** by the `deployment-mode: sandbox` label — the `deployment`-generated pipeline manifest a project can carry in the same directory has its own `DEPLOY_TAG` and must not be touched — and inserts the parameter and rewrites the image lines *together*, since a `${IMAGE_TAG}` reference with no declaration fails in `oc process` just as silently as the defect being fixed. Anything off-shape is warned, skipped, and named in `nextSteps`/`agentContext` rather than pattern-edited.

## Verification

Beyond the unit tests (nx-oc: 17 suites / 186 tests, +4 executor cases, +6 migration cases; `nx-oc-e2e` green), checked with the real `oc` CLI:

```
$ oc process --local -f <freshly generated> -p PROJECT=my-ns -p IMAGE_TAG=pr-42
   my-api-migrate -> …svc:5000/my-ns/my-api:pr-42
   my-api         -> …svc:5000/my-ns/my-api:pr-42
$ oc process --local -f <freshly generated> -p PROJECT=my-ns
   my-api-migrate -> …svc:5000/my-ns/my-api:sandbox
   my-api         -> …svc:5000/my-ns/my-api:sandbox
```

Same result on the pre-fix fixture after the migration runs — and the migrated output is byte-identical to freshly generated output on the lines the migration owns. Both template branches were rendered to confirm the pipeline path is unchanged.

## One incidental test change

`not.toContain('ImageStream')` in the sandbox generator spec became `not.toContain('kind: ImageStream')`. Its intent is that the sandbox manifest declares no ImageStream *object*, but the substring form failed on a parameter *description* that mentioned the word — which is how it broke here. (I also reworded the description to "Image tag to deploy", since the sandbox manifest has no ImageStream to speak of.)

## Scope

This fixes the flag; it does **not** make the sandbox multi-tenant. Two branches using different `--imageTag` values still share one Deployment, Service and Route, so it's still last-writer-wins — the difference is that each deploy now runs the image it just pushed. Per-instance deploys additionally need the DB name and nginx `proxy_pass` parameterized, Keycloak redirect registration per host, and label-scoped teardown reworked; not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)