### PR TITLE
fix(nx-agent): name the dispatch tool the runtime actually exposes

### DIFF
--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design
 description: Turn a requirement into a bounded context, domain model, and (when there's a UI consumer) a UX design followed by an API design driven by what that UX actually needs — resolving any open Questions along the way, since domain modeling is exactly where they get answered. Vocabulary and domain-model artifacts use real @abgov/nx-agent generators; UX/API design are hand-authored, matching those same conventions, until a generator exists for them.
-allowed-tools: Read, Write, Bash, Grep, Glob, Task
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 argument-hint: "<requirement slug to design against>"
 ---
 

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: develop
 description: Implement an api-design/ux-design against real code, following the project's own generated recipe (its own AGENTS.md — the exact steps vary by stack), with a project-docs-ancestors code comment tying every new file back to the design it implements. Runs an inline gate battery — audit, secret scan, build, test, always blocking — plus an independent code review, every pass, advisory.
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
 argument-hint: "<api-design or ux-design slug to implement>"
 project-docs-ancestors: [skill-designs:develop-skill-lineage-plan-step]
 ---

--- a/.claude/skills/discover/SKILL.md
+++ b/.claude/skills/discover/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discover
 description: Frame a feature request into a service description and requirements with IDs seeded at birth. Two modes — intake (decompose a features:<slug> artifact) and refinement (example-map one requirement to closure) — same skill, branches on what it's given.
-allowed-tools: Read, Write, Bash, Grep, Glob, Task
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 argument-hint: "<feature slug to decompose, or a requirement slug to refine>"
 ---
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design
 description: Turn a requirement into a bounded context, domain model, and (when there's a UI consumer) a UX design followed by an API design driven by what that UX actually needs — resolving any open Questions along the way, since domain modeling is exactly where they get answered. Vocabulary and domain-model artifacts use real @abgov/nx-agent generators; UX/API design are hand-authored, matching those same conventions, until a generator exists for them.
-allowed-tools: Read, Write, Bash, Grep, Glob, Task
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 argument-hint: "<requirement slug to design against>"
 ---
 

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/develop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: develop
 description: Implement an api-design/ux-design against real code, following the project's own generated recipe (its own AGENTS.md — the exact steps vary by stack), with a project-docs-ancestors code comment tying every new file back to the design it implements. Runs an inline gate battery — audit, secret scan, build, test, always blocking — plus an independent code review, every pass, advisory.
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Task
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
 argument-hint: "<api-design or ux-design slug to implement>"
 project-docs-ancestors: [skill-designs:develop-skill-lineage-plan-step]
 ---

--- a/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
+++ b/packages/nx-agent/src/generators/agent-delivery/files/skills/discover/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discover
 description: Frame a feature request into a service description and requirements with IDs seeded at birth. Two modes — intake (decompose a features:<slug> artifact) and refinement (example-map one requirement to closure) — same skill, branches on what it's given.
-allowed-tools: Read, Write, Bash, Grep, Glob, Task
+allowed-tools: Read, Write, Bash, Grep, Glob, Agent
 argument-hint: "<feature slug to decompose, or a requirement slug to refine>"
 ---
 


### PR DESCRIPTION
## Why

The `discover`, `design`, and `develop` skills each declared `Task` in their `allowed-tools`
frontmatter. This runtime exposes `Agent`; `Task` is a retired name.

`allowed-tools` is **additive pre-approval**, not a restriction — so a name that resolves to
nothing simply grants nothing. All three skills require an independent review dispatch on every
pass ("Run every time a requirement finishes refinement", "Independent code review — every pass"),
and that dispatch was unapproved in every one of them.

The failure mode is silent, which is why it survived: a review that was never dispatched is
indistinguishable from a review that found nothing.

## What

One word, in both copies — they have to move together or they diverge:

- `packages/nx-agent/src/generators/agent-delivery/files/skills/{discover,design,develop}/SKILL.md`
  — what a consuming workspace receives from `nx g @abgov/nx-agent:agent-delivery`.
- `.claude/skills/{discover,design,develop}/SKILL.md` — this repo's own copies, which were
  byte-identical to those templates before this change and still are.

`deploy` and `handoff` declare no dispatch tool and have no review step, so they are untouched.

## Verification

```
npx nx test nx-agent      # 22 suites, 341 tests pass
npx nx build nx-agent
npx nx lint nx-agent      # 0 errors (30 pre-existing warnings)
npx secretlint <changed>  # clean
npx nx g @abgov/nx-agent:project-docs-lineage --strict   # clean
```

No spec asserted the old name, so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)