### PR TITLE
docs: name the formatting tools in AGENTS.md instead of restating their values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,14 +214,20 @@ unless explicitly directed.
 
 ## Code Style
 
-- **Formatter**: Prettier with `singleQuote: true` (`.prettierrc`)
-- **Linter**: ESLint with `@typescript-eslint`; `no-extra-semi` is an error
-- **Quotes**: single quotes in all TypeScript files — never double quotes
-- **Semicolons**: do not add semicolons at the end of statements
-- **Indentation**: 2 spaces (enforced by `.editorconfig`)
-- **Module boundaries**: `@nx/enforce-module-boundaries` is active; do not import
-  from one package into another unless a `tsconfig.base.json` alias already exists
-- **Final newline**: all files must end with a newline
+This section names the tools and the things they cannot tell you. It deliberately does **not**
+restate the values they enforce: a second copy of `.prettierrc` written in prose is a copy nothing
+executes, so it drifts, and the drift is invisible because every real consumer reads the config.
+
+- **Run `npm run format:write` before committing.** Prettier owns quoting, semicolons,
+  indentation and final newlines. **Formatting is not gated** — it runs in no CI job and no
+  pre-commit hook — so this command is the only thing that applies it. Don't hand-match a style
+  from memory; run the formatter and match what it produces.
+- **Lint with `npx nx lint <project>`.** The config is `eslint.config.mjs` at the root plus one
+  per package. Read those for which rules are on rather than assuming, including where a rule you
+  expect is explicitly disabled.
+- **Module boundaries**: `@nx/enforce-module-boundaries` is active, and importing across packages
+  needs a `tsconfig.base.json` alias to exist first. This one is worth stating because the lint
+  error does not tell you the remedy.
 
 ---
 
@@ -521,8 +527,7 @@ Key wiring to preserve when editing:
 - Do not commit generated `.openshift/` manifests unless adding new template files
 - Do not use `jest.config.js` — all configs use `jest.config.ts`
 - Do not remove the `snapshotFormat` block from `jest.preset.js`
-- Do not add semicolons at the end of statements
-- Do not use double quotes for strings in TypeScript files
+- Do not hand-match formatting from memory — run `npm run format:write` (see **Code Style**)
 - Do not push directly to `main` or `beta` branches
 - Do not run `npx nx migrate` without explicit instruction
 


### PR DESCRIPTION
## Why

The **Code Style** section restated the values Prettier and ESLint enforce. Two of its seven
bullets had drifted into being wrong:

| Bullet | Reality |
|---|---|
| "`no-extra-semi` is an error" | `eslint.config.mjs` sets it to `'off'` — twice |
| "do not add semicolons at the end of statements" | `.prettierrc` sets only `singleQuote`, so `semi` defaults to `true`, and all five packages are semicolon-terminated |

An agent following the semicolon bullet writes code the formatter immediately undoes. Three more
bullets restated config the same bullet pointed at (single quotes, two-space indent, final
newline), so they could only duplicate or drift.

**The wrong ones are the two no tool would ever correct you on**, which is the pattern rather than
bad luck: every real consumer reads `.prettierrc` and `eslint.config.mjs`; only an agent reads the
prose, and the prose cannot tell it is stale.

AGENTS.md already contained the right instruction and contradicted itself — the generated
`nx-agent:managed:agent-guidance` section says *"check what's actually configured (don't assume
Prettier or an ESLint complexity rule just because it's common)"*, 300 lines below a hand-authored
section doing exactly that.

## What

Keeps the two bullets carrying information the tooling can't give you — which tools to run, and
that a cross-package import needs a `tsconfig.base.json` alias to exist first (the one rule whose
remedy the lint error doesn't state) — and replaces the rest with an **action**, because there is a
real gap underneath: formatting is gated nowhere, so `npm run format:write` is the only thing that
applies it.

Also drops the two `Don'ts` restating the same values, one of them the wrong semicolon rule.

## Notes

- **`AGENTS.md` already fails `prettier --check` on `main`**, before this change — the section
  asserting formatting rules from memory sits in a file nothing formats. Deliberately not fixed
  here: reformatting 760 lines would bury a 15-line edit.
- Verified no generator template or guidance file carries these bullets, so nothing shipped them to
  a consuming workspace. This is local to this repo's own hand-authored instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)